### PR TITLE
fix(server): repair main after #5 (ModelConfig→ModelEntry) + pre-push check hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Pre-push hook — run the same checks GitHub Actions runs (doc-sync +
+# full workspace type-check & tests) so failures surface locally instead
+# of in CI.
+#
+# Enabled per-clone with:  git config core.hooksPath .githooks
+# Skip a single push with:  git push --no-verify
+#
+set -e
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root/deno"
+
+echo "pre-push: running 'deno task check' (verify-docs + tests)…"
+deno task check
+echo "pre-push: checks passed."

--- a/deno/CLAUDE.md
+++ b/deno/CLAUDE.md
@@ -181,6 +181,7 @@ The CLI uses Cliffy framework with these patterns:
 ## Instructions
 
 - Always run a type check using `deno check ./**/*.ts ./**/*.tsx` at the end of session to verify results
+- `deno task check` runs the full CI suite locally (doc-sync + workspace type-check & tests). A version-controlled `pre-push` hook (`<repo>/.githooks/pre-push`) runs it before every push so failures surface locally, not in GitHub Actions. Enable it per-clone with `git config core.hooksPath .githooks`; bypass a single push with `git push --no-verify`.
 - Use absolute import paths prefixed with `@/`, not of relative path imports
 
 Use US English spelling in code, prose and documentation

--- a/deno/deno.json
+++ b/deno/deno.json
@@ -40,6 +40,7 @@
   "tasks": {
     "release": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run .scripts/release.ts",
     "bump": "deno run --allow-read --allow-write .scripts/bump.ts",
+    "check": "deno task verify-docs && deno test --allow-all",
     "test:watch": "deno test --allow-all --watch",
     "test:coverage": "deno test --allow-all --coverage=coverage",
     "coverage:report": "deno coverage coverage --lcov > coverage.lcov",

--- a/deno/server/src/createServer.test.ts
+++ b/deno/server/src/createServer.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals, assertExists } from 'jsr:@std/assert@^1.0.10'
 import * as v from 'valibot'
-import type { Enrichments, GeneratorsMapContainer, ModelConfig, TransformModelArgs } from '@skmtc/core'
+import type {
+  Enrichments,
+  GeneratorsMapContainer,
+  ModelEntry,
+  TransformModelArgs
+} from '@skmtc/core'
 import { emptyEnrichmentSchema } from '@skmtc/core'
 import { createServer } from './createServer.ts'
 
@@ -95,16 +100,18 @@ Deno.test('POST /artifacts - rejects body with invalid protocol', async () => {
 })
 
 Deno.test('GET /generators - lists configured generator IDs', async () => {
-  const modelGen: ModelConfig<Enrichments> = {
+  const modelGen: ModelEntry<Enrichments> = {
     id: 'modelGen',
     type: 'model',
     toEnrichmentSchema: () => emptyEnrichmentSchema,
+    isSupported: () => true,
+    supportsVariant: () => false,
     transform(_args: TransformModelArgs): void {}
   }
   const app = createServer({
     toGeneratorConfigMap: (() => ({ modelGen })) as <
-      EnrichmentType = undefined,
-    >() => GeneratorsMapContainer<EnrichmentType>,
+      EnrichmentType = undefined
+    >() => GeneratorsMapContainer<EnrichmentType>
   })
 
   const res = await app.request('/generators')
@@ -115,16 +122,18 @@ Deno.test('GET /generators - lists configured generator IDs', async () => {
 
 Deno.test('POST /descriptors - returns one descriptor per generator', async () => {
   type Enrichment = { coerce?: boolean }
-  const modelGen: ModelConfig<Enrichment> = {
+  const modelGen: ModelEntry<Enrichment> = {
     id: 'modelGen',
     type: 'model',
+    isSupported: () => true,
+    supportsVariant: () => false,
     toEnrichmentSchema: () => v.object({ coerce: v.optional(v.boolean()) }),
     transform(_args: TransformModelArgs): void {}
   }
   const app = createServer({
     toGeneratorConfigMap: (() => ({ modelGen })) as <
-      EnrichmentType = undefined,
-    >() => GeneratorsMapContainer<EnrichmentType>,
+      EnrichmentType = undefined
+    >() => GeneratorsMapContainer<EnrichmentType>
   })
 
   const res = await app.request('/descriptors', { method: 'POST' })
@@ -154,9 +163,11 @@ Deno.test('POST /enrichment-defaults - empty generator map returns empty default
 
 Deno.test('POST /enrichment-defaults - returns seeded defaults per supported subject', async () => {
   type Enrichment = { subject?: { note?: string }; generator?: undefined; stack?: undefined }
-  const modelGen: ModelConfig<Enrichment> = {
+  const modelGen: ModelEntry<Enrichment> = {
     id: 'modelGen',
     type: 'model',
+    isSupported: () => true,
+    supportsVariant: () => false,
     toEnrichmentSchema: () =>
       v.object({
         subject: v.optional(v.object({ note: v.optional(v.string()) })),
@@ -172,8 +183,8 @@ Deno.test('POST /enrichment-defaults - returns seeded defaults per supported sub
   }
   const app = createServer({
     toGeneratorConfigMap: (() => ({ modelGen })) as <
-      EnrichmentType = undefined,
-    >() => GeneratorsMapContainer<EnrichmentType>,
+      EnrichmentType = undefined
+    >() => GeneratorsMapContainer<EnrichmentType>
   })
 
   const oasWithModel = {


### PR DESCRIPTION
## Why

PR #5 merged the core refactor that renamed `ModelConfig` → `ModelEntry` (and made `isSupported`/`supportsVariant` required), but **without** the consumer fix in `server/src/createServer.test.ts`. As a result `main` is currently **red** — CI run `28188471000` failed with:

```
TS2305: Module '@skmtc/core' has no exported member 'ModelConfig'.
TS7031: Binding element 'refName' implicitly has an 'any' type.
```

This PR repairs `main` and adds a guard so the same class of failure is caught locally next time.

## Changes

- **`fix(server)`** — type the `createServer` test fixtures as `ModelEntry` and supply the now-required `isSupported`/`supportsVariant` fields. Workspace type-checks again.
- **`chore(repo)`** — add `deno task check` (verify-docs + full workspace type-check & tests) and a version-controlled `.githooks/pre-push` that runs it before every push, so failures surface locally instead of in GitHub Actions. Enable per-clone with `git config core.hooksPath .githooks`; bypass with `git push --no-verify`.

## Verification

- `deno task check` (the full CI-equivalent suite) run locally and via the pre-push hook on the push of this branch: **2770 passed, 0 failed, 4 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)