### PR TITLE
feat(cli): add `skmtc describe` for local preview metadata

### DIFF
--- a/deno/cli/commands/describe.test.ts
+++ b/deno/cli/commands/describe.test.ts
@@ -1,0 +1,271 @@
+import { assertEquals, assertStringIncludes } from '@std/assert'
+import { join } from '@std/path/join'
+import { printDescribeResult, renderDescribe } from './describe.ts'
+import type { DescribeResult } from '@/lib/describe-headless.ts'
+import { withCapturedExit } from '@/tests/strict-mode-helpers.test.ts'
+import { createMockSkmtcRoot } from '@/tests/mocks/skmtc-root.mock.ts'
+import { createMockManager } from '@/tests/mocks/manager.mock.ts'
+import { createMockProject } from '@/tests/mocks/project.mock.ts'
+import { mockClientJsonContents } from '@/tests/fixtures/client-json.fixture.ts'
+
+const captureLogs = (fn: () => void): string[] => {
+  const logs: string[] = []
+  const original = console.log
+  console.log = (msg?: unknown) => logs.push(String(msg ?? ''))
+  try {
+    fn()
+  } finally {
+    console.log = original
+  }
+  return logs
+}
+
+const OriginalWorker = globalThis.Worker
+
+class MockWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((error: ErrorEvent) => void) | null = null
+
+  constructor(
+    public url: string,
+    public options?: WorkerOptions
+  ) {}
+
+  postMessage(_data: unknown) {}
+
+  terminate() {}
+
+  simulateMessage(data: unknown) {
+    if (this.onmessage) {
+      this.onmessage(new MessageEvent('message', { data }))
+    }
+  }
+}
+
+// Install a Worker that, once constructed, emits READY then a follow-up
+// (RESULT or ERROR). describeWithWorker posts DESCRIBE on READY (a no-op
+// against the mock) and settles on the follow-up message.
+const installSequencedWorker = (followUp: Record<string, unknown>) => {
+  globalThis.Worker = class {
+    constructor(url: string | URL, options?: WorkerOptions) {
+      const instance = new MockWorker(url.toString(), options)
+      setTimeout(() => {
+        instance.simulateMessage({ type: 'READY' })
+        setTimeout(() => instance.simulateMessage(followUp), 0)
+      }, 0)
+      return instance as unknown as Worker
+    }
+  } as unknown as typeof Worker
+}
+
+const resultMessage = {
+  type: 'RESULT',
+  subjects: { '@scope/gen-x': { type: 'model', models: ['User'] } },
+  descriptors: [],
+  enrichmentDefaults: {},
+  parseIssues: []
+}
+
+const baseResult: DescribeResult = {
+  projectName: 'my-api',
+  subjects: {
+    '@scope/gen-x': { type: 'model', models: ['User'] }
+  },
+  descriptors: [
+    {
+      generator: '@scope/gen-x',
+      subjectKind: 'model',
+      supportsVariant: false,
+      fields: [{ key: 'title', label: 'Title', optional: false, kind: 'text' }]
+    }
+  ],
+  enrichmentDefaults: { '@scope/gen-x': { User: { main: {} } } },
+  parseIssues: []
+}
+
+Deno.test('printDescribeResult - text reports descriptor + subject counts and per-descriptor fields', () => {
+  const logs = captureLogs(() => printDescribeResult(baseResult, { format: 'text' }))
+  const joined = logs.join('\n')
+  assertStringIncludes(
+    joined,
+    'describe "my-api": 1 generator descriptor(s), 1 generator(s) with supported subjects.'
+  )
+  assertStringIncludes(joined, '@scope/gen-x (model) — 1 field(s)')
+})
+
+Deno.test('printDescribeResult - text appends ", variants" only when the entry supports variants', () => {
+  const withVariant: DescribeResult = {
+    ...baseResult,
+    descriptors: [
+      { generator: '@scope/gen-x', subjectKind: 'operation', supportsVariant: true, fields: [] }
+    ]
+  }
+  const variantLogs = captureLogs(() => printDescribeResult(withVariant, { format: 'text' }))
+  assertStringIncludes(variantLogs.join('\n'), '@scope/gen-x (operation, variants) — 0 field(s)')
+
+  // The base fixture's descriptor has supportsVariant:false → no suffix.
+  const baseLogs = captureLogs(() => printDescribeResult(baseResult, { format: 'text' }))
+  assertEquals(baseLogs.join('\n').includes(', variants'), false)
+})
+
+Deno.test('printDescribeResult - text prints a parse-issue line only when issues exist', () => {
+  const clean = captureLogs(() => printDescribeResult(baseResult, { format: 'text' }))
+  assertEquals(clean.join('\n').includes('parse issue'), false)
+
+  const withIssues: DescribeResult = {
+    ...baseResult,
+    parseIssues: [
+      {
+        protocol: 'oas',
+        level: 'warning',
+        type: 'MISSING_OBJECT_TYPE',
+        location: 'components:schemas:User',
+        message: 'missing type'
+      }
+    ]
+  }
+  const logs = captureLogs(() => printDescribeResult(withIssues, { format: 'text' }))
+  assertStringIncludes(logs.join('\n'), '(1 parse issue(s))')
+})
+
+Deno.test('printDescribeResult - json emits one object carrying all four sections', () => {
+  const logs = captureLogs(() => printDescribeResult(baseResult, { format: 'json' }))
+  assertEquals(logs.length, 1)
+  const parsed: DescribeResult = JSON.parse(logs[0])
+  assertEquals(parsed.projectName, 'my-api')
+  assertEquals(Object.keys(parsed.subjects), ['@scope/gen-x'])
+  assertEquals(parsed.descriptors.length, 1)
+  assertEquals(parsed.enrichmentDefaults['@scope/gen-x'], { User: { main: {} } })
+  assertEquals(parsed.parseIssues, [])
+})
+
+Deno.test('renderDescribe - missing project arg fails with a recipe (exit 2)', async () => {
+  const { errors, exitCode } = await withCapturedExit(async () => {
+    await renderDescribe({ projectName: undefined })
+  })
+  assertEquals(exitCode, 2)
+  const joined = errors.join('\n')
+  assertStringIncludes(joined, 'missing required argument: <project>')
+  assertStringIncludes(joined, 'skmtc describe')
+})
+
+Deno.test('renderDescribe - unknown project fails with a recipe (exit 2)', async () => {
+  const skmtcRoot = createMockSkmtcRoot(createMockManager(), { projects: [] })
+  const { errors, exitCode } = await withCapturedExit(async () => {
+    await renderDescribe({ projectName: 'nope', skmtcRoot })
+  })
+  assertEquals(exitCode, 2)
+  assertStringIncludes(errors.join('\n'), 'missing required argument: <project>')
+})
+
+Deno.test('renderDescribe - existing project without a bundle exits 1 with a build hint', async () => {
+  // The mock project's path has no bundle.js on disk, so describe hits
+  // the precondition guard: a missing bundle is a build error (exit 1),
+  // not a bad-argument recipe error (exit 2).
+  const manager = createMockManager()
+  const project = createMockProject(manager, { name: 'my-api' })
+  const skmtcRoot = createMockSkmtcRoot(manager, { projects: [project] })
+
+  const { errors, exitCode } = await withCapturedExit(async () => {
+    await renderDescribe({ projectName: 'my-api', skmtcRoot })
+  })
+
+  assertEquals(exitCode, 1)
+  assertStringIncludes(errors.join('\n'), 'skmtc bundle my-api')
+})
+
+Deno.test('renderDescribe - bundle present but no schema source fails with a recipe (exit 2)', async () => {
+  const tempDir = await Deno.makeTempDir()
+  await Deno.writeTextFile(join(tempDir, 'bundle.js'), '')
+  try {
+    const manager = createMockManager()
+    const project = createMockProject(manager, { name: 'my-api' })
+    project.toPath = () => tempDir
+    // settings only — no `source`, and no schemaSourceString override.
+    project.clientJson.contents = { settings: mockClientJsonContents.settings }
+    const skmtcRoot = createMockSkmtcRoot(manager, { projects: [project] })
+
+    const { errors, exitCode } = await withCapturedExit(async () => {
+      await renderDescribe({ projectName: 'my-api', skmtcRoot })
+    })
+
+    assertEquals(exitCode, 2)
+    const joined = errors.join('\n')
+    assertStringIncludes(joined, 'missing required argument: [schema]')
+    assertStringIncludes(joined, 'client.json#source')
+  } finally {
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test('renderDescribe - happy path prints the result and exits 0', async () => {
+  const tempDir = await Deno.makeTempDir()
+  // An empty bundle.js satisfies the existence precondition; the mocked
+  // Worker means it is never actually executed.
+  await Deno.writeTextFile(join(tempDir, 'bundle.js'), '')
+  const schemaPath = join(tempDir, 'openapi.json')
+  await Deno.writeTextFile(
+    schemaPath,
+    JSON.stringify({ openapi: '3.0.0', info: { title: 'E2E API', version: '1.0.0' }, paths: {} })
+  )
+
+  installSequencedWorker(resultMessage)
+
+  const logs: string[] = []
+  const originalLog = console.log
+  console.log = (msg?: unknown) => logs.push(String(msg ?? ''))
+
+  try {
+    const manager = createMockManager()
+    const project = createMockProject(manager, { name: 'my-api' })
+    project.toPath = () => tempDir
+    project.clientJson.contents = { settings: mockClientJsonContents.settings, source: schemaPath }
+    const skmtcRoot = createMockSkmtcRoot(manager, { projects: [project] })
+
+    const { exitCode } = await withCapturedExit(async () => {
+      await renderDescribe({ projectName: 'my-api', skmtcRoot })
+    })
+
+    assertEquals(exitCode, 0)
+    assertStringIncludes(logs.join('\n'), 'describe "my-api"')
+  } finally {
+    console.log = originalLog
+    globalThis.Worker = OriginalWorker
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})
+
+Deno.test('renderDescribe - worker failure is caught and exits 1 with a rebundle hint', async () => {
+  const tempDir = await Deno.makeTempDir()
+  await Deno.writeTextFile(join(tempDir, 'bundle.js'), '')
+  const schemaPath = join(tempDir, 'openapi.json')
+  await Deno.writeTextFile(
+    schemaPath,
+    JSON.stringify({ openapi: '3.0.0', info: { title: 'E2E API', version: '1.0.0' }, paths: {} })
+  )
+
+  // A core-version skew surfaces as a worker ERROR; renderDescribe must
+  // turn that into a clean exit 1 with a rebundle hint, not an uncaught
+  // rejection.
+  installSequencedWorker({ type: 'ERROR', error: 'toSupportedSubjects is not a function' })
+
+  try {
+    const manager = createMockManager()
+    const project = createMockProject(manager, { name: 'my-api' })
+    project.toPath = () => tempDir
+    project.clientJson.contents = { settings: mockClientJsonContents.settings, source: schemaPath }
+    const skmtcRoot = createMockSkmtcRoot(manager, { projects: [project] })
+
+    const { errors, exitCode } = await withCapturedExit(async () => {
+      await renderDescribe({ projectName: 'my-api', skmtcRoot })
+    })
+
+    assertEquals(exitCode, 1)
+    const joined = errors.join('\n')
+    assertStringIncludes(joined, 'describe failed for "my-api"')
+    assertStringIncludes(joined, 'skmtc bundle my-api')
+  } finally {
+    globalThis.Worker = OriginalWorker
+    await Deno.remove(tempDir, { recursive: true })
+  }
+})

--- a/deno/cli/commands/describe.ts
+++ b/deno/cli/commands/describe.ts
@@ -1,0 +1,148 @@
+import { existsSync } from '@std/fs/exists'
+import { SkmtcRoot } from '@/lib/skmtc-root.ts'
+import { Manager } from '@/lib/manager.ts'
+import { failWithRecipe, resolveOutputFormat } from '@/lib/strict-mode.ts'
+import { describeHeadless, type DescribeResult } from '@/lib/describe-headless.ts'
+import { toBundleFsPath } from '@/lib/to-bundle-path.ts'
+
+type RenderDescribeArgs = {
+  projectName: string | undefined
+  schemaSourceString?: string | undefined
+  jsonFlag?: boolean
+  // Optional dependency for testing.
+  skmtcRoot?: SkmtcRoot
+}
+
+/**
+ * `describe` runs a project's bundle in read-only mode to report the
+ * preview-rail metadata: which subjects (operations / models) each
+ * generator supports, the form-renderable enrichment descriptors, and
+ * the schema-derived enrichment defaults. It is the local twin of the
+ * hub runner's `supportedSubjects` / `enrichmentDescriptors` /
+ * `enrichmentDefaults` RPCs — same `@skmtc/core` calls, same shapes.
+ *
+ * Like `doctor` / `agent-context` / `clean` it has no Ink variant — it
+ * always runs headless and emits a text or `--json` result. The
+ * `<project>` arg is required up front (recipe error otherwise), and the
+ * project must have been bundled (`skmtc bundle <project>`).
+ */
+export const renderDescribe = async ({
+  projectName,
+  schemaSourceString,
+  jsonFlag,
+  skmtcRoot: providedSkmtcRoot
+}: RenderDescribeArgs) => {
+  if (projectName === undefined) {
+    return failWithRecipe({
+      command: 'describe',
+      arg: '<project>',
+      usage: 'skmtc describe <project>',
+      example: 'skmtc describe my-api',
+      discover: 'ls .skmtc/  (list existing projects)'
+    })
+  }
+
+  const skmtcRoot = providedSkmtcRoot ?? (await SkmtcRoot.open(new Manager()))
+
+  const project = skmtcRoot.projects.find(({ name }) => name === projectName)
+
+  if (project === undefined) {
+    return failWithRecipe({
+      command: 'describe',
+      arg: '<project>',
+      usage: 'skmtc describe <project>',
+      example: 'skmtc describe my-api',
+      discover: 'ls .skmtc/  (list existing projects)'
+    })
+  }
+
+  // describe runs the project bundle to read generator capabilities — a
+  // missing bundle is a precondition failure, not a bad argument, so it
+  // exits 1 with a build hint rather than a recipe error.
+  if (!existsSync(toBundleFsPath(project.toPath()))) {
+    console.error(
+      `Error: no bundle for "${projectName}". Run \`skmtc bundle ${projectName}\` ` +
+        `first — describe runs the project bundle to read generator capabilities.`
+    )
+    await skmtcRoot.manager.cleanup()
+    Deno.exit(1)
+  }
+
+  const source = schemaSourceString ?? project.clientJson.contents?.source
+
+  if (typeof source !== 'string' || source.length === 0) {
+    return failWithRecipe({
+      command: 'describe',
+      arg: '[schema]',
+      usage: 'skmtc describe <project> [schema]',
+      example: 'skmtc describe my-api ./openapi.json',
+      discover: 'set client.json#source, or pass the schema path/URL as the second arg'
+    })
+  }
+
+  // The bundle runs the engine's read-only metadata pass. The dominant
+  // failure is a core-version skew between the worker and the project's
+  // generators (e.g. a generator built against an older `@skmtc/core`
+  // lacks entry methods the trio calls) — surface it as a clean exit 1
+  // instead of an uncaught worker rejection.
+  const result = await describeHeadless({ project, schemaSourceString }).catch(error => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(
+      `Error: describe failed for "${projectName}": ${message}\n` +
+        `If this is a "not a function" error, the project's generators were built ` +
+        `against a different @skmtc/core than the worker — rebundle the project ` +
+        `(\`skmtc bundle ${projectName}\`) against version-aligned generators.`
+    )
+    return null
+  })
+
+  if (result === null) {
+    await skmtcRoot.manager.cleanup()
+    Deno.exit(1)
+  }
+
+  printDescribeResult(result, { format: resolveOutputFormat({ jsonFlag }) })
+
+  await skmtcRoot.manager.cleanup()
+
+  Deno.exit(0)
+}
+
+type PrintDescribeResultOptions = {
+  format: 'text' | 'json'
+}
+
+export const printDescribeResult = (
+  result: DescribeResult,
+  { format }: PrintDescribeResultOptions
+): void => {
+  switch (format) {
+    case 'json': {
+      console.log(JSON.stringify(result, null, 2))
+      return
+    }
+    case 'text': {
+      const subjectGenerators = Object.keys(result.subjects).length
+      console.log(
+        `describe "${result.projectName}": ${result.descriptors.length} generator descriptor(s), ` +
+          `${subjectGenerators} generator(s) with supported subjects.`
+      )
+
+      for (const descriptor of result.descriptors) {
+        const variants = descriptor.supportsVariant ? ', variants' : ''
+        console.log(
+          `  ${descriptor.generator} (${descriptor.subjectKind}${variants}) — ${descriptor.fields.length} field(s)`
+        )
+      }
+
+      if (result.parseIssues.length > 0) {
+        console.log(`  (${result.parseIssues.length} parse issue(s))`)
+      }
+      return
+    }
+    default: {
+      const _exhaustive: never = format
+      throw new Error(`Unhandled output format: ${JSON.stringify(_exhaustive)}`)
+    }
+  }
+}

--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.3",
+  "version": "0.9.5",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {
@@ -8,8 +8,8 @@
     "@cliffy/command": "jsr:@cliffy/command@1.1.0",
     "@skmtc/core": "jsr:@skmtc/core@0.20.2",
     "@skmtc/convert": "jsr:@skmtc/convert@0.1.16",
-    "@skmtc/worker": "jsr:@skmtc/worker@0.3.33",
-    "@skmtc/worker/types": "jsr:@skmtc/worker@0.3.33/types",
+    "@skmtc/worker": "jsr:@skmtc/worker@0.3.34",
+    "@skmtc/worker/types": "jsr:@skmtc/worker@0.3.34/types",
     "@skmtc/server": "jsr:@skmtc/server@0.2.45",
     "chokidar": "npm:chokidar@^4.0.3",
     "ink": "npm:ink@^6.2.3",

--- a/deno/cli/lib/cli-schema.ts
+++ b/deno/cli/lib/cli-schema.ts
@@ -136,6 +136,14 @@ export const COMMAND_DESCRIPTORS: CommandDescriptor[] = [
     agentMode: 'json-only'
   },
   {
+    name: 'describe',
+    description:
+      "Report a project's preview metadata by running its bundle read-only: supported subjects (operations / models) per generator, the form-renderable enrichment descriptors, and the schema-derived enrichment defaults.",
+    args: ['<project>', '[schema]'],
+    flags: [{ flag: '--json', description: 'Emit structured JSON output.' }],
+    agentMode: 'json-only'
+  },
+  {
     name: 'publish',
     description:
       'Build and publish an immutable version of this project to skmtc-hub. The stack is the project deno.json#name (@account/slug, the package name; the scope may be an org); versions are addressed by semver and re-publishing an existing version is rejected.',

--- a/deno/cli/lib/describe-headless.test.ts
+++ b/deno/cli/lib/describe-headless.test.ts
@@ -1,0 +1,100 @@
+import { assertEquals } from '@std/assert'
+import { describeHeadless } from '@/lib/describe-headless.ts'
+import { createMockManager } from '@/tests/mocks/manager.mock.ts'
+import { createMockProject } from '@/tests/mocks/project.mock.ts'
+import { mockClientJsonContents } from '@/tests/fixtures/client-json.fixture.ts'
+import type { DescribePayload } from '@skmtc/worker/types'
+
+const OriginalWorker = globalThis.Worker
+
+// Mirrors the MockWorker in describe-worker.test.ts — we only need it to
+// drive the READY → DESCRIBE → RESULT handshake without a real bundle.
+class MockWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((error: ErrorEvent) => void) | null = null
+
+  constructor(
+    public url: string,
+    public options?: WorkerOptions
+  ) {}
+
+  postMessage(_data: unknown) {}
+
+  terminate() {}
+
+  simulateMessage(data: unknown) {
+    if (this.onmessage) {
+      this.onmessage(new MessageEvent('message', { data }))
+    }
+  }
+}
+
+const emptyDescribeResult = {
+  type: 'RESULT',
+  subjects: {},
+  descriptors: [],
+  enrichmentDefaults: {},
+  parseIssues: []
+}
+
+Deno.test(
+  'describeHeadless - resolves client.json#source, feeds it to the worker, and stamps projectName',
+  async () => {
+    const schemaPath = await Deno.makeTempFile({ suffix: '.json' })
+    await Deno.writeTextFile(
+      schemaPath,
+      JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Source-Of-Truth API', version: '1.0.0' },
+        paths: {}
+      })
+    )
+
+    // A mutable box: the closure assignment is invisible to TS flow
+    // analysis, so a plain `let` would stay narrowed to `null`. Reading
+    // a box property after the `await` keeps the declared type.
+    const captured: { payload: DescribePayload | null } = { payload: null }
+
+    globalThis.Worker = class {
+      constructor(url: string | URL, options?: WorkerOptions) {
+        const instance = new MockWorker(url.toString(), options)
+        instance.postMessage = (data: unknown) => {
+          const message = data as { type: string; payload: DescribePayload }
+          if (message.type === 'DESCRIBE') {
+            captured.payload = message.payload
+            setTimeout(() => instance.simulateMessage(emptyDescribeResult), 0)
+          }
+        }
+        setTimeout(() => instance.simulateMessage({ type: 'READY' }), 0)
+        return instance as unknown as Worker
+      }
+    } as unknown as typeof Worker
+
+    try {
+      const manager = createMockManager()
+      const project = createMockProject(manager, { name: 'my-api' })
+      // No explicit schema override is passed, so describe must fall back
+      // to client.json#source — point it at our fixture file.
+      project.clientJson.contents = {
+        settings: mockClientJsonContents.settings,
+        source: schemaPath
+      }
+
+      const result = await describeHeadless({ project, schemaSourceString: undefined })
+
+      // The worker's response is stamped with the project it ran for.
+      assertEquals(result.projectName, 'my-api')
+
+      // The schema the worker received is the one resolved from
+      // client.json#source, converted host-side to an OAS document.
+      const payload = captured.payload
+      assertEquals(payload?.document.type, 'oas')
+      if (payload?.document.type === 'oas') {
+        assertEquals(payload.document.value.info.title, 'Source-Of-Truth API')
+      }
+    } finally {
+      globalThis.Worker = OriginalWorker
+      await Deno.remove(schemaPath)
+    }
+  }
+)

--- a/deno/cli/lib/describe-headless.ts
+++ b/deno/cli/lib/describe-headless.ts
@@ -1,0 +1,41 @@
+import type { Project } from '@/lib/project.ts'
+import { toSchemaContents } from '@/lib/to-schema-contents.ts'
+import { toBundlePath } from '@/lib/to-bundle-path.ts'
+import { describeWithWorker, type DescribeResponse } from '@/lib/describe-worker.ts'
+
+/** Describe result plus the project it was computed for. */
+export type DescribeResult = DescribeResponse & {
+  projectName: string
+}
+
+type DescribeHeadlessArgs = {
+  project: Project
+  /** Explicit schema override; falls back to `client.json#source`. */
+  schemaSourceString: string | undefined
+}
+
+/**
+ * Run the read-only `DESCRIBE` pass for a project: load the schema, then
+ * spawn the project bundle to compute supported subjects, enrichment
+ * descriptors, and enrichment defaults — the metadata a preview rail
+ * needs, in the same shapes the hub runner produces.
+ *
+ * The caller is responsible for validating that the bundle exists and a
+ * schema source is present (see `commands/describe.ts`).
+ */
+export const describeHeadless = async ({
+  project,
+  schemaSourceString
+}: DescribeHeadlessArgs): Promise<DescribeResult> => {
+  const source = schemaSourceString ?? project.clientJson.contents?.source ?? ''
+  const schemaContents = await toSchemaContents(source)
+
+  const result = await describeWithWorker({
+    schemaContents: schemaContents.contents,
+    fileType: schemaContents.fileType,
+    clientSettings: project.clientJson.contents?.settings,
+    bundlePath: toBundlePath(project.toPath())
+  })
+
+  return { projectName: project.name, ...result }
+}

--- a/deno/cli/lib/describe-worker.test.ts
+++ b/deno/cli/lib/describe-worker.test.ts
@@ -1,0 +1,194 @@
+import { assertEquals, assertRejects } from '@std/assert'
+import { describeWithWorker } from './describe-worker.ts'
+import type { DescribePayload } from '@skmtc/worker/types'
+
+// Store original Worker constructor
+const OriginalWorker = globalThis.Worker
+
+// Mock Worker class for testing — mirrors generate-worker.test.ts.
+class MockWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((error: ErrorEvent) => void) | null = null
+
+  constructor(
+    public url: string,
+    public options?: WorkerOptions
+  ) {}
+
+  postMessage(_data: unknown) {}
+
+  terminate() {}
+
+  simulateMessage(data: unknown) {
+    if (this.onmessage) {
+      this.onmessage(new MessageEvent('message', { data }))
+    }
+  }
+
+  simulateError(error: Error) {
+    if (this.onerror) {
+      this.onerror(new ErrorEvent('error', { error, message: error.message }))
+    }
+  }
+}
+
+const createMockSchemaContents = () =>
+  JSON.stringify({
+    openapi: '3.0.0',
+    info: { title: 'Test API', version: '1.0.0' },
+    paths: {}
+  })
+
+// A representative DESCRIBE RESULT payload (the three engine outputs).
+// Discriminant literals are `as const` so the shapes satisfy the
+// strongly-typed `DescribeResponse` fields the resolved promise carries.
+const createMockDescribeResult = () => ({
+  type: 'RESULT',
+  subjects: { '@scope/gen-x': { type: 'model' as const, models: ['User'] } },
+  descriptors: [
+    {
+      generator: '@scope/gen-x',
+      subjectKind: 'model' as const,
+      supportsVariant: false,
+      fields: []
+    }
+  ],
+  enrichmentDefaults: { '@scope/gen-x': { User: { main: {} } } },
+  parseIssues: []
+})
+
+Deno.test('describeWithWorker - creates Worker read-only (write: false)', async () => {
+  let capturedWorker: MockWorker | null = null as MockWorker | null
+
+  globalThis.Worker = class {
+    constructor(url: string | URL, options?: WorkerOptions) {
+      const instance = new MockWorker(url.toString(), options)
+      capturedWorker = instance
+      setTimeout(() => {
+        instance.simulateMessage({ type: 'READY' })
+        setTimeout(() => instance.simulateMessage(createMockDescribeResult()), 0)
+      }, 0)
+      return instance as unknown as Worker
+    }
+  } as unknown as typeof Worker
+
+  try {
+    await describeWithWorker({
+      schemaContents: createMockSchemaContents(),
+      clientSettings: undefined,
+      fileType: 'json' as const,
+      bundlePath: './worker.ts'
+    })
+
+    assertEquals(capturedWorker?.options?.type, 'module')
+    const permissions = capturedWorker?.options?.deno?.permissions as {
+      read?: boolean
+      net?: boolean
+      write?: boolean
+      env?: boolean
+      run?: boolean
+    }
+    assertEquals(permissions?.read, true)
+    assertEquals(permissions?.net, false)
+    // describe is read-only — no artifacts are written.
+    assertEquals(permissions?.write, false)
+    assertEquals(permissions?.run, false)
+  } finally {
+    globalThis.Worker = OriginalWorker
+  }
+})
+
+Deno.test('describeWithWorker - handles READY and posts a DESCRIBE message (OAS document)', async () => {
+  let capturedPayload: unknown = null
+
+  globalThis.Worker = class {
+    constructor(url: string | URL, options?: WorkerOptions) {
+      const instance = new MockWorker(url.toString(), options)
+      instance.postMessage = (data: unknown) => {
+        const message = data as { type: string; payload: unknown }
+        if (message.type === 'DESCRIBE') {
+          capturedPayload = message.payload
+          setTimeout(() => instance.simulateMessage(createMockDescribeResult()), 0)
+        }
+      }
+      setTimeout(() => instance.simulateMessage({ type: 'READY' }), 0)
+      return instance as unknown as Worker
+    }
+  } as unknown as typeof Worker
+
+  try {
+    await describeWithWorker({
+      schemaContents: createMockSchemaContents(),
+      clientSettings: undefined,
+      fileType: 'json' as const,
+      bundlePath: './worker.ts'
+    })
+
+    const payload = capturedPayload as DescribePayload
+    assertEquals(payload.document.type, 'oas')
+    if (payload.document.type === 'oas') {
+      assertEquals(payload.document.value.openapi, '3.0.0')
+    }
+  } finally {
+    globalThis.Worker = OriginalWorker
+  }
+})
+
+Deno.test('describeWithWorker - resolves with subjects/descriptors/defaults on RESULT', async () => {
+  const expected = createMockDescribeResult()
+
+  globalThis.Worker = class {
+    constructor(url: string | URL, options?: WorkerOptions) {
+      const instance = new MockWorker(url.toString(), options)
+      setTimeout(() => {
+        instance.simulateMessage({ type: 'READY' })
+        setTimeout(() => instance.simulateMessage(expected), 0)
+      }, 0)
+      return instance as unknown as Worker
+    }
+  } as unknown as typeof Worker
+
+  try {
+    const result = await describeWithWorker({
+      schemaContents: createMockSchemaContents(),
+      clientSettings: undefined,
+      fileType: 'json' as const,
+      bundlePath: './worker.ts'
+    })
+
+    assertEquals(result.subjects, expected.subjects)
+    assertEquals(result.descriptors, expected.descriptors)
+    assertEquals(result.enrichmentDefaults, expected.enrichmentDefaults)
+    assertEquals(result.parseIssues, expected.parseIssues)
+  } finally {
+    globalThis.Worker = OriginalWorker
+  }
+})
+
+Deno.test('describeWithWorker - rejects on ERROR message', async () => {
+  globalThis.Worker = class {
+    constructor(url: string | URL, options?: WorkerOptions) {
+      const instance = new MockWorker(url.toString(), options)
+      setTimeout(() => {
+        instance.simulateMessage({ type: 'READY' })
+        setTimeout(() => instance.simulateMessage({ type: 'ERROR', error: 'boom' }), 0)
+      }, 0)
+      return instance as unknown as Worker
+    }
+  } as unknown as typeof Worker
+
+  try {
+    await assertRejects(
+      () =>
+        describeWithWorker({
+          schemaContents: createMockSchemaContents(),
+          clientSettings: undefined,
+          fileType: 'json' as const,
+          bundlePath: './worker.ts'
+        }),
+      Error
+    )
+  } finally {
+    globalThis.Worker = OriginalWorker
+  }
+})

--- a/deno/cli/lib/describe-worker.ts
+++ b/deno/cli/lib/describe-worker.ts
@@ -1,0 +1,97 @@
+import type { ClientSettings } from '@skmtc/core/Settings'
+import type {
+  EnrichmentDefaults,
+  EnrichmentDescriptor,
+  ParseIssue,
+  SupportedSubjects
+} from '@skmtc/core'
+import { toDocumentInput } from '@/lib/document-input.ts'
+import type { FileType } from '@/lib/types.ts'
+
+/**
+ * Host-side result of a `DESCRIBE` worker run — the read-only metadata
+ * the preview rail needs, in the same shapes the hub runner returns
+ * from `/subjects`, `/descriptors`, `/enrichment-defaults`.
+ */
+export type DescribeResponse = {
+  subjects: SupportedSubjects
+  descriptors: EnrichmentDescriptor[]
+  enrichmentDefaults: EnrichmentDefaults
+  parseIssues: ParseIssue[]
+}
+
+type DescribeWithWorkerArgs = {
+  schemaContents: string
+  /** File type of the schema source — drives OAS-vs-GQL document building. */
+  fileType: FileType
+  clientSettings: ClientSettings | undefined
+  bundlePath: string
+}
+
+/**
+ * Spawn the project's bundle worker and run a single `DESCRIBE` message.
+ *
+ * Mirrors {@link generateWithWorker} but for the read-only metadata
+ * pass: no artifacts are produced and nothing is written to disk, so the
+ * worker is spawned without `write` permission. On `READY` we post the
+ * host-built `document` + `clientSettings`; the worker replies with one
+ * `RESULT` carrying subjects + descriptors + defaults.
+ */
+export const describeWithWorker = ({
+  schemaContents,
+  fileType,
+  clientSettings,
+  bundlePath
+}: DescribeWithWorkerArgs): Promise<DescribeResponse> => {
+  const workerUrl = new URL(bundlePath, import.meta.url)
+
+  const worker = new Worker(workerUrl.href, {
+    type: 'module',
+    deno: {
+      permissions: {
+        read: true,
+        net: false,
+        write: false,
+        env: true,
+        run: false
+      }
+    }
+  })
+
+  return new Promise((resolve, reject) => {
+    worker.onmessage = async (e: MessageEvent) => {
+      const { type } = e.data
+
+      switch (type) {
+        case 'READY': {
+          const document = await toDocumentInput(schemaContents, fileType)
+          worker.postMessage({
+            type: 'DESCRIBE',
+            payload: {
+              document,
+              clientSettings
+            }
+          })
+          break
+        }
+
+        case 'RESULT': {
+          worker.terminate()
+          const { subjects, descriptors, enrichmentDefaults, parseIssues } = e.data
+          resolve({ subjects, descriptors, enrichmentDefaults, parseIssues })
+          break
+        }
+
+        case 'ERROR': {
+          worker.terminate()
+          reject(new Error(e.data.error ?? String(e.data)))
+          break
+        }
+      }
+    }
+
+    worker.onerror = error => {
+      reject(error)
+    }
+  })
+}

--- a/deno/cli/lib/document-input.test.ts
+++ b/deno/cli/lib/document-input.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals, assertObjectMatch } from '@std/assert'
+import { toDocumentInput } from '@/lib/document-input.ts'
+
+Deno.test('toDocumentInput - graphql posts the raw SDL unparsed', async () => {
+  // The whole reason GQL is routed differently: a pre-parsed document
+  // would carry class instances / OasRef back-refs that don't survive
+  // structured clone, so the SDL must cross the worker boundary as the
+  // verbatim string and be parsed worker-side.
+  const sdl = 'type Query { hello: String }'
+  const result = await toDocumentInput(sdl, 'graphql')
+
+  assertEquals(result.type, 'gql')
+  if (result.type !== 'gql') throw new Error('expected gql document')
+  // Strictly the same string — no parse, no normalization.
+  assertEquals(result.value, sdl)
+})
+
+Deno.test('toDocumentInput - OAS 3.0 JSON passes through as an oas document', async () => {
+  const result = await toDocumentInput(
+    JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Modern API', version: '1.0.0' },
+      paths: {}
+    }),
+    'json'
+  )
+
+  assertEquals(result.type, 'oas')
+  if (result.type !== 'oas') throw new Error('expected oas document')
+  assertEquals(result.value.openapi, '3.0.0')
+  assertEquals(result.value.info.title, 'Modern API')
+})
+
+Deno.test('toDocumentInput - Swagger 2.0 JSON is converted to OpenAPI 3.0 host-side', async () => {
+  // describe/generate run @skmtc/convert on the host so the worker only
+  // ever sees OAS 3.x. This locks in that a Swagger 2.0 source is
+  // upgraded before it crosses the boundary, not left for the worker.
+  const result = await toDocumentInput(
+    JSON.stringify({
+      swagger: '2.0',
+      info: { title: 'Legacy API', version: '1.0.0' },
+      paths: {}
+    }),
+    'json'
+  )
+
+  assertEquals(result.type, 'oas')
+  if (result.type !== 'oas') throw new Error('expected oas document')
+  assertEquals(result.value.openapi, '3.0.0')
+  assertEquals(result.value.info.title, 'Legacy API')
+  // The swagger discriminant is gone after the upgrade.
+  assertEquals('swagger' in result.value, false)
+})
+
+Deno.test('toDocumentInput - YAML OAS is parsed into an oas document', async () => {
+  const result = await toDocumentInput(
+    ['openapi: 3.0.0', 'info:', '  title: Yaml API', '  version: 1.0.0', 'paths: {}'].join('\n'),
+    'yaml'
+  )
+
+  assertEquals(result.type, 'oas')
+  if (result.type !== 'oas') throw new Error('expected oas document')
+  assertEquals(result.value.openapi, '3.0.0')
+  assertObjectMatch(result.value.info, { title: 'Yaml API', version: '1.0.0' })
+})

--- a/deno/cli/lib/document-input.ts
+++ b/deno/cli/lib/document-input.ts
@@ -1,0 +1,38 @@
+import { stringToSchema, toV3Document } from '@skmtc/convert'
+import type { SkmtcDocumentInput } from '@skmtc/core'
+import { fileTypeToProtocol, type FileType } from '@/lib/types.ts'
+
+/**
+ * Build the host-side `SkmtcDocumentInput` for a worker run (generate or
+ * describe).
+ *
+ * - For OAS (JSON / YAML) sources we run the host-side `@skmtc/convert`
+ *   to normalize Swagger 2 / OAS 3.1 → 3.0. The resulting
+ *   `OpenAPIV3.Document` is JSON-clone-safe so it crosses the worker
+ *   boundary without surprises.
+ * - For GraphQL we post the raw SDL string. A pre-parsed `GqlDocument`
+ *   would carry class instances and `OasRef` back-refs that don't
+ *   survive structured clone, so SDL parsing happens inside the worker.
+ *
+ * Switch is exhaustive over `Protocol`; adding a new protocol forces a
+ * compile error here.
+ */
+export const toDocumentInput = async (
+  schemaContents: string,
+  fileType: FileType
+): Promise<SkmtcDocumentInput> => {
+  const protocol = fileTypeToProtocol(fileType)
+  switch (protocol) {
+    case 'gql': {
+      return { type: 'gql', value: schemaContents }
+    }
+    case 'oas': {
+      const documentObject = await toV3Document(stringToSchema(schemaContents))
+      return { type: 'oas', value: documentObject }
+    }
+    default: {
+      const _exhaustive: never = protocol
+      throw new Error(`Unhandled protocol: ${_exhaustive}`)
+    }
+  }
+}

--- a/deno/cli/lib/generate-worker.ts
+++ b/deno/cli/lib/generate-worker.ts
@@ -1,8 +1,7 @@
-import { toV3Document, stringToSchema } from '@skmtc/convert'
 import type { ClientSettings } from '@skmtc/core/Settings'
-import type { SkmtcDocumentInput } from '@skmtc/core'
 import type { SerializableAttribution } from '@skmtc/worker/types'
-import { fileTypeToProtocol, type FileType } from '@/lib/types.ts'
+import { toDocumentInput } from '@/lib/document-input.ts'
+import type { FileType } from '@/lib/types.ts'
 import type { GenerateResponse } from '@/types/generateResponse.ts'
 
 // Re-export so existing callers (e.g. `services/generateSandboxApi.ts`)
@@ -30,41 +29,6 @@ type GenerateWithWorkerArgs = {
    * on in core; this only controls emission.)
    */
   attribution?: SerializableAttribution
-}
-
-/**
- * Build the host-side `SkmtcDocumentInput` for a generate run.
- *
- * - For OAS (JSON / YAML) sources we run the host-side
- *   `@skmtc/convert` to normalize Swagger 2 / OAS 3.1 → 3.0. The
- *   resulting `OpenAPIV3.Document` is JSON-clone-safe so it crosses the
- *   worker boundary without surprises.
- * - For GraphQL we post the raw SDL string. A pre-parsed `GqlDocument`
- *   would carry class instances and `OasRef` back-refs that don't
- *   survive structured clone, so SDL parsing happens inside the worker
- *   via `toArtifacts` (now protocol-agnostic).
- *
- * Switch is exhaustive over `Protocol`; adding a new protocol forces a
- * compile error here.
- */
-const toDocumentInput = async (
-  schemaContents: string,
-  fileType: FileType
-): Promise<SkmtcDocumentInput> => {
-  const protocol = fileTypeToProtocol(fileType)
-  switch (protocol) {
-    case 'gql': {
-      return { type: 'gql', value: schemaContents }
-    }
-    case 'oas': {
-      const documentObject = await toV3Document(stringToSchema(schemaContents))
-      return { type: 'oas', value: documentObject }
-    }
-    default: {
-      const _exhaustive: never = protocol
-      throw new Error(`Unhandled protocol: ${_exhaustive}`)
-    }
-  }
 }
 
 export const generateWithWorker = ({

--- a/deno/cli/mod.ts
+++ b/deno/cli/mod.ts
@@ -15,6 +15,9 @@ const COMMANDS_THAT_SKIP_REGISTRY_CHECK = new Set<string>([
   'doctor',
   'agent-context',
   'clean',
+  // describe runs the project's local bundle to read generator
+  // capabilities; it never touches JSR.
+  'describe',
   // login/logout talk to the hub (or just the local filesystem), not
   // the JSR registry.
   'login',
@@ -240,6 +243,21 @@ const run = async () => {
         jsonFlag: json,
         dryRunFlag: dryRun,
         verboseFlag: verbose
+      })
+    })
+
+  const describeCommand = new Command()
+    .description(getCommandDescriptor('describe').description)
+    // Optional project arg routes a missing value to the recipe error
+    // (with the `ls .skmtc/` discovery hint), matching `clean` / `list`.
+    .arguments('[project:string] [schema:string]')
+    .option('--json', 'Emit structured JSON output.')
+    .action(async ({ json }, projectName, schemaSourceString) => {
+      const { renderDescribe } = await import('@/commands/describe.ts')
+      await renderDescribe({
+        projectName,
+        schemaSourceString,
+        jsonFlag: json
       })
     })
 
@@ -523,6 +541,7 @@ const run = async () => {
     .command('generate', generateCommand)
     .command('bundle', bundleCommand)
     .command('clean', cleanCommand)
+    .command('describe', describeCommand)
     .command('publish', publishCommand)
     .command('push', pushCommand)
     .command('pull', pullCommand)

--- a/deno/deno.lock
+++ b/deno/deno.lock
@@ -1083,9 +1083,9 @@
         "dependencies": [
           "jsr:@cliffy/command@1.1.0",
           "jsr:@skmtc/convert@0.1.16",
-          "jsr:@skmtc/core@0.20.0",
-          "jsr:@skmtc/server@0.2.43",
-          "jsr:@skmtc/worker@0.3.31",
+          "jsr:@skmtc/core@0.20.2",
+          "jsr:@skmtc/server@0.2.45",
+          "jsr:@skmtc/worker@0.3.34",
           "npm:@inkjs/ui@2",
           "npm:@types/react@19",
           "npm:chokidar@^4.0.3",
@@ -1122,32 +1122,32 @@
       },
       "lang-csharp": {
         "dependencies": [
-          "jsr:@skmtc/core@0.20.0"
+          "jsr:@skmtc/core@0.20.2"
         ]
       },
       "lang-go": {
         "dependencies": [
-          "jsr:@skmtc/core@0.20.0"
+          "jsr:@skmtc/core@0.20.2"
         ]
       },
       "lang-kotlin": {
         "dependencies": [
-          "jsr:@skmtc/core@0.20.0"
+          "jsr:@skmtc/core@0.20.2"
         ]
       },
       "lang-php": {
         "dependencies": [
-          "jsr:@skmtc/core@0.20.0"
+          "jsr:@skmtc/core@0.20.2"
         ]
       },
       "lang-rust": {
         "dependencies": [
-          "jsr:@skmtc/core@0.20.0"
+          "jsr:@skmtc/core@0.20.2"
         ]
       },
       "lang-typescript": {
         "dependencies": [
-          "jsr:@skmtc/core@0.20.0"
+          "jsr:@skmtc/core@0.20.2"
         ]
       },
       "mcp": {
@@ -1172,7 +1172,7 @@
       "server": {
         "dependencies": [
           "jsr:@skmtc/convert@0.1.16",
-          "jsr:@skmtc/core@0.20.0",
+          "jsr:@skmtc/core@0.20.2",
           "npm:hono@4.7.2"
         ]
       },
@@ -1188,7 +1188,7 @@
       },
       "worker": {
         "dependencies": [
-          "jsr:@skmtc/core@0.20.0",
+          "jsr:@skmtc/core@0.20.2",
           "npm:openapi-types@^12.1.3"
         ]
       }

--- a/deno/worker/deno.json
+++ b/deno/worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/worker",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",

--- a/deno/worker/mod.ts
+++ b/deno/worker/mod.ts
@@ -1,14 +1,16 @@
 import { type GeneratorsMapContainer, toArtifacts } from '@skmtc/core'
-import { StackTrail } from '@skmtc/core'
+import { StackTrail, toEnrichmentDefaults, toEnrichmentDescriptor, toSupportedSubjects } from '@skmtc/core'
 import type { AttributionState } from '@skmtc/core/AttributionState'
-import type { GeneratePayload, SerializableAttribution } from './types.ts'
+import type { SerializableAttribution, WorkerMessage } from './types.ts'
 
 // Re-export for hosts that want both the runtime entry and the
 // payload types from the same module path.
 export type {
+  DescribePayload,
   GeneratePayload,
   WorkerMessage,
   WorkerResult,
+  WorkerDescribeResult,
   SerializableAttribution
 } from './types.ts'
 
@@ -76,14 +78,17 @@ const toWorker = (
   toGeneratorConfigMap: <EnrichmentType = undefined>() => GeneratorsMapContainer<EnrichmentType>
 ) => {
   self.onmessage = async (e: MessageEvent) => {
-    const { type, payload } = e.data as {
-      type: string
-      payload: GeneratePayload
-    }
+    // Boundary cast of the structured-clone payload, as elsewhere in
+    // this handler. `message` is the discriminated union; `rawType` is
+    // captured separately so the malformed-message `default` can report
+    // the offending value without narrowing `message` to `never`.
+    const rawType = (e.data as { type?: unknown }).type
+    const message = e.data as WorkerMessage
 
     try {
-      switch (type) {
+      switch (message.type) {
         case 'GENERATE': {
+          const { payload } = message
           const startAt = Date.now()
           const traceId = `trace-${startAt}`
           const spanId = `span-${startAt}`
@@ -117,10 +122,54 @@ const toWorker = (
           })
           break
         }
+        case 'DESCRIBE': {
+          const { payload } = message
+          const startAt = Date.now()
+          const traceId = `trace-${startAt}`
+          const spanId = `span-${startAt}`
+
+          // The three read-only engine calls the bundle's `server.js`
+          // exposes at /subjects, /descriptors, /enrichment-defaults.
+          // Calling them here (rather than via a server bundle) keeps
+          // local `skmtc describe` shape-identical to the hub runner.
+          // Each pass gets its own StackTrail (the parse phase mutates
+          // it). Descriptors are documentless — a pure map over the
+          // bundled generators.
+          const { subjects, parseIssues: subjectIssues } = toSupportedSubjects({
+            traceId,
+            spanId,
+            document: payload.document,
+            settings: payload.clientSettings,
+            toGeneratorConfigMap,
+            stackTrail: new StackTrail([traceId, spanId]),
+            silent: true
+          })
+
+          const { enrichmentDefaults, parseIssues: defaultIssues } = toEnrichmentDefaults({
+            traceId,
+            spanId,
+            document: payload.document,
+            settings: payload.clientSettings,
+            toGeneratorConfigMap,
+            stackTrail: new StackTrail([traceId, spanId]),
+            silent: true
+          })
+
+          const descriptors = Object.values(toGeneratorConfigMap()).map(toEnrichmentDescriptor)
+
+          self.postMessage({
+            type: 'RESULT',
+            subjects,
+            descriptors,
+            enrichmentDefaults,
+            parseIssues: [...subjectIssues, ...defaultIssues]
+          })
+          break
+        }
         default: {
           self.postMessage({
             type: 'ERROR',
-            error: `Unknown message type: ${type}`
+            error: `Unknown message type: ${String(rawType)}`
           })
           break
         }

--- a/deno/worker/types.ts
+++ b/deno/worker/types.ts
@@ -1,5 +1,11 @@
 import type { ClientSettings } from '@skmtc/core/Settings'
-import type { SkmtcDocumentInput } from '@skmtc/core'
+import type {
+  EnrichmentDefaults,
+  EnrichmentDescriptor,
+  ParseIssue,
+  SkmtcDocumentInput,
+  SupportedSubjects
+} from '@skmtc/core'
 import type { RegistryEntry, Sidecar, GenerationMapEntry } from '@skmtc/core/Anchors'
 import type { ManifestContent } from '@skmtc/core/Manifest'
 
@@ -67,13 +73,27 @@ export type GeneratePayload = {
 }
 
 /**
- * Top-level message shape posted to the worker. Currently only one
- * type (`GENERATE`) is defined; future commands would add variants.
+ * Wire shape of the `DESCRIBE` message payload posted by the host.
+ *
+ * Read-only capability introspection — the subset of `GeneratePayload`
+ * the metadata pass needs. `document` is the same `SkmtcDocumentInput`
+ * union built host-side; `clientSettings` scopes `isSupported` and the
+ * default-derivation. No `attribution` (nothing is rendered) and no
+ * `silent` (the worker forces silent for DESCRIBE).
  */
-export type WorkerMessage = {
-  type: 'GENERATE'
-  payload: GeneratePayload
+export type DescribePayload = {
+  clientSettings?: ClientSettings
+  document: SkmtcDocumentInput
 }
+
+/**
+ * Top-level message shape posted to the worker — a discriminated union
+ * over `type`. `GENERATE` runs the full pipeline; `DESCRIBE` runs the
+ * read-only metadata pass (subjects + descriptors + defaults).
+ */
+export type WorkerMessage =
+  | { type: 'GENERATE'; payload: GeneratePayload }
+  | { type: 'DESCRIBE'; payload: DescribePayload }
 
 /**
  * Wire shape of the worker's RESULT message back to the host. Mirrors
@@ -86,4 +106,21 @@ export type WorkerResult = {
   manifest: ManifestContent
   sidecars?: Record<string, Sidecar>
   generationMap?: GenerationMapEntry[]
+}
+
+/**
+ * Wire shape of the worker's RESULT message for a `DESCRIBE` request.
+ * Mirrors the three engine calls (`toSupportedSubjects`,
+ * `toEnrichmentDescriptor`, `toEnrichmentDefaults`) the bundle's
+ * `server.js` exposes at `/subjects`, `/descriptors`,
+ * `/enrichment-defaults` — so a local `skmtc describe` produces the same
+ * shapes the hub runner does. `parseIssues` are the union of the
+ * subjects + defaults passes (descriptors are documentless).
+ */
+export type WorkerDescribeResult = {
+  type: 'RESULT'
+  subjects: SupportedSubjects
+  descriptors: EnrichmentDescriptor[]
+  enrichmentDefaults: EnrichmentDefaults
+  parseIssues: ParseIssue[]
 }


### PR DESCRIPTION
## Summary

Adds a read-only `skmtc describe <project> [schema]` command that runs a project's bundle to report the **preview-rail metadata** — supported subjects per generator, form-renderable enrichment descriptors, and schema-derived enrichment defaults. This is the local twin of the hub runner's `supportedSubjects` / `enrichmentDescriptors` / `enrichmentDefaults` RPCs, so a local Vite preview can render the same rails the hosted product does.

## Changes

- **`@skmtc/worker`**: additive `DESCRIBE` message calling `toSupportedSubjects`, `toEnrichmentDescriptor`, and `toEnrichmentDefaults` — the same `@skmtc/core` calls the server bundle exposes at `/subjects`, `/descriptors`, `/enrichment-defaults`, so shapes match the hub.
- **`@skmtc/cli`**: the `describe` command + worker-spawn host (`describe-worker`) + headless loader; extracts the shared `toDocumentInput` out of `generate-worker` into `document-input`.
- `describe` fails cleanly (exit 1, diagnostic) when the project's generators were built against a different `@skmtc/core` than the worker.

Released `@skmtc/worker@0.3.34` and `@skmtc/cli@0.9.5` to local JSR.

## Testing

- `deno task check` (verify-docs + full test suite): **2775 passed, 0 failed** via the pre-push hook.
- New `describe-worker.test.ts` covers the host path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
