### PR TITLE
refactor: language-blind Lang + workspace kind → type rename

### DIFF
--- a/deno/.scripts/bump.ts
+++ b/deno/.scripts/bump.ts
@@ -178,8 +178,8 @@ export const bump = async (): Promise<void> => {
   console.log(`Bump (${level}) + cascade:\n`)
   for (const pkg of order) {
     const planned = plan.get(pkg.name) as PlannedRelease
-    const kind = targets.has(pkg.name) ? level : 'cascade patch'
-    console.log(`  ${pkg.name}  ${pkg.version} -> ${planned.version}  (${kind})`)
+    const type = targets.has(pkg.name) ? level : 'cascade patch'
+    console.log(`  ${pkg.name}  ${pkg.version} -> ${planned.version}  (${type})`)
   }
 
   if (dryRun) {

--- a/deno/.scripts/release.ts
+++ b/deno/.scripts/release.ts
@@ -425,10 +425,10 @@ export const release = async (): Promise<void> => {
   console.log('\nRelease plan (dependency order):')
   for (const pkg of order) {
     const planned = plan.get(pkg.name) as PlannedRelease
-    const kind = pkg.version === planned.version
+    const type = pkg.version === planned.version
       ? 'direct'
       : `cascade ${pkg.version} -> ${planned.version}`
-    console.log(`  ${pkg.name}@${planned.version}  (${kind})`)
+    console.log(`  ${pkg.name}@${planned.version}  (${type})`)
   }
 
   console.log('\nApplying version + import updates...')

--- a/deno/cli/commands/bundle.test.tsx
+++ b/deno/cli/commands/bundle.test.tsx
@@ -55,7 +55,7 @@ Deno.test('printBundleResult - text format for bundled outcome', () => {
   console.log = (msg: string) => logs.push(msg)
   try {
     printBundleResult(
-      { kind: 'bundled', projectName: 'my-api', bundlePath: '/path/to/bundle.js' },
+      { type: 'bundled', projectName: 'my-api', bundlePath: '/path/to/bundle.js' },
       { format: 'text' }
     )
   } finally {
@@ -70,7 +70,7 @@ Deno.test('printBundleResult - json format emits the discriminated result', () =
   console.log = (msg: string) => logs.push(msg)
   try {
     printBundleResult(
-      { kind: 'bundled', projectName: 'my-api', bundlePath: '/path/to/bundle.js' },
+      { type: 'bundled', projectName: 'my-api', bundlePath: '/path/to/bundle.js' },
       { format: 'json' }
     )
   } finally {
@@ -78,7 +78,7 @@ Deno.test('printBundleResult - json format emits the discriminated result', () =
   }
   assertEquals(logs.length, 1)
   const parsed = JSON.parse(logs[0])
-  assertEquals(parsed.kind, 'bundled')
+  assertEquals(parsed.type, 'bundled')
   assertEquals(parsed.bundlePath, '/path/to/bundle.js')
   assertEquals(parsed.projectName, 'my-api')
 })

--- a/deno/cli/commands/bundle.tsx
+++ b/deno/cli/commands/bundle.tsx
@@ -75,8 +75,8 @@ type PrintBundleResultOptions = {
  * path. Every project (remote-only included) builds a local bundle,
  * so there is no no-op outcome.
  *
- * JSON shape keeps the `kind` discriminator — readable for `jq -e
- * '.kind == "bundled"'` style scripting.
+ * JSON shape keeps the `type` discriminator — readable for `jq -e
+ * '.type == "bundled"'` style scripting.
  */
 export const printBundleResult = (
   result: BundleHeadlessResult,

--- a/deno/cli/commands/clone.test.tsx
+++ b/deno/cli/commands/clone.test.tsx
@@ -65,7 +65,7 @@ Deno.test('printCloneResult - text format reports cloned ids@version + verify hi
           { moduleName: '@skmtc/gen-zod', version: '0.0.55' }
         ],
         bundle: {
-          kind: 'bundled',
+          type: 'bundled',
           projectName: 'my-api',
           bundlePath: '.skmtc/my-api/bundle.js'
         }
@@ -99,7 +99,7 @@ Deno.test('printCloneResult - json format emits a parseable object with verifyWi
         projectName: 'my-api',
         cloned: [{ moduleName: '@skmtc/gen-typescript', version: '0.0.55' }],
         bundle: {
-          kind: 'bundled',
+          type: 'bundled',
           projectName: 'my-api',
           bundlePath: '.skmtc/my-api/bundle.js'
         }
@@ -118,7 +118,7 @@ Deno.test('printCloneResult - json format emits a parseable object with verifyWi
   // The bundle field is part of the contract — agents read it to
   // confirm the post-clone rebundle landed.
   assertEquals(parsed.bundle, {
-    kind: 'bundled',
+    type: 'bundled',
     projectName: 'my-api',
     bundlePath: '.skmtc/my-api/bundle.js'
   })

--- a/deno/cli/commands/describe.test.ts
+++ b/deno/cli/commands/describe.test.ts
@@ -74,7 +74,7 @@ const baseResult: DescribeResult = {
   descriptors: [
     {
       generator: '@scope/gen-x',
-      subjectKind: 'model',
+      subjectType: 'model',
       supportsVariant: false,
       fields: [{ key: 'title', label: 'Title', optional: false, type: 'text' }]
     }
@@ -97,7 +97,7 @@ Deno.test('printDescribeResult - text appends ", variants" only when the entry s
   const withVariant: DescribeResult = {
     ...baseResult,
     descriptors: [
-      { generator: '@scope/gen-x', subjectKind: 'operation', supportsVariant: true, fields: [] }
+      { generator: '@scope/gen-x', subjectType: 'operation', supportsVariant: true, fields: [] }
     ]
   }
   const variantLogs = captureLogs(() => printDescribeResult(withVariant, { format: 'text' }))

--- a/deno/cli/commands/describe.ts
+++ b/deno/cli/commands/describe.ts
@@ -131,7 +131,7 @@ export const printDescribeResult = (
       for (const descriptor of result.descriptors) {
         const variants = descriptor.supportsVariant ? ', variants' : ''
         console.log(
-          `  ${descriptor.generator} (${descriptor.subjectKind}${variants}) — ${descriptor.fields.length} field(s)`
+          `  ${descriptor.generator} (${descriptor.subjectType}${variants}) — ${descriptor.fields.length} field(s)`
         )
       }
 

--- a/deno/cli/commands/generate-switch.ts
+++ b/deno/cli/commands/generate-switch.ts
@@ -93,9 +93,9 @@ export const generateSwitch = async ({
     // output and can recover; agents need the upfront refusal.
     if (mode === 'strict') {
       const freshness = checkBundleFreshness({ projectName })
-      if (freshness.kind === 'stale' || freshness.kind === 'missing-worker') {
+      if (freshness.type === 'stale' || freshness.type === 'missing-worker') {
         console.error(`Error: ${freshness.message}\n`)
-        if (freshness.kind === 'stale') {
+        if (freshness.type === 'stale') {
           console.error(`${freshness.hint}\n`)
         }
         Deno.exit(2)
@@ -136,7 +136,7 @@ export const generateSwitch = async ({
     })
 
     // If any parseIssue came back at `error` level, the run isn't a
-    // success even when the JSON payload has `kind: "generated"`.
+    // success even when the JSON payload has `type: "generated"`.
     // Core's CoreContext catches top-level failures and synthesizes
     // an INVALID_SCHEMA error so this branch can detect them — see
     // `core/context/CoreContext.ts` around the toArtifacts catch.
@@ -155,7 +155,7 @@ export const generateSwitch = async ({
     // (the convention `parseIssues` already uses for "ran but found
     // problems"). The generated files stay on disk so the operator
     // can fix the generator and rerun.
-    const typecheckFailed = typecheckResult?.kind === 'failed'
+    const typecheckFailed = typecheckResult?.type === 'failed'
     Deno.exit(fatalParseIssue || typecheckFailed ? 1 : 0)
   }
 

--- a/deno/cli/commands/init.test.tsx
+++ b/deno/cli/commands/init.test.tsx
@@ -78,7 +78,7 @@ Deno.test('printInitResult - text format for created project', () => {
   console.log = (msg: string) => logs.push(msg)
   try {
     printInitResult(
-      { kind: 'created', projectName: 'my-api', basePath: './src' },
+      { type: 'created', projectName: 'my-api', basePath: './src' },
       { format: 'text' }
     )
   } finally {
@@ -94,7 +94,7 @@ Deno.test('printInitResult - text format for existing project (no-op)', () => {
   const original = console.log
   console.log = (msg: string) => logs.push(msg)
   try {
-    printInitResult({ kind: 'existed', projectName: 'my-api' }, { format: 'text' })
+    printInitResult({ type: 'existed', projectName: 'my-api' }, { format: 'text' })
   } finally {
     console.log = original
   }
@@ -111,7 +111,7 @@ Deno.test(
     console.log = (msg: string) => logs.push(msg)
     try {
       printInitResult(
-        { kind: 'created', projectName: 'my-api', basePath: './src' },
+        { type: 'created', projectName: 'my-api', basePath: './src' },
         { format: 'json' }
       )
     } finally {
@@ -119,7 +119,7 @@ Deno.test(
     }
     assertEquals(logs.length, 1)
     const parsed = JSON.parse(logs[0])
-    assertEquals(parsed.kind, 'created')
+    assertEquals(parsed.type, 'created')
     assertEquals(parsed.basePath, './src')
     assertEquals(parsed.nextStep, 'skmtc install <generators...> my-api')
   }
@@ -133,14 +133,14 @@ Deno.test(
     console.log = (msg: string) => logs.push(msg)
     try {
       printInitResult(
-        { kind: 'existed', projectName: 'my-api' },
+        { type: 'existed', projectName: 'my-api' },
         { format: 'json' }
       )
     } finally {
       console.log = original
     }
     const parsed = JSON.parse(logs[0])
-    assertEquals(parsed.kind, 'existed')
+    assertEquals(parsed.type, 'existed')
     assertEquals(parsed.nextStep, null)
   }
 )

--- a/deno/cli/commands/init.tsx
+++ b/deno/cli/commands/init.tsx
@@ -110,7 +110,7 @@ export const printInitResult = (
       const payload = {
         ...result,
         nextStep:
-          result.kind === 'created'
+          result.type === 'created'
             ? `skmtc install <generators...> ${result.projectName}`
             : null
       }
@@ -118,7 +118,7 @@ export const printInitResult = (
       return
     }
     case 'text': {
-      switch (result.kind) {
+      switch (result.type) {
         case 'created': {
           console.log(`Initialized project "${result.projectName}" at .skmtc/${result.projectName}/`)
           console.log(`  basePath: ${result.basePath}`)

--- a/deno/cli/commands/install.test.tsx
+++ b/deno/cli/commands/install.test.tsx
@@ -66,7 +66,7 @@ Deno.test('printInstallResult - text format reports installed ids + verify hint'
         // Remote-only projects rebundle like any other: generate
         // loads the project-local bundle.js.
         bundle: {
-          kind: 'bundled',
+          type: 'bundled',
           projectName: 'my-api',
           bundlePath: '.skmtc/my-api/bundle.js'
         }
@@ -97,7 +97,7 @@ Deno.test('printInstallResult - text format reports rebundle when project has a 
         // Hybrid project (had a clone, now adding a remote): the post-
         // install rebundle picks up the new cross-generator import.
         bundle: {
-          kind: 'bundled',
+          type: 'bundled',
           projectName: 'my-api',
           bundlePath: '.skmtc/my-api/bundle.js'
         }
@@ -125,7 +125,7 @@ Deno.test('printInstallResult - json format emits a parseable object with verify
         projectName: 'my-api',
         installed: ['@skmtc/gen-zod'],
         bundle: {
-          kind: 'bundled',
+          type: 'bundled',
           projectName: 'my-api',
           bundlePath: '.skmtc/my-api/bundle.js'
         }
@@ -139,7 +139,7 @@ Deno.test('printInstallResult - json format emits a parseable object with verify
   const parsed: InstallHeadlessResult & { verifyWith: string } = JSON.parse(logs[0])
   assertEquals(parsed.projectName, 'my-api')
   assertEquals(parsed.installed, ['@skmtc/gen-zod'])
-  assertEquals(parsed.bundle.kind, 'bundled')
+  assertEquals(parsed.bundle.type, 'bundled')
   assertEquals(parsed.verifyWith, 'cat .skmtc/my-api/deno.json')
 })
 

--- a/deno/cli/commands/login.tsx
+++ b/deno/cli/commands/login.tsx
@@ -15,7 +15,7 @@
  *                                  instead of prompting (the `whoami`).
  *   - `skmtc login --with-token`   reads the PAT from stdin (the `gh`
  *                                  pattern) — works in strict mode.
- *   - `--json`                     `{ "kind": "logged-in", "handle": ... }`
+ *   - `--json`                     `{ "type": "logged-in", "handle": ... }`
  *                                  on success; recipe error (exit 2) on
  *                                  missing input.
  *
@@ -56,7 +56,7 @@ type RenderLoginArgs = {
 };
 
 type LoginResult = {
-  kind: "logged-in";
+  type: "logged-in";
   handle: string;
 };
 
@@ -103,7 +103,7 @@ export const renderLogin = async ({
     try {
       const handle = await validateHubToken({ origin, token });
       writeStoredAuth({ host: origin, token });
-      printLoginResult({ kind: "logged-in", handle }, { format });
+      printLoginResult({ type: "logged-in", handle }, { format });
       Deno.exit(0);
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
@@ -122,7 +122,7 @@ export const renderLogin = async ({
         token: stored.token,
       });
       printLoginResult(
-        { kind: "logged-in", handle },
+        { type: "logged-in", handle },
         { format, tokenLast4: maskToken(stored.token) },
       );
       Deno.exit(0);

--- a/deno/cli/commands/logout.ts
+++ b/deno/cli/commands/logout.ts
@@ -1,7 +1,7 @@
 /**
  * `skmtc logout` — delete the stored hub credential.
  *
- * Idempotent: exits 0 (and emits `{ "kind": "logged-out" }` under
+ * Idempotent: exits 0 (and emits `{ "type": "logged-out" }` under
  * `--json`) whether or not a token was stored. Touches only
  * `~/.skmtc/auth.json`; `--token` flags and `$SKMTC_HUB_TOKEN` are
  * the caller's to manage.
@@ -18,7 +18,7 @@ export const renderLogout = ({ jsonFlag }: RenderLogoutArgs): void => {
   const removed = deleteStoredAuth()
 
   if (resolveOutputFormat({ jsonFlag }) === 'json') {
-    console.log(JSON.stringify({ kind: 'logged-out', removed }, null, 2))
+    console.log(JSON.stringify({ type: 'logged-out', removed }, null, 2))
   } else {
     console.log(removed ? 'Logged out — stored token deleted.' : 'Logged out — no stored token.')
   }

--- a/deno/cli/commands/project.ts
+++ b/deno/cli/commands/project.ts
@@ -114,7 +114,7 @@ export const renderProjectCreate = async ({
   });
 
   printCreateResult(result, { format: resolveOutputFormat({ jsonFlag }) });
-  Deno.exit(result.kind === "failed" ? 1 : 0);
+  Deno.exit(result.type === "failed" ? 1 : 0);
 };
 
 export const printCreateResult = (
@@ -125,7 +125,7 @@ export const printCreateResult = (
     console.log(JSON.stringify(result, null, 2));
     return;
   }
-  switch (result.kind) {
+  switch (result.type) {
     case "created": {
       console.log(`Created ${result.project.account}/${result.project.slug}`);
       console.log(`  origin: ${result.origin}`);
@@ -225,7 +225,7 @@ export const renderProjectRm = async ({
   });
 
   printRmResult(result, { format: resolveOutputFormat({ jsonFlag }) });
-  Deno.exit(result.kind === "failed" ? 1 : 0);
+  Deno.exit(result.type === "failed" ? 1 : 0);
 };
 
 export const printRmResult = (
@@ -236,7 +236,7 @@ export const printRmResult = (
     console.log(JSON.stringify(result, null, 2));
     return;
   }
-  switch (result.kind) {
+  switch (result.type) {
     case "removed": {
       console.log(
         result.existed

--- a/deno/cli/commands/publish.test.ts
+++ b/deno/cli/commands/publish.test.ts
@@ -6,7 +6,7 @@ import { getCommandDescriptor } from '@/lib/cli-schema.ts'
 import { captureStdout } from '@/tests/strict-mode-helpers.test.ts'
 
 const publishedResult: PublishHeadlessResult = {
-  kind: 'published',
+  type: 'published',
   projectName: 'my-api',
   bundlePath: '/root/.skmtc/my-api/server.js',
   bundleBytes: 57344,
@@ -48,7 +48,7 @@ Deno.test('printPublishResult - failed result reports the stage and reason', asy
   try {
     printPublishResult(
       {
-        kind: 'failed',
+        type: 'failed',
         projectName: 'my-api',
         reason: 'version 3.0.1 is already published for acme/my-api',
         stage: 'publish'

--- a/deno/cli/commands/publish.tsx
+++ b/deno/cli/commands/publish.tsx
@@ -84,7 +84,7 @@ export const renderPublish = async ({
       version,
     });
     printPublishResult(result, { format: resolveOutputFormat({ jsonFlag }) });
-    Deno.exit(result.kind === "published" ? 0 : 1);
+    Deno.exit(result.type === "published" ? 0 : 1);
   }
 
   const skmtcRoot = providedSkmtcRoot ?? (await SkmtcRoot.open(new Manager()));
@@ -123,7 +123,7 @@ export const printPublishResult = (
       return;
     }
     case "text": {
-      switch (result.kind) {
+      switch (result.type) {
         case "published": {
           console.log(
             `Published "${result.projectName}" → ${result.stack.account}/${result.stack.slug}@${result.version}`,

--- a/deno/cli/commands/pull.ts
+++ b/deno/cli/commands/pull.ts
@@ -98,7 +98,7 @@ export const renderPull = async ({
   });
 
   printPullResult(result, { format: resolveOutputFormat({ jsonFlag }) });
-  Deno.exit(result.kind === "failed" ? 1 : 0);
+  Deno.exit(result.type === "failed" ? 1 : 0);
 };
 
 type PrintPullResultOptions = {
@@ -115,7 +115,7 @@ export const printPullResult = (
       return;
     }
     case "text": {
-      switch (result.kind) {
+      switch (result.type) {
         case "pulled": {
           if (!result.changed) {
             console.log(

--- a/deno/cli/commands/push.ts
+++ b/deno/cli/commands/push.ts
@@ -140,7 +140,7 @@ export const renderPush = async ({
   })
 
   printPushResult(result, { format: resolveOutputFormat({ jsonFlag }) })
-  Deno.exit(result.kind === 'failed' ? 1 : 0)
+  Deno.exit(result.type === 'failed' ? 1 : 0)
 }
 
 type PrintPushResultOptions = {
@@ -157,7 +157,7 @@ export const printPushResult = (
       return
     }
     case 'text': {
-      switch (result.kind) {
+      switch (result.type) {
         case 'pushed': {
           console.log(
             `Pushed "${result.projectName}" → ${result.project.account}/${result.project.slug}`

--- a/deno/cli/components/PublishView.tsx
+++ b/deno/cli/components/PublishView.tsx
@@ -17,10 +17,10 @@ type PublishViewProps = {
 };
 
 type Stage =
-  | { kind: "validating" }
-  | { kind: "running" }
-  | { kind: "done"; result: PublishHeadlessResult }
-  | { kind: "misconfigured"; missing: string[] };
+  | { type: "validating" }
+  | { type: "running" }
+  | { type: "done"; result: PublishHeadlessResult }
+  | { type: "misconfigured"; missing: string[] };
 
 /**
  * Interactive Ink path for `skmtc publish`. Strict / `--json` /
@@ -36,7 +36,7 @@ type Stage =
  */
 export const PublishView = ({ project, view }: PublishViewProps) => {
   const { state, dispatch, dispatchMessage, exit } = useSkmtc();
-  const [stage, setStage] = useState<Stage>({ kind: "validating" });
+  const [stage, setStage] = useState<Stage>({ type: "validating" });
 
   useEffect(() => {
     const { token, origin } = resolveHubAuth({
@@ -46,7 +46,7 @@ export const PublishView = ({ project, view }: PublishViewProps) => {
 
     if (!token) {
       setStage({
-        kind: "misconfigured",
+        type: "misconfigured",
         missing: ["--token <pat> (or $SKMTC_HUB_TOKEN, or `skmtc login`)"],
       });
       dispatchMessage({ error: "Publish is missing required arguments" });
@@ -54,7 +54,7 @@ export const PublishView = ({ project, view }: PublishViewProps) => {
       return;
     }
 
-    setStage({ kind: "running" });
+    setStage({ type: "running" });
     const run = async () => {
       const result = await publishHeadless({
         skmtcRoot: state.skmtcRoot,
@@ -64,9 +64,9 @@ export const PublishView = ({ project, view }: PublishViewProps) => {
         version: view.version,
       });
 
-      setStage({ kind: "done", result });
+      setStage({ type: "done", result });
 
-      if (result.kind === "published") {
+      if (result.type === "published") {
         dispatchMessage({
           success:
             `Published ${result.stack.account}/${result.stack.slug}@${result.version}`,
@@ -90,7 +90,7 @@ export const PublishView = ({ project, view }: PublishViewProps) => {
     run();
   }, []);
 
-  switch (stage.kind) {
+  switch (stage.type) {
     case "validating":
       return (
         <TaskBox active>
@@ -115,7 +115,7 @@ export const PublishView = ({ project, view }: PublishViewProps) => {
       );
     case "done": {
       const result = stage.result;
-      if (result.kind === "published") {
+      if (result.type === "published") {
         return (
           <Box flexDirection="column">
             <Text color="green">

--- a/deno/cli/lib/bundle-freshness.test.ts
+++ b/deno/cli/lib/bundle-freshness.test.ts
@@ -68,12 +68,12 @@ Deno.test('checkBundleFreshness - remote-only projects are checked like any othe
     })
 
     const beforeBundle = checkBundleFreshness({ projectName })
-    assertEquals(beforeBundle.kind, 'missing-worker')
+    assertEquals(beforeBundle.type, 'missing-worker')
 
     writeWorker(['@skmtc/gen-typescript', '@skmtc/gen-zod'])
 
     const afterBundle = checkBundleFreshness({ projectName })
-    assertEquals(afterBundle.kind, 'fresh')
+    assertEquals(afterBundle.type, 'fresh')
   })
 })
 
@@ -86,7 +86,7 @@ Deno.test('checkBundleFreshness - returns fresh when deno.json and worker.ts agr
     writeWorker(['@skmtc/gen-typescript', '@skmtc/gen-zod'])
 
     const result = checkBundleFreshness({ projectName })
-    assertEquals(result.kind, 'fresh')
+    assertEquals(result.type, 'fresh')
   })
 })
 
@@ -98,7 +98,7 @@ Deno.test('checkBundleFreshness - returns missing-worker when worker.ts absent',
     // No writeWorker call — confirms the missing-worker outcome.
 
     const result = checkBundleFreshness({ projectName })
-    assertEquals(result.kind, 'missing-worker')
+    assertEquals(result.type, 'missing-worker')
   })
 })
 
@@ -112,8 +112,8 @@ Deno.test('checkBundleFreshness - returns stale when deno.json adds a generator'
     writeWorker(['@skmtc/gen-typescript'])
 
     const result = checkBundleFreshness({ projectName })
-    assertEquals(result.kind, 'stale')
-    if (result.kind === 'stale') {
+    assertEquals(result.type, 'stale')
+    if (result.type === 'stale') {
       assertEquals(result.added, ['@skmtc/gen-shadcn-form'])
       assertEquals(result.removed, [])
     }
@@ -129,8 +129,8 @@ Deno.test('checkBundleFreshness - returns stale when deno.json removes a generat
     writeWorker(['@skmtc/gen-typescript', '@skmtc/gen-old'])
 
     const result = checkBundleFreshness({ projectName })
-    assertEquals(result.kind, 'stale')
-    if (result.kind === 'stale') {
+    assertEquals(result.type, 'stale')
+    if (result.type === 'stale') {
       assertEquals(result.added, [])
       assertEquals(result.removed, ['@skmtc/gen-old'])
     }
@@ -152,7 +152,7 @@ Deno.test(
       writeWorker(['@skmtc/gen-typescript'])
 
       const result = checkBundleFreshness({ projectName })
-      assertEquals(result.kind, 'fresh')
+      assertEquals(result.type, 'fresh')
     })
   }
 )

--- a/deno/cli/lib/bundle-freshness.ts
+++ b/deno/cli/lib/bundle-freshness.ts
@@ -24,17 +24,17 @@ import { parseModuleName } from '@skmtc/core/parseModuleName'
 
 export type BundleFreshness =
   | {
-      kind: 'fresh'
+      type: 'fresh'
       message: string
     }
   | {
-      kind: 'missing-worker'
+      type: 'missing-worker'
       /** Path the worker was expected at. */
       workerPath: string
       message: string
     }
   | {
-      kind: 'stale'
+      type: 'stale'
       /** Generator IDs declared in `deno.json#imports` today. */
       currentIds: string[]
       /** Generator IDs the on-disk `worker.ts` was built against. */
@@ -108,7 +108,7 @@ export const checkBundleFreshness = ({
   const workerPath = join(projectPath, 'worker.ts')
   if (!existsSync(workerPath)) {
     return {
-      kind: 'missing-worker',
+      type: 'missing-worker',
       workerPath,
       message:
         `Expected ${workerPath} to exist but it does not. Run \`skmtc bundle ${projectName}\` to build it.`
@@ -125,7 +125,7 @@ export const checkBundleFreshness = ({
 
   if (added.length === 0 && removed.length === 0) {
     return {
-      kind: 'fresh',
+      type: 'fresh',
       message: `bundle.js matches deno.json (${currentIds.length} generator(s)).`
     }
   }
@@ -135,7 +135,7 @@ export const checkBundleFreshness = ({
   const removedHint =
     removed.length > 0 ? `remove: ${removed.join(', ')}` : ''
   return {
-    kind: 'stale',
+    type: 'stale',
     currentIds,
     bundleIds,
     added,

--- a/deno/cli/lib/bundle-headless.ts
+++ b/deno/cli/lib/bundle-headless.ts
@@ -25,7 +25,7 @@ type BundleHeadlessArgs = {
 }
 
 export type BundleHeadlessResult = {
-  kind: 'bundled'
+  type: 'bundled'
   projectName: string
   bundlePath: string
 }
@@ -54,7 +54,7 @@ export const bundleHeadless = async ({
   }
 
   return {
-    kind: 'bundled',
+    type: 'bundled',
     projectName,
     bundlePath
   }

--- a/deno/cli/lib/clone-headless.ts
+++ b/deno/cli/lib/clone-headless.ts
@@ -46,7 +46,7 @@ export type CloneHeadlessResult = {
   /**
    * Result of the post-clone rebundle. Clone always introduces at
    * least one local generator (the cloned one), so this is always
-   * `kind: 'bundled'` — but we keep the discriminated union for
+   * `type: 'bundled'` — but we keep the discriminated union for
    * symmetry with {@link installHeadless} (which can be `noop` for
    * remote-only projects).
    *

--- a/deno/cli/lib/describe-worker.test.ts
+++ b/deno/cli/lib/describe-worker.test.ts
@@ -48,7 +48,7 @@ const createMockDescribeResult = () => ({
   descriptors: [
     {
       generator: '@scope/gen-x',
-      subjectKind: 'model' as const,
+      subjectType: 'model' as const,
       supportsVariant: false,
       fields: []
     }

--- a/deno/cli/lib/init-headless.ts
+++ b/deno/cli/lib/init-headless.ts
@@ -26,8 +26,8 @@ type InitHeadlessArgs = {
 }
 
 export type InitHeadlessResult =
-  | { kind: 'created'; projectName: string; basePath: string }
-  | { kind: 'existed'; projectName: string }
+  | { type: 'created'; projectName: string; basePath: string }
+  | { type: 'existed'; projectName: string }
 
 export class InvalidBasePathError extends Error {
   constructor(public readonly basePath: string, message: string) {
@@ -66,7 +66,7 @@ export const initHeadless = async ({
 
   const existing = skmtcRoot.projects.find(p => p.name === projectName)
   if (existing) {
-    return { kind: 'existed', projectName }
+    return { type: 'existed', projectName }
   }
 
   await skmtcRoot.createProject({
@@ -76,5 +76,5 @@ export const initHeadless = async ({
     availableGenerators: []
   })
 
-  return { kind: 'created', projectName, basePath }
+  return { type: 'created', projectName, basePath }
 }

--- a/deno/cli/lib/install-headless.test.ts
+++ b/deno/cli/lib/install-headless.test.ts
@@ -9,7 +9,7 @@ import type { BundleHeadlessResult } from '@/lib/bundle-headless.ts'
  */
 const stubBundleFn = ({ projectName }: { projectName: string }): Promise<BundleHeadlessResult> =>
   Promise.resolve({
-    kind: 'bundled',
+    type: 'bundled',
     projectName,
     bundlePath: `.skmtc/${projectName}/bundle.js`
   })

--- a/deno/cli/lib/install-headless.ts
+++ b/deno/cli/lib/install-headless.ts
@@ -23,7 +23,7 @@ export type InstallHeadlessResult = {
   projectName: string
   installed: string[]
   /**
-   * Result of the post-install rebundle. Always `kind: 'bundled'` —
+   * Result of the post-install rebundle. Always `type: 'bundled'` —
    * every project (remote-only included) generates from its local
    * `bundle.js`, so install rebuilds it to pick up the newly
    * installed generator.

--- a/deno/cli/lib/migrate-variants-headless.ts
+++ b/deno/cli/lib/migrate-variants-headless.ts
@@ -62,7 +62,7 @@ const wrapOperationEnrichments = (
     for (const [routingKey, byInner] of Object.entries(byPath as Record<string, unknown>)) {
       // Routing key shape decides whether this is an operation-keyed
       // entry. OAS uses a path starting with `/`; GraphQL uses a
-      // root-kind name (`query` / `mutation` / `subscription`).
+      // root-type name (`query` / `mutation` / `subscription`).
       const isOasPath = routingKey.startsWith('/')
       const isGqlRoot = GQL_ROOT_KINDS.has(routingKey)
       if (!isOasPath && !isGqlRoot) continue

--- a/deno/cli/lib/model-generator.ts
+++ b/deno/cli/lib/model-generator.ts
@@ -53,7 +53,7 @@ export const ${mainModule}Base = toTsModelProjectionBase({
   },
 
   toIdentifierType(): TsIdentifierType {
-    return { kind: 'variable' }
+    return { type: 'variable' }
   },
 
   toExportPath({ refName, enrichments, variant }): string {

--- a/deno/cli/lib/operation-generator.ts
+++ b/deno/cli/lib/operation-generator.ts
@@ -58,7 +58,7 @@ export const ${mainModule}Base = toTsOasOperationProjectionBase({
   },
 
   toIdentifierType(): TsIdentifierType {
-    return { kind: 'variable' }
+    return { type: 'variable' }
   },
 
   toExportPath({ operation, enrichments, variant }): string {

--- a/deno/cli/lib/print-generate-result.test.ts
+++ b/deno/cli/lib/print-generate-result.test.ts
@@ -63,7 +63,7 @@ Deno.test('printGenerateResult - json format includes file list and manifest pat
   })
   assertEquals(logs.length, 1)
   const parsed = JSON.parse(logs[0])
-  assertEquals(parsed.kind, 'generated')
+  assertEquals(parsed.type, 'generated')
   assertEquals(parsed.projectName, 'my-api')
   assertEquals(parsed.basePath, './src')
   assertEquals(parsed.manifestPath, '.skmtc/my-api/.settings/manifest.json')

--- a/deno/cli/lib/print-generate-result.ts
+++ b/deno/cli/lib/print-generate-result.ts
@@ -40,7 +40,7 @@ export const printGenerateResult = ({
   switch (format) {
     case 'json': {
       const payload = {
-        kind: 'generated' as const,
+        type: 'generated' as const,
         projectName,
         basePath: basePath ?? null,
         manifestPath,
@@ -95,7 +95,7 @@ export const printGenerateResult = ({
 }
 
 const printTypecheckText = (typecheck: TypecheckResult): void => {
-  switch (typecheck.kind) {
+  switch (typecheck.type) {
     case 'skipped':
       // Skipped is verbose-only — keep the default output quiet.
       return
@@ -122,7 +122,7 @@ const printTypecheckText = (typecheck: TypecheckResult): void => {
       return
     default: {
       const _exhaustive: never = typecheck
-      throw new Error(`Unhandled typecheck kind: ${JSON.stringify(_exhaustive)}`)
+      throw new Error(`Unhandled typecheck type: ${JSON.stringify(_exhaustive)}`)
     }
   }
 }

--- a/deno/cli/lib/project-headless.ts
+++ b/deno/cli/lib/project-headless.ts
@@ -70,7 +70,7 @@ type CreateArgs = {
 
 export type CreateResult =
   | {
-    kind: "created";
+    type: "created";
     projectName: string;
     project: Scoped;
     origin: string;
@@ -85,7 +85,7 @@ export type CreateResult =
     url?: string;
   }
   | {
-    kind: "failed";
+    type: "failed";
     projectName: string;
     reason: string;
     stage: "read" | "stack" | "api" | "create" | "seed";
@@ -95,7 +95,7 @@ const fail = (
   projectName: string,
   reason: string,
   stage: "read" | "stack" | "api" | "create" | "seed",
-): CreateResult => ({ kind: "failed", projectName, reason, stage });
+): CreateResult => ({ type: "failed", projectName, reason, stage });
 
 /** Register `client.json#source` as a hub API; returns its `@account/slug`. */
 async function registerSchema(
@@ -416,7 +416,7 @@ export const createHeadless = async ({
   }
 
   return {
-    kind: "created",
+    type: "created",
     projectName,
     project: dest,
     origin,
@@ -440,14 +440,14 @@ type RmArgs = {
 
 export type RmResult =
   | {
-    kind: "removed";
+    type: "removed";
     projectName: string;
     project: Scoped;
     origin: string;
     existed: boolean;
   }
   | {
-    kind: "failed";
+    type: "failed";
     projectName: string;
     reason: string;
     stage: "read" | "delete";
@@ -473,7 +473,7 @@ export const rmHeadless = async ({
   );
   if (!dest || !dest.account) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: `invalid project name "${name}" — expected @account/slug`,
       stage: "read",
@@ -489,7 +489,7 @@ export const rmHeadless = async ({
     );
     if (res.status === 404) {
       return {
-        kind: "removed",
+        type: "removed",
         projectName,
         project: dest,
         origin,
@@ -502,7 +502,7 @@ export const rmHeadless = async ({
         ? ` — deleting needs the 'admin:resource' scope (your token lacks it)`
         : "";
       return {
-        kind: "failed",
+        type: "failed",
         projectName,
         reason: `delete failed (${res.status})${hint}: ${text.slice(0, 300)}`,
         stage: "delete",
@@ -510,7 +510,7 @@ export const rmHeadless = async ({
     }
     await res.text();
     return {
-      kind: "removed",
+      type: "removed",
       projectName,
       project: dest,
       origin,
@@ -518,7 +518,7 @@ export const rmHeadless = async ({
     };
   } catch (err) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: err instanceof Error ? err.message : String(err),
       stage: "delete",

--- a/deno/cli/lib/publish-headless.test.ts
+++ b/deno/cli/lib/publish-headless.test.ts
@@ -223,8 +223,8 @@ Deno.test("publishHeadless - missing version fails before any network call", asy
       token: "pat-123",
     });
 
-    assertEquals(result.kind, "failed");
-    if (result.kind !== "failed") throw new Error("expected a failed result");
+    assertEquals(result.type, "failed");
+    if (result.type !== "failed") throw new Error("expected a failed result");
     assertEquals(result.stage, "version");
     assertStringIncludes(
       result.reason,

--- a/deno/cli/lib/publish-headless.ts
+++ b/deno/cli/lib/publish-headless.ts
@@ -49,7 +49,7 @@ type PublishHeadlessArgs = {
 
 export type PublishHeadlessResult =
   | {
-    kind: "published";
+    type: "published";
     projectName: string;
     bundlePath: string;
     bundleBytes: number;
@@ -63,7 +63,7 @@ export type PublishHeadlessResult =
     sourceTotalBytes: number;
   }
   | {
-    kind: "failed";
+    type: "failed";
     projectName: string;
     reason: string;
     stage: "version" | "identity" | "bundle" | "publish";
@@ -306,7 +306,7 @@ export const publishHeadless = async ({
     });
   } catch (err) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: err instanceof Error ? err.message : String(err),
       stage: "version",
@@ -323,7 +323,7 @@ export const publishHeadless = async ({
     slug = stack.slug;
   } catch (err) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: err instanceof Error ? err.message : String(err),
       stage: "identity",
@@ -340,7 +340,7 @@ export const publishHeadless = async ({
     files = await collectSourceFiles(project.toPath());
   } catch (err) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: err instanceof Error ? err.message : String(err),
       stage: "bundle",
@@ -360,7 +360,7 @@ export const publishHeadless = async ({
     });
   } catch (err) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: err instanceof Error ? err.message : String(err),
       stage: "publish",
@@ -368,7 +368,7 @@ export const publishHeadless = async ({
   }
 
   return {
-    kind: "published",
+    type: "published",
     projectName,
     bundlePath,
     bundleBytes: published.bundleBytes,

--- a/deno/cli/lib/pull-headless.ts
+++ b/deno/cli/lib/pull-headless.ts
@@ -50,7 +50,7 @@ type PullHeadlessArgs = {
 
 export type PullHeadlessResult =
   | {
-    kind: "pulled";
+    type: "pulled";
     projectName: string;
     project: { account: string; slug: string };
     origin: string;
@@ -64,12 +64,12 @@ export type PullHeadlessResult =
     remoteWritten: boolean;
   }
   | {
-    kind: "aborted";
+    type: "aborted";
     projectName: string;
     project: { account: string; slug: string };
   }
   | {
-    kind: "failed";
+    type: "failed";
     projectName: string;
     reason: string;
     stage: "read" | "destination" | "pull";
@@ -126,7 +126,7 @@ export const pullHeadless = async ({
   const contents = project.clientJson.contents;
   if (!contents) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason:
         `no client.json for "${projectName}" (.skmtc/${projectName}/.settings/client.json)`,
@@ -137,7 +137,7 @@ export const pullHeadless = async ({
   const destSpec = projectFlag?.trim() || contents.project?.trim();
   if (!destSpec) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason:
         'no hub destination — set `project: "@account/slug"` in client.json or pass --project @account/slug',
@@ -147,7 +147,7 @@ export const pullHeadless = async ({
   const dest = parseScopedName(destSpec);
   if (!dest) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: `invalid hub destination "${destSpec}" — expected @account/slug`,
       stage: "destination",
@@ -165,7 +165,7 @@ export const pullHeadless = async ({
     );
     if (getResponse.status === 404) {
       return {
-        kind: "failed",
+        type: "failed",
         projectName,
         reason:
           `project ${account}/${slug} not found at ${origin} — create it in the web app first ` +
@@ -179,7 +179,7 @@ export const pullHeadless = async ({
         ? ` — not authorized to read ${account}/${slug}`
         : "";
       return {
-        kind: "failed",
+        type: "failed",
         projectName,
         reason: `client-config pull failed (${getResponse.status})${hint}: ${
           text.slice(0, 500)
@@ -190,7 +190,7 @@ export const pullHeadless = async ({
     hubBody = await getResponse.json();
   } catch (err) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: err instanceof Error ? err.message : String(err),
       stage: "pull",
@@ -199,7 +199,7 @@ export const pullHeadless = async ({
 
   if (!isObject(hubBody) || !isObject(hubBody.settings)) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: `unexpected response from ${origin} — missing settings object`,
       stage: "pull",
@@ -230,7 +230,7 @@ export const pullHeadless = async ({
     );
   } catch (err) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: `pulled config failed validation: ${
         err instanceof Error ? err.message : String(err)
@@ -244,7 +244,7 @@ export const pullHeadless = async ({
 
   if (!changed) {
     return {
-      kind: "pulled",
+      type: "pulled",
       projectName,
       project: { account, slug },
       origin,
@@ -258,7 +258,7 @@ export const pullHeadless = async ({
   if (confirmOverwrite) {
     const proceed = await confirmOverwrite({ account, slug, enrichmentGenerators });
     if (!proceed) {
-      return { kind: "aborted", projectName, project: { account, slug } };
+      return { type: "aborted", projectName, project: { account, slug } };
     }
   }
 
@@ -269,7 +269,7 @@ export const pullHeadless = async ({
     contents.project?.trim() !== destSpec;
 
   return {
-    kind: "pulled",
+    type: "pulled",
     projectName,
     project: { account, slug },
     origin,

--- a/deno/cli/lib/push-headless.test.ts
+++ b/deno/cli/lib/push-headless.test.ts
@@ -97,8 +97,8 @@ Deno.test("pushHeadless - fails before any network call when there is no destina
       token: "pat",
       origin: "https://hub.test",
     });
-    assertEquals(result.kind, "failed");
-    if (result.kind !== "failed") throw new Error("expected failed");
+    assertEquals(result.type, "failed");
+    if (result.type !== "failed") throw new Error("expected failed");
     assertEquals(result.stage, "destination");
     assertEquals(fetchCalls, 0);
   } finally {
@@ -148,8 +148,8 @@ Deno.test("pushHeadless - PUTs the client.json settings to the resolved destinat
       origin: "https://hub.test",
     });
 
-    assertEquals(result.kind, "pushed");
-    if (result.kind !== "pushed") throw new Error("expected pushed");
+    assertEquals(result.type, "pushed");
+    if (result.type !== "pushed") throw new Error("expected pushed");
     assertEquals(result.project, { account: "acme", slug: "petstore" });
     assertEquals(result.enrichmentCount, 1);
     assertEquals(result.overwroteExistingConfig, false);
@@ -184,8 +184,8 @@ Deno.test('pushHeadless - a 404 on the destination is a clear "create it first" 
       token: "pat",
       origin: "https://hub.test",
     });
-    assertEquals(result.kind, "failed");
-    if (result.kind !== "failed") throw new Error("expected failed");
+    assertEquals(result.type, "failed");
+    if (result.type !== "failed") throw new Error("expected failed");
     assertEquals(result.stage, "push");
     assertStringIncludes(result.reason, "create it in the web app first");
   } finally {
@@ -227,7 +227,7 @@ Deno.test("pushHeadless - aborts when the overwrite confirm declines", async () 
       origin: "https://hub.test",
       confirmOverwrite: () => Promise.resolve(false),
     });
-    assertEquals(result.kind, "aborted");
+    assertEquals(result.type, "aborted");
     assertEquals(putCalled, false);
   } finally {
     globalThis.fetch = originalFetch;
@@ -248,8 +248,8 @@ Deno.test("pushHeadless - an explicit --project is written back into client.json
       origin: "https://hub.test",
       projectFlag: "@org/x",
     });
-    assertEquals(result.kind, "pushed");
-    if (result.kind !== "pushed") throw new Error("expected pushed");
+    assertEquals(result.type, "pushed");
+    if (result.type !== "pushed") throw new Error("expected pushed");
     assertEquals(result.project, { account: "org", slug: "x" });
     assertEquals(result.remoteWritten, true);
     assertEquals(wrote(), true);
@@ -299,8 +299,8 @@ Deno.test("pushHeadless - --base-files-only pushes base files without the client
       baseFilesOnly: true,
     });
 
-    assertEquals(result.kind, "pushed");
-    if (result.kind !== "pushed") throw new Error("expected pushed");
+    assertEquals(result.type, "pushed");
+    if (result.type !== "pushed") throw new Error("expected pushed");
     assertEquals(result.baseFilesPushed, 2);
     // Config was left untouched.
     assertEquals(result.overwroteExistingConfig, false);
@@ -357,8 +357,8 @@ Deno.test("pushHeadless - --base-files also PUTs to /preview/base-files", async 
       origin: "https://hub.test",
       baseFiles: { "package.json": "{}", "src/app.tsx": "x" },
     });
-    assertEquals(result.kind, "pushed");
-    if (result.kind !== "pushed") throw new Error("expected pushed");
+    assertEquals(result.type, "pushed");
+    if (result.type !== "pushed") throw new Error("expected pushed");
     assertEquals(result.baseFilesPushed, 2);
     assertEquals(
       calls.some((c) =>

--- a/deno/cli/lib/push-headless.ts
+++ b/deno/cli/lib/push-headless.ts
@@ -62,7 +62,7 @@ type PushHeadlessArgs = {
 
 export type PushHeadlessResult =
   | {
-    kind: "pushed";
+    type: "pushed";
     projectName: string;
     project: { account: string; slug: string };
     origin: string;
@@ -76,12 +76,12 @@ export type PushHeadlessResult =
     baseFilesPushed?: number;
   }
   | {
-    kind: "aborted";
+    type: "aborted";
     projectName: string;
     project: { account: string; slug: string };
   }
   | {
-    kind: "failed";
+    type: "failed";
     projectName: string;
     reason: string;
     stage: "read" | "destination" | "push";
@@ -119,7 +119,7 @@ export const pushHeadless = async ({
   const contents = project.clientJson.contents;
   if (!contents) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason:
         `no client.json for "${projectName}" (.skmtc/${projectName}/.settings/client.json)`,
@@ -130,7 +130,7 @@ export const pushHeadless = async ({
   const destSpec = projectFlag?.trim() || contents.project?.trim();
   if (!destSpec) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason:
         'no hub destination — set `project: "@account/slug"` in client.json or pass --project @account/slug',
@@ -140,7 +140,7 @@ export const pushHeadless = async ({
   const dest = parseScopedName(destSpec);
   if (!dest) {
     return {
-      kind: "failed",
+      type: "failed",
       projectName,
       reason: `invalid hub destination "${destSpec}" — expected @account/slug`,
       stage: "destination",
@@ -162,7 +162,7 @@ export const pushHeadless = async ({
     );
     if (getResponse.status === 404) {
       return {
-        kind: "failed",
+        type: "failed",
         projectName,
         reason:
           `project ${account}/${slug} not found at ${origin} — create it in the web app first ` +
@@ -186,7 +186,7 @@ export const pushHeadless = async ({
       enrichmentCount: toEnrichmentCount(existing),
     });
     if (!proceed) {
-      return { kind: "aborted", projectName, project: { account, slug } };
+      return { type: "aborted", projectName, project: { account, slug } };
     }
   }
 
@@ -227,7 +227,7 @@ export const pushHeadless = async ({
           ? ` — project ${account}/${slug} not found`
           : "";
         return {
-          kind: "failed",
+          type: "failed",
           projectName,
           reason: `client-config push failed (${putResponse.status})${hint}: ${
             text.slice(0, 500)
@@ -238,7 +238,7 @@ export const pushHeadless = async ({
       pushedConfig = await putResponse.json();
     } catch (err) {
       return {
-        kind: "failed",
+        type: "failed",
         projectName,
         reason: err instanceof Error ? err.message : String(err),
         stage: "push",
@@ -270,7 +270,7 @@ export const pushHeadless = async ({
       if (!filesResponse.ok) {
         const text = await filesResponse.text();
         return {
-          kind: "failed",
+          type: "failed",
           projectName,
           reason:
             `base-files push failed (${filesResponse.status})${configNote}: ${
@@ -286,7 +286,7 @@ export const pushHeadless = async ({
         ? ""
         : " — client-config was already updated";
       return {
-        kind: "failed",
+        type: "failed",
         projectName,
         reason: `base-files push failed${configNote}: ${
           err instanceof Error ? err.message : String(err)
@@ -310,7 +310,7 @@ export const pushHeadless = async ({
   }
 
   return {
-    kind: "pushed",
+    type: "pushed",
     projectName,
     project: { account, slug },
     origin,

--- a/deno/cli/lib/typecheck.test.ts
+++ b/deno/cli/lib/typecheck.test.ts
@@ -27,8 +27,8 @@ Deno.test('runTypecheck - skips with reason no-files when filePaths empty', asyn
     basePathAbs: undefined
   })
 
-  assertEquals(result.kind, 'skipped')
-  if (result.kind === 'skipped') {
+  assertEquals(result.type, 'skipped')
+  if (result.type === 'skipped') {
     assertEquals(result.reason, 'no-files')
   }
 })
@@ -48,7 +48,7 @@ Deno.test(
         basePathAbs: subdir
       })
 
-      assertEquals(result.kind, 'no-tsconfig')
+      assertEquals(result.type, 'no-tsconfig')
     })
   }
 )
@@ -82,7 +82,7 @@ Deno.test(
         basePathAbs: join(tempRoot, 'src')
       })
 
-      assertEquals(result.kind, 'passed')
+      assertEquals(result.type, 'passed')
     })
   }
 )
@@ -125,8 +125,8 @@ Deno.test(
         basePathAbs: join(tempRoot, 'src')
       })
 
-      assertEquals(result.kind, 'failed')
-      if (result.kind === 'failed') {
+      assertEquals(result.type, 'failed')
+      if (result.type === 'failed') {
         // Every diagnostic should be in mine.ts; theirs.ts is filtered out.
         for (const d of result.diagnostics) {
           assertEquals(d.file.endsWith('mine.ts'), true)
@@ -152,7 +152,7 @@ Deno.test(
  *     looking for"`), which exits non-zero and prints its message to
  *     stdout — no "Version" line.
  *
- * The probe must run from the same kind of bare directory the test
+ * The probe must run from the same type of bare directory the test
  * uses. We create a throwaway temp dir under `homedir()` and probe
  * `npx tsc --version` from there.
  */

--- a/deno/cli/lib/typecheck.ts
+++ b/deno/cli/lib/typecheck.ts
@@ -21,28 +21,28 @@ import { existsSync } from '@std/fs/exists'
 
 export type TypecheckResult =
   | {
-      kind: 'skipped'
+      type: 'skipped'
       reason: 'flag-not-set' | 'no-files'
       message: string
     }
   | {
-      kind: 'no-tsconfig'
+      type: 'no-tsconfig'
       message: string
       hint: string
     }
   | {
-      kind: 'passed'
+      type: 'passed'
       tsconfig: string
       filesChecked: number
     }
   | {
-      kind: 'failed'
+      type: 'failed'
       tsconfig: string
       filesChecked: number
       diagnostics: TypecheckDiagnostic[]
     }
   | {
-      kind: 'tsc-error'
+      type: 'tsc-error'
       message: string
       hint: string
     }
@@ -144,7 +144,7 @@ export const runTypecheck = async ({
 }: RunTypecheckArgs): Promise<TypecheckResult> => {
   if (filePaths.length === 0) {
     return {
-      kind: 'skipped',
+      type: 'skipped',
       reason: 'no-files',
       message: 'No files emitted; skipping type-check.'
     }
@@ -158,7 +158,7 @@ export const runTypecheck = async ({
     : findTsconfig(searchStart)
   if (tsconfig === null) {
     return {
-      kind: 'no-tsconfig',
+      type: 'no-tsconfig',
       message: `No tsconfig.json found walking up from ${searchStart}.`,
       hint:
         'Either run `skmtc generate` from inside the consumer app, ' +
@@ -181,7 +181,7 @@ export const runTypecheck = async ({
     output = await cmd.output()
   } catch (error) {
     return {
-      kind: 'tsc-error',
+      type: 'tsc-error',
       message: `Failed to run \`${tscCmd}\`: ${error instanceof Error ? error.message : String(error)}`,
       hint:
         'Make sure `tsc` is installed in the consumer project (or globally) ' +
@@ -214,13 +214,13 @@ export const runTypecheck = async ({
 
   if (ownDiagnostics.length === 0) {
     return {
-      kind: 'passed',
+      type: 'passed',
       tsconfig,
       filesChecked: filePaths.length
     }
   }
   return {
-    kind: 'failed',
+    type: 'failed',
     tsconfig,
     filesChecked: filePaths.length,
     diagnostics: ownDiagnostics

--- a/deno/cli/tests/cli-graphql-smoke.test.ts
+++ b/deno/cli/tests/cli-graphql-smoke.test.ts
@@ -74,7 +74,7 @@ import { toTsModelProjectionBase } from '@skmtc/lang-typescript'
 const ModelBase = toTsModelProjectionBase({
   id: '@fake/gen-minimal',
   toIdentifierName: ({ refName }) => refName,
-  toIdentifierType: () => ({ kind: 'type' }),
+  toIdentifierType: () => ({ type: 'type' }),
   toExportPath: ({ refName }) => '@/types/' + refName + '.generated.ts'
 })
 

--- a/deno/cli/types/denoFile.generated.ts
+++ b/deno/cli/types/denoFile.generated.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod'
 
 export const denoFile = z.object({
-  kind: z.literal('file'),
+  type: z.literal('file'),
   content: z.string(),
   encoding: z.enum(['utf-8', 'base64']),
 })
 
 export type DenoFile = {
-  kind: 'file'
+  type: 'file'
   content: string
   encoding: 'utf-8' | 'base64'
 }

--- a/deno/core/anchors/buildSidecar.ts
+++ b/deno/core/anchors/buildSidecar.ts
@@ -84,7 +84,7 @@ export const buildSidecar = ({
   const internRegistry = (() => {
     const cache = new Map<string, number>()
     return (entry: RegistryEntry): number => {
-      const key = `${entry.kind}|${entry.host}`
+      const key = `${entry.type}|${entry.host}`
       const hit = cache.get(key)
       if (hit !== undefined) return hit
       const idx = sidecar.R.length

--- a/deno/core/anchors/generationMap.test.ts
+++ b/deno/core/anchors/generationMap.test.ts
@@ -7,7 +7,7 @@ const baseSidecar = (overrides: Partial<Sidecar> = {}): Sidecar => ({
   f: 'src/types/User.generated.ts',
   src: 'openapi.json',
   parser: 'tsc@5.6.3',
-  R: [{ host: 'jsr.io', kind: 'jsr' }],
+  R: [{ host: 'jsr.io', type: 'jsr' }],
   G: [{ name: '@skmtc/gen-typescript', version: '0.0.55', r: 0 }],
   S: ['oas:#/components/schemas/User'],
   V: ['main'],

--- a/deno/core/anchors/postPass.test.ts
+++ b/deno/core/anchors/postPass.test.ts
@@ -167,12 +167,12 @@ Deno.test('postPass - generatorMeta lookup populates generator entries', () => {
     parser: oxcAdapter,
     generatorMeta: generatorId => ({
       version: generatorId === '@scope/gen-zod' ? '1.2.3' : '',
-      registry: { host: 'jsr.skmtc.dev', kind: 'jsr-private' }
+      registry: { host: 'jsr.skmtc.dev', type: 'jsr-private' }
     })
   })
 
   assert(sidecar.G.some(g => g.name === '@scope/gen-zod' && g.version === '1.2.3'))
-  assert(sidecar.R.some(r => r.host === 'jsr.skmtc.dev' && r.kind === 'jsr-private'))
+  assert(sidecar.R.some(r => r.host === 'jsr.skmtc.dev' && r.type === 'jsr-private'))
 })
 
 Deno.test('postPass - anchor bytes survive a slice through the rendered source', () => {

--- a/deno/core/anchors/postPass.ts
+++ b/deno/core/anchors/postPass.ts
@@ -21,7 +21,7 @@ import { buildSidecar, type ResolvedAnchor } from './buildSidecar.ts'
  * Lookup contract for per-generator metadata. Phase D's CLI builds
  * this once from the project's lockfile + `deno.json` import map and
  * passes it in. Generators not in the map fall back to `version: ''`
- * + `registry: { host: 'jsr.io', kind: 'jsr' }` — the sidecar still
+ * + `registry: { host: 'jsr.io', type: 'jsr' }` — the sidecar still
  * builds, just with degraded provenance.
  */
 export type GeneratorMetaLookup = (generatorId: string) => {
@@ -31,7 +31,7 @@ export type GeneratorMetaLookup = (generatorId: string) => {
 
 const defaultLookup: GeneratorMetaLookup = () => ({
   version: '',
-  registry: { host: 'jsr.io', kind: 'jsr' }
+  registry: { host: 'jsr.io', type: 'jsr' }
 })
 
 export type PostPassArgs = {

--- a/deno/core/anchors/sidecar.test.ts
+++ b/deno/core/anchors/sidecar.test.ts
@@ -22,7 +22,7 @@ const anchor = (overrides: Partial<ResolvedAnchor> = {}): ResolvedAnchor => ({
   landmark: 'User',
   path: [0],
   generatorVersion: '0.0.55',
-  registry: { host: 'jsr.io', kind: 'jsr' },
+  registry: { host: 'jsr.io', type: 'jsr' },
   ...overrides
 })
 
@@ -83,12 +83,12 @@ Deno.test('buildSidecar - repeat string values reuse pool indices', () => {
 Deno.test('buildSidecar - distinct registries pool independently and gi references ri', () => {
   const a1 = anchor({
     landmark: 'A',
-    registry: { host: 'jsr.io', kind: 'jsr' },
+    registry: { host: 'jsr.io', type: 'jsr' },
     attribution: { generatorId: '@public/gen', schemaPointer: 'oas:#/components/schemas/A', variant: 'main', definitionName: 'A', producerName: 'GenA' }
   })
   const a2 = anchor({
     landmark: 'B',
-    registry: { host: 'jsr.skmtc.dev', kind: 'jsr-private' },
+    registry: { host: 'jsr.skmtc.dev', type: 'jsr-private' },
     attribution: { generatorId: '@private/gen', schemaPointer: 'oas:#/components/schemas/B', variant: 'main', definitionName: 'B', producerName: 'GenB' }
   })
 

--- a/deno/core/anchors/sidecar.ts
+++ b/deno/core/anchors/sidecar.ts
@@ -18,7 +18,7 @@ import * as v from 'valibot'
  */
 export const registryEntry = v.object({
   host: v.string(),
-  kind: v.union([v.literal('jsr'), v.literal('jsr-private')])
+  type: v.union([v.literal('jsr'), v.literal('jsr-private')])
 })
 
 /**

--- a/deno/core/anchors/writeSidecars.test.ts
+++ b/deno/core/anchors/writeSidecars.test.ts
@@ -10,7 +10,7 @@ const baseSidecar = (overrides: Partial<Sidecar> = {}): Sidecar => ({
   f: 'out.ts',
   src: 'openapi.json',
   parser: 'tsc@5.6.3',
-  R: [{ host: 'jsr.io', kind: 'jsr' }],
+  R: [{ host: 'jsr.io', type: 'jsr' }],
   G: [{ name: '@scope/gen', version: '0.0.1', r: 0 }],
   S: ['oas:#/components/schemas/X'],
   V: ['main'],

--- a/deno/core/context/CoreContext.test.ts
+++ b/deno/core/context/CoreContext.test.ts
@@ -312,7 +312,7 @@ Deno.test('CoreContext - toArtifacts() includes results tree', () => {
 Deno.test(
   'CoreContext - toArtifacts() synthesizes an error parseIssue when parsing throws',
   () => {
-    // The CLI's `generate --json` previously reported `kind:
+    // The CLI's `generate --json` previously reported `type:
     // "generated"` with 0 files when the worker's `toArtifacts`
     // caught a top-level failure — there was no signal in the
     // returned shape that anything had gone wrong. The catch now

--- a/deno/core/context/GenerateContext.cross-variant.test.ts
+++ b/deno/core/context/GenerateContext.cross-variant.test.ts
@@ -67,7 +67,7 @@ const METHOD = 'patch' as const
 const PeerBase = toTsOasOperationProjectionBase({
   id: '@test/peer-gen',
   toIdentifierName: () => 'usePatchQuote',
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
   toExportPath: () => '@/services/usePatchQuote.ts',
   toEnrichmentSchema: () => emptyEnrichmentSchema
 })
@@ -84,7 +84,7 @@ class PeerProjection extends PeerBase {
 const FormBase = toTsOasOperationProjectionBase({
   id: '@test/form-gen',
   toIdentifierName: ({ variant }) => withVariant('EditQuotesForm', variant),
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
   toExportPath: ({ variant }) => `@/forms/${withVariant('EditQuotesForm', variant)}.tsx`,
   toEnrichmentSchema: () => variantEnrichmentSchema
 })

--- a/deno/core/context/GenerateContext.end-to-end.test.ts
+++ b/deno/core/context/GenerateContext.end-to-end.test.ts
@@ -48,7 +48,7 @@ const mockLogger: log.Logger = {
 const FormBase = toTsOasOperationProjectionBase({
   id: '@test/e2e-form',
   toIdentifierName: ({ variant }) => withVariant('PatchQuoteForm', variant),
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
   toExportPath: ({ variant }) =>
     `@/forms/${withVariant('PatchQuoteForm', variant)}.tsx`,
   toEnrichmentSchema: () => variantEnrichmentSchema

--- a/deno/core/context/GenerateContext.normalized-model-variants.test.ts
+++ b/deno/core/context/GenerateContext.normalized-model-variants.test.ts
@@ -58,7 +58,7 @@ const mockLogger: log.Logger = {
 const FormBase = toTsOasOperationProjectionBase({
   id: '@test/form',
   toIdentifierName: ({ variant }) => withVariant('EditQuotesForm', variant),
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
   toExportPath: ({ variant }) => `@/forms/${withVariant('EditQuotesForm', variant)}.tsx`,
   toEnrichmentSchema: () => variantEnrichmentSchema
 })

--- a/deno/core/context/GenerateContext.ts
+++ b/deno/core/context/GenerateContext.ts
@@ -1434,7 +1434,7 @@ export class GenerateContext implements GenerateContextType {
   /**
    * Build content settings for a model projection by calling its statics
    * `toIdentifierName` (pure, for the name) + `toIdentifierType`
-   * (context-aware, for kind/typeName/exported), `toExportPath`, and
+   * (context-aware, for type/typeName/exported), `toExportPath`, and
    * `toEnrichments` against the given `refName` and `variant`. The full
    * identifier is assembled through the projection's language
    * (`lang.toIdentifier`).

--- a/deno/core/context/GenerateContext.webhook-variants.test.ts
+++ b/deno/core/context/GenerateContext.webhook-variants.test.ts
@@ -68,7 +68,7 @@ const makeDoc = () =>
 const FanoutBase = toTsWebhookProjectionBase({
   id: '@test/fanout-webhook',
   toIdentifierName: ({ webhook, variant }) => withVariant(`${cap(webhook.name)}Handler`, variant),
-  toIdentifierType: () => ({ kind: 'type' }),
+  toIdentifierType: () => ({ type: 'type' }),
   toExportPath: ({ webhook, variant }) =>
     `@/webhooks/${withVariant(`${cap(webhook.name)}Handler`, variant)}.ts`,
   toEnrichmentSchema: () => variantEnrichmentSchema
@@ -131,7 +131,7 @@ Deno.test('webhook variants - variants-aware handler emits a distinct file per d
 const PeerBase = toTsWebhookProjectionBase({
   id: '@test/peer-webhook',
   toIdentifierName: ({ webhook }) => `${cap(webhook.name)}Ack`,
-  toIdentifierType: () => ({ kind: 'type' }),
+  toIdentifierType: () => ({ type: 'type' }),
   toExportPath: ({ webhook }) => `@/webhooks/shared/${cap(webhook.name)}Ack.ts`,
   toEnrichmentSchema: () => emptyEnrichmentSchema
 })
@@ -147,7 +147,7 @@ class PeerHandler extends PeerBase {
 const CallerBase = toTsWebhookProjectionBase({
   id: '@test/caller-webhook',
   toIdentifierName: ({ webhook, variant }) => withVariant(`${cap(webhook.name)}Handler`, variant),
-  toIdentifierType: () => ({ kind: 'type' }),
+  toIdentifierType: () => ({ type: 'type' }),
   toExportPath: ({ webhook, variant }) =>
     `@/webhooks/${withVariant(`${cap(webhook.name)}Handler`, variant)}.ts`,
   toEnrichmentSchema: () => variantEnrichmentSchema

--- a/deno/core/context/ParseContext.errorHandling.test.ts
+++ b/deno/core/context/ParseContext.errorHandling.test.ts
@@ -13,7 +13,7 @@
  *   2. When the *target* fails to parse, `registerRefError(error, refKey)`
  *      records the failure against that key. For OAS this happens
  *      automatically inside `logIssueNoKey` when the current stack trail
- *      is at a `components.<kind>.<name>` position.
+ *      is at a `components.<type>.<name>` position.
  *   3. After parse finishes, `removeErroredItems` walks every errored
  *      ref key, looks up its consumers, prunes them from the parsed
  *      document, and emits an `INVALID_DEPENDENCY_REF` issue per pruned

--- a/deno/core/context/ParseIssue.ts
+++ b/deno/core/context/ParseIssue.ts
@@ -33,7 +33,7 @@ import type { OasIssueType } from '@/context/generateTypes.ts'
  *
  * - `NESTED_LIST_LOSSY` — `[[T]]` collapsed to `OasUnknown`.
  * - `UNKNOWN_TYPE_KIND` — defensive fallback for an unrecognized
- *   GraphQL type kind. Should never fire in practice.
+ *   GraphQL type type. Should never fire in practice.
  * - `DROPPED_DIRECTIVE` — applied directive ignored during mapping
  *   (other than `@deprecated`, whose `reason` we capture).
  * - `SKIPPED_FIELD_ARGUMENTS` — non-root object/interface field

--- a/deno/core/dsl/CodeFileBase.ts
+++ b/deno/core/dsl/CodeFileBase.ts
@@ -1,35 +1,35 @@
 import { FileBase } from '@/dsl/FileBase.ts'
 import type { DefinitionBase } from '@/dsl/Definition.ts'
 import type { IdentifierBase } from '@/dsl/IdentifierBase.ts'
-import type { Lang, LangKind } from '@/dsl/Lang.ts'
 import type { ImportBase } from '@/dsl/ImportBase.ts'
 import type { ReExportBase } from '@/dsl/ReExportBase.ts'
 
 /**
  * Query for {@link CodeFileBase.findDefinitions}. `name` filters by identifier
- * name; `type` filters by the language's declaration kind ({@link LangKind},
- * inferred from the file's {@link Lang} — `'class'` / `'interface'` / … for
- * TypeScript). Omit both to return every definition.
+ * name; `type` filters by the declaration type as the opaque-boundary
+ * `string`. A lang's concrete file narrows the override to its own
+ * `XxEntityType` (`'class'` / `'interface'` / … for TypeScript). Omit both to
+ * return every definition.
  */
-export type FindDefinitionsQuery<L extends Lang> = {
-  type?: LangKind<L>
+export type FindDefinitionsQuery = {
+  type?: string
   name?: string
 }
 
 /**
  * The neutral name/kind filter every language's `findDefinitions` shares. The
- * language passes its definition list and a `kindOf` extractor — the one
+ * language passes its definition list and a `typeOf` extractor — the one
  * lang-specific bit, which narrows to the language's Identifier subclass to
- * read the typed `kind`.
+ * read the typed `type` (returned here as the opaque `string`).
  *
  * - no `name` and no `type` → returns `all` (the whole list; the former
  *   `listDefinitions`).
  * - otherwise → the matching subset, or `undefined` when nothing matches.
  */
-export const matchDefinitions = <L extends Lang>(
+export const matchDefinitions = (
   all: DefinitionBase[],
-  query: FindDefinitionsQuery<L> | undefined,
-  kindOf: (identifier: IdentifierBase) => LangKind<L> | undefined
+  query: FindDefinitionsQuery | undefined,
+  typeOf: (identifier: IdentifierBase) => string | undefined
 ): DefinitionBase[] | undefined => {
   const name = query?.name
   const type = query?.type
@@ -40,7 +40,7 @@ export const matchDefinitions = <L extends Lang>(
 
   const matches = all.filter(definition => {
     const nameMatches = name === undefined || definition.identifier.name === name
-    const typeMatches = type === undefined || kindOf(definition.identifier) === type
+    const typeMatches = type === undefined || typeOf(definition.identifier) === type
     return nameMatches && typeMatches
   })
 
@@ -52,10 +52,9 @@ export const matchDefinitions = <L extends Lang>(
  * coordinates definitions, imports, and re-exports. (`JsonFile`, with none of
  * these, extends {@link FileBase} directly.)
  *
- * Generic over the file's language {@link Lang} (`CodeFileBase<TsLang>`) — the
- * source of the typed declaration kind ({@link LangKind}) that
- * {@link findDefinitions} filters on. The parameter is **required**: a code
- * file always belongs to a concrete language.
+ * Language-blind: the declaration type {@link findDefinitions} filters on is
+ * the opaque-boundary `string` here; a lang's concrete file narrows its own
+ * `findDefinitions` override to its `XxEntityType`.
  *
  * Pure contract — no fields, no merge logic. Storage AND the duplication/merge
  * policy are language-specific and live in the concrete lang subclass; the
@@ -64,7 +63,7 @@ export const matchDefinitions = <L extends Lang>(
  * cache and file inspection use. The cache resolves a single primary by name
  * via `findDefinitions({ name })?.[0]`.
  */
-export abstract class CodeFileBase<L extends Lang> extends FileBase {
+export abstract class CodeFileBase extends FileBase {
   /**
    * Add a definition, applying the language's duplication rule (e.g.
    * TypeScript declaration merging). Called by the engine's `register`.
@@ -88,8 +87,9 @@ export abstract class CodeFileBase<L extends Lang> extends FileBase {
    * Query the file's definitions. With no `name`/`type` → every definition (an
    * array; the neutral "list all" used to inspect a file, e.g. assert the
    * peer-dedup invariant). With `name` and/or `type` → the matching subset, or
-   * `undefined` when nothing matches. `type` is the language's declaration
-   * kind, inferred from {@link Lang}. Implement with {@link matchDefinitions}.
+   * `undefined` when nothing matches. `type` is the declaration type as the
+   * opaque `string`; a lang's concrete file may narrow it. Implement with
+   * {@link matchDefinitions}.
    */
-  abstract findDefinitions(query?: FindDefinitionsQuery<L>): DefinitionBase[] | undefined
+  abstract findDefinitions(query?: FindDefinitionsQuery): DefinitionBase[] | undefined
 }

--- a/deno/core/dsl/CodeFileBase.ts
+++ b/deno/core/dsl/CodeFileBase.ts
@@ -17,7 +17,7 @@ export type FindDefinitionsQuery = {
 }
 
 /**
- * The neutral name/kind filter every language's `findDefinitions` shares. The
+ * The neutral name/type filter every language's `findDefinitions` shares. The
  * language passes its definition list and a `typeOf` extractor — the one
  * lang-specific bit, which narrows to the language's Identifier subclass to
  * read the typed `type` (returned here as the opaque `string`).

--- a/deno/core/dsl/ContentSettings.test.ts
+++ b/deno/core/dsl/ContentSettings.test.ts
@@ -1,10 +1,9 @@
 import { assertEquals } from '@std/assert/equals'
-import { assert } from '@std/assert/assert'
-import { createType, createVariable, isTsIdentifier } from '@skmtc/lang-typescript'
+import { IdentifierBase } from '@/dsl/IdentifierBase.ts'
 import { ContentSettings } from '@/dsl/ContentSettings.ts'
 
 Deno.test('ContentSettings - creates settings with enrichments', () => {
-  const identifier = createType('User')
+  const identifier = new IdentifierBase({ name: 'User' })
   const enrichments = { validateRequired: true, generateComments: false }
 
   const settings = new ContentSettings({
@@ -20,7 +19,7 @@ Deno.test('ContentSettings - creates settings with enrichments', () => {
 })
 
 Deno.test('ContentSettings.empty - creates settings without enrichments', () => {
-  const identifier = createType('Product')
+  const identifier = new IdentifierBase({ name: 'Product' })
 
   const settings = ContentSettings.empty({
     identifier,
@@ -33,7 +32,7 @@ Deno.test('ContentSettings.empty - creates settings without enrichments', () => 
 })
 
 Deno.test('ContentSettings - stores identifier properties', () => {
-  const identifier = createVariable('apiClient', { typeName: 'ApiClient' })
+  const identifier = new IdentifierBase({ name: 'apiClient', typeName: 'ApiClient' })
 
   const settings = new ContentSettings({
     identifier,
@@ -42,10 +41,8 @@ Deno.test('ContentSettings - stores identifier properties', () => {
     variant: 'main'
   })
 
+  // Only the neutral identifier facts belong in a core test; the typed `type`
+  // is a lang concern, exercised in each `@skmtc/lang-*` package's own tests.
   assertEquals(settings.identifier.name, 'apiClient')
   assertEquals(settings.identifier.typeName, 'ApiClient')
-  // The engine holds the identifier as the neutral `IdentifierBase`; narrow
-  // to `TsIdentifier` cast-free to read the typed `kind`.
-  assert(isTsIdentifier(settings.identifier))
-  assertEquals(settings.identifier.kind, 'variable')
 })

--- a/deno/core/dsl/GeneratorKeys.test.ts
+++ b/deno/core/dsl/GeneratorKeys.test.ts
@@ -86,7 +86,7 @@ Deno.test('Webhook key is collision-free vs a same-named operation path', () => 
   // distinct strings
   assertEquals(webhookKey === (operationKey as string), false)
 
-  // each guard accepts only its own kind
+  // each guard accepts only its own type
   assertEquals(isWebhookGeneratorKey(webhookKey), true)
   assertEquals(isOasOperationGeneratorKey(webhookKey), false)
   assertEquals(isOasOperationGeneratorKey(operationKey), true)

--- a/deno/core/dsl/GeneratorKeys.ts
+++ b/deno/core/dsl/GeneratorKeys.ts
@@ -140,7 +140,7 @@ export type OasOperationGeneratorKey = Brand<NakedOasOperationGeneratorKey, 'Oas
  * Branded type for GraphQL operation generator keys.
  *
  * Sibling to {@link OasOperationGeneratorKey} for the GraphQL protocol. The key
- * encodes the generator ID, the root kind (`query` / `mutation` /
+ * encodes the generator ID, the root type (`query` / `mutation` /
  * `subscription`), and the root field name.
  */
 export type GqlOperationGeneratorKey = Brand<
@@ -345,14 +345,14 @@ export const toWebhookGeneratorKey = ({
  * Arguments for {@link toGqlOperationGeneratorKey}.
  *
  * Can specify operation details directly or provide a {@link GqlOperation}
- * object from which the root kind and field name will be extracted. The
+ * object from which the root type and field name will be extracted. The
  * `variant` segment is always required (see {@link Variant}).
  */
 type ToGqlOperationGeneratorKeyArgs =
   | {
       /** Unique identifier for the generator */
       generatorId: string
-      /** GraphQL root kind */
+      /** GraphQL root type */
       rootKind: GqlRootKind
       /** Root field name */
       fieldName: string
@@ -615,7 +615,7 @@ export const isWebhookGeneratorKey = (arg: unknown): arg is WebhookGeneratorKey 
  *
  * Validates that the argument is a string with the format
  * `generatorId|rootKind|fieldName`, with `rootKind` constrained to a
- * GraphQL root operation kind (`query` / `mutation` / `subscription`).
+ * GraphQL root operation type (`query` / `mutation` / `subscription`).
  */
 export const isGqlOperationGeneratorKey = (arg: unknown): arg is GqlOperationGeneratorKey => {
   if (typeof arg !== 'string') {
@@ -819,7 +819,7 @@ export type GeneratorKeyObject =
       type: 'gqlOperation'
       /** Generator identifier */
       generatorId: string
-      /** GraphQL root kind */
+      /** GraphQL root type */
       rootKind: GqlRootKind
       /** Root field name */
       fieldName: string

--- a/deno/core/dsl/IdentifierBase.ts
+++ b/deno/core/dsl/IdentifierBase.ts
@@ -18,7 +18,7 @@ export type IdentifierBaseArgs = {
  * `(name, exportPath)` cross-generator cache key, and `DefinitionBase`. The
  * engine reads ONLY `.name` (the cache-key source); `typeName` and
  * `exported` are language-neutral facts it threads but never interprets.
- * Crucially it carries NO `kind` — the per-language declaration vocabulary
+ * Crucially it carries NO `type` — the per-language declaration vocabulary
  * lives, typed, on the language subclasses.
  *
  * It completes the neutral `*Base` family
@@ -28,9 +28,9 @@ export type IdentifierBaseArgs = {
  * through a language package's factories (`createVariable` / `createType`
  * for TypeScript; `createDataClass` / `createEnumClass` / … for Kotlin) or
  * the engine's assembly seam `lang.toIdentifier({ name, ...identifierType })`.
- * The engine holds the result as `IdentifierBase`; the language's `kind` is
- * read only by the language renderers, which narrow via an `instanceof`
- * guard (`isTsIdentifier` / `isKtIdentifier`).
+ * The engine holds the result as `IdentifierBase`; the language's `type` is
+ * read only by the language renderers, which narrow back to the concrete
+ * subclass via `instanceof` (e.g. `value instanceof TsIdentifier`).
  */
 export class IdentifierBase {
   /** The identifier name — the only field the engine reads. */
@@ -60,6 +60,23 @@ export class IdentifierBase {
    * identifier is interpolated into generated code.
    */
   toString(): string {
+    return this.name
+  }
+
+  /**
+   * The key under which a file stores and dedups this identifier's
+   * definition: two definitions whose identifiers share a `declarationKey`
+   * occupy the same declaration slot, so the later one collapses into the
+   * first (the cross-generator cache then resolves a name to its
+   * first-registered definition).
+   *
+   * The neutral default is the bare {@link name} — one definition per name,
+   * which is what most languages want. A language whose declaration space is
+   * richer overrides this: TypeScript folds in the declaration `type` so a
+   * `class Foo` and a `declare namespace Foo` — distinct declarations the
+   * compiler legitimately merges — get distinct keys instead of colliding.
+   */
+  declarationKey(): string {
     return this.name
   }
 }

--- a/deno/core/dsl/IdentifierBase.ts
+++ b/deno/core/dsl/IdentifierBase.ts
@@ -23,7 +23,7 @@ export type IdentifierBaseArgs = {
  *
  * It completes the neutral `*Base` family
  * (`CodeFileBase` / `DefinitionBase` / `ImportBase`): the concrete,
- * kind-carrying subclasses (`TsIdentifier`, `KtIdentifier`) live in the
+ * type-carrying subclasses (`TsIdentifier`, `KtIdentifier`) live in the
  * `@skmtc/lang-*` packages and **extend** this base. Construction goes
  * through a language package's factories (`createVariable` / `createType`
  * for TypeScript; `createDataClass` / `createEnumClass` / … for Kotlin) or

--- a/deno/core/dsl/IdentifierType.ts
+++ b/deno/core/dsl/IdentifierType.ts
@@ -1,29 +1,22 @@
-import type { Lang, LangKind } from '@/dsl/Lang.ts'
-
 /**
  * The non-`name` parts of an identifier — everything a projection's
  * `toIdentifierType` derives from the schema (context-aware), bundled so
  * the engine can assemble the full identifier with
  * `lang.toIdentifier({ name, ...identifierType })`.
  *
- * Generic over the projection's {@link Lang}: the `kind` is drawn from that
- * language's declaration vocabulary, recovered via {@link LangKind} from the
- * typed `kind` on the {@link import('@/dsl/IdentifierBase.ts').IdentifierBase}
- * subclass the lang produces (`KtEntityKind` for `KtLang`, `TsEntityKind` for
- * the TypeScript `Lang`, …). A bare `Lang` falls back to the loose
- * `kind: string` — the opaque-kind boundary the engine never interprets.
- *
- * This is what lets a language's projection-base veneer parameterize core's
- * config (`ModelProjectionBaseConfig<E, KtLang>`) instead of recasting
- * `toIdentifierType`'s return: the tightening rides the `L` type argument.
+ * The `type` is the opaque-boundary `string` — the engine never interprets
+ * it. Each language's declaration-type vocabulary is a fixed fact of its lang
+ * package; a lang veneer tightens `toIdentifierType`'s return to its own
+ * `XxIdentifierType` (`type` narrowed to `XxEntityType`), which is assignable
+ * back to this shape. Core never models or recovers that vocabulary.
  *
  * Pairs with `toIdentifierName(args) -> string` (the pure, cache-key
  * source): the engine assembles
  * `lang.toIdentifier({ name: P.toIdentifierName(args), ...P.toIdentifierType(coordinate, context) })`.
  */
-export type IdentifierType<L extends Lang = Lang> = {
-  /** Per-language declaration kind — `LangKind<L>`, opaque to the engine. */
-  kind: LangKind<L>
+export type IdentifierType = {
+  /** Per-language declaration type — the opaque-boundary `string`. */
+  type: string
   /** Optional type annotation, opaque to the engine (lang-interpreted). */
   typeName?: string
   /** Whether the identifier is exported. Defaults to `true`. */

--- a/deno/core/dsl/Inserted.test.ts
+++ b/deno/core/dsl/Inserted.test.ts
@@ -1,23 +1,23 @@
 import { assertEquals } from '@std/assert/equals'
 import { Inserted } from '@/dsl/Inserted.ts'
 import { ContentSettings } from '@/dsl/ContentSettings.ts'
-import { TsDefinition, createType, createVariable, isTsIdentifier } from '@skmtc/lang-typescript'
-import { assert } from '@std/assert'
+import { IdentifierBase } from '@/dsl/IdentifierBase.ts'
+import { MockDefinition } from '@/test/MockFile.ts'
 import { toGeneratorOnlyKey } from '@/dsl/GeneratorKeys.ts'
-import type { GenerateContextType } from '../context/generateTypes.ts'
+import type { GenerateContextType } from '@/context/generateTypes.ts'
 
 // Minimal mock context for testing
 const mockContext = {} as GenerateContextType
 const testGeneratorKey = toGeneratorOnlyKey({ generatorId: 'test' })
 
 Deno.test('Inserted - toName returns identifier name', () => {
-  const identifier = createType('User')
+  const identifier = new IdentifierBase({ name: 'User' })
   const settings = ContentSettings.empty({
     identifier,
     exportPath: './src/models/User.ts'
   })
 
-  const definition = new TsDefinition({
+  const definition = new MockDefinition({
     context: mockContext,
     identifier,
     value: { generatorKey: testGeneratorKey, toString: () => '{ id: string }' }
@@ -32,13 +32,13 @@ Deno.test('Inserted - toName returns identifier name', () => {
 })
 
 Deno.test('Inserted - toIdentifier returns full identifier', () => {
-  const identifier = createVariable('apiClient', { typeName: 'ApiClient' })
+  const identifier = new IdentifierBase({ name: 'apiClient', typeName: 'ApiClient' })
   const settings = ContentSettings.empty({
     identifier,
     exportPath: './src/api.ts'
   })
 
-  const definition = new TsDefinition({
+  const definition = new MockDefinition({
     context: mockContext,
     identifier,
     value: { generatorKey: testGeneratorKey, toString: () => 'new Client()' }
@@ -53,18 +53,16 @@ Deno.test('Inserted - toIdentifier returns full identifier', () => {
 
   assertEquals(resultIdentifier.name, 'apiClient')
   assertEquals(resultIdentifier.typeName, 'ApiClient')
-  assert(isTsIdentifier(resultIdentifier))
-  assertEquals(resultIdentifier.kind, 'variable')
 })
 
 Deno.test('Inserted - toExportPath returns export path', () => {
-  const identifier = createType('Product')
+  const identifier = new IdentifierBase({ name: 'Product' })
   const settings = ContentSettings.empty({
     identifier,
     exportPath: './src/models/Product.ts'
   })
 
-  const definition = new TsDefinition({
+  const definition = new MockDefinition({
     context: mockContext,
     identifier,
     value: { generatorKey: testGeneratorKey, toString: () => '{ name: string }' }
@@ -79,14 +77,14 @@ Deno.test('Inserted - toExportPath returns export path', () => {
 })
 
 Deno.test('Inserted - toValue returns generated value', () => {
-  const identifier = createType('Status')
+  const identifier = new IdentifierBase({ name: 'Status' })
   const settings = ContentSettings.empty({
     identifier,
     exportPath: './src/types.ts'
   })
 
   const value = { generatorKey: testGeneratorKey, toString: () => "'active' | 'inactive'" }
-  const definition = new TsDefinition({
+  const definition = new MockDefinition({
     context: mockContext,
     identifier,
     value
@@ -101,7 +99,7 @@ Deno.test('Inserted - toValue returns generated value', () => {
 })
 
 Deno.test('Inserted - works with enrichments', () => {
-  const identifier = createType('ValidatedUser')
+  const identifier = new IdentifierBase({ name: 'ValidatedUser' })
   const enrichments = { validateRequired: true, generateComments: false }
   const settings = new ContentSettings({
     identifier,
@@ -110,7 +108,7 @@ Deno.test('Inserted - works with enrichments', () => {
     variant: 'main'
   })
 
-  const definition = new TsDefinition({
+  const definition = new MockDefinition({
     context: mockContext,
     identifier,
     value: { generatorKey: testGeneratorKey, toString: () => '{ id: string }' }

--- a/deno/core/dsl/Lang.ts
+++ b/deno/core/dsl/Lang.ts
@@ -11,13 +11,9 @@ import type { SnippetBase, SnippetBaseArgs } from '@/dsl/SnippetBase.ts'
  * Arguments for {@link Lang.toDefinition} — everything the language needs
  * to wrap a generated `value` in its own `Definition` subclass.
  *
- * `identifier` stays the neutral {@link IdentifierBase}: the engine holds
- * identifiers as the base and passes that to the factory (which narrows via
- * its own `instanceof` guard). Keeping it neutral is also what lets a typed
- * `Lang` (e.g. `KtLang`) satisfy the bare `Lang` constraint — `identifier`
- * is a contravariant parameter, so a narrower type here would break the
- * subtype relation. The typed identifier surfaces only on `toIdentifier`'s
- * RETURN (a covariant position).
+ * `identifier` is the neutral {@link IdentifierBase}: the engine holds
+ * identifiers as the base and passes that to the factory, which narrows to
+ * its own concrete subclass via `instanceof`.
  */
 export type LangToDefinitionArgs<V extends GeneratedValue = GeneratedValue> = {
   context: GenerateContextType
@@ -43,12 +39,12 @@ export type LangToImportArgs = {
  * seam. `name` comes from the projection's pure `toIdentifierName`; the
  * remaining fields come from the context-aware `toIdentifierType`
  * (spread in). The language builds its concrete `IdentifierBase` subclass
- * (`TsIdentifier` / `KtIdentifier`), reading the opaque `kind` into its
- * typed `EntityKind` slot.
+ * (`TsIdentifier` / `KtIdentifier`), reading the opaque `type` into its
+ * typed `EntityType` slot.
  */
 export type LangToIdentifierArgs = {
   name: string
-  kind: string
+  type: string
   typeName?: string
   exported?: boolean
 }
@@ -76,7 +72,7 @@ export type LangToIdentifierArgs = {
  * vocabulary is intra-lang-package (each language's register function
  * converts its own form), so the neutral interface never names one.
  */
-export type Lang<IdentifierT extends IdentifierBase = IdentifierBase> = {
+export type Lang = {
   /** Construct the language's file for `path`. */
   createFile: (args: { path: string; settings: ClientSettings | undefined }) => FileBase
   /** Wrap a generated `value` in this language's `Definition` subclass. */
@@ -85,31 +81,14 @@ export type Lang<IdentifierT extends IdentifierBase = IdentifierBase> = {
   toImport: (args: LangToImportArgs) => ImportBase
   /**
    * Assemble this language's `IdentifierBase` subclass from name +
-   * kind/type/exported. `kind` arrives as the opaque-boundary `string` (the
-   * engine never narrows it); the language reads it into its typed
-   * `EntityKind` slot. The returned `IdentifierT` is the language's concrete
-   * subclass — its typed `kind` is the ONLY place `IdentifierT` appears (a
-   * covariant return position), which is what lets {@link IdentifierType}
-   * recover the vocabulary to tighten the projection config while a typed
-   * `Lang` still satisfies the bare `Lang` constraint.
+   * type/typeName/exported. `type` arrives as the opaque-boundary `string` — the
+   * engine never narrows it; the language reads it into its own typed
+   * `EntityType` slot. The engine holds the result as the neutral
+   * `IdentifierBase`; the declaration-type vocabulary is a fixed fact of each
+   * language package, never modelled or recovered here.
    */
-  toIdentifier: (args: LangToIdentifierArgs) => IdentifierT
+  toIdentifier: (args: LangToIdentifierArgs) => IdentifierBase
 }
-
-/**
- * The language's declaration-kind vocabulary, recovered from the typed
- * `kind` on the {@link IdentifierBase} subclass a `Lang` produces.
- *
- * `KtIdentifier` carries `kind: KtEntityKind`, `TsIdentifier` carries
- * `kind: TsEntityKind`, … The neutral `IdentifierBase` has no `kind`, so a
- * bare `Lang` falls back to the loose `string` — the opaque-kind boundary
- * the engine speaks.
- */
-export type LangKind<L extends Lang> = ReturnType<L['toIdentifier']> extends {
-  kind: infer Kind extends string
-}
-  ? Kind
-  : string
 
 /**
  * The constructor contract a language's snippet base class must satisfy to
@@ -129,12 +108,10 @@ export type LangKind<L extends Lang> = ReturnType<L['toIdentifier']> extends {
  * generic over the base's *instance* type cannot type-safely extend it
  * (TS2415/TS2545 — see the scratch in `notes/lang/14`), and the price would
  * be that language-specific instance members are type-erased on projection
- * classes. Only the STATIC `lang` is parameterized — over the neutral `Lang`
- * by default, narrowed to a language's typed `Lang` (e.g. `KtLang`) when a
- * veneer threads `L` through. Narrowing a covariant static intersection does
- * not reawaken TS2415; the `extends config.base` in the factories stays well
- * typed because the instance side is unchanged.
+ * classes. The static `lang` is the neutral {@link Lang} — the engine reads
+ * it language-blind; each lang package's concrete declaration-type vocabulary
+ * is a fixed fact of that package, never recovered through this type.
  */
-export type LangSnippetConstructor<L extends Lang = Lang> = (new (
+export type LangSnippetConstructor = (new (
   args: SnippetBaseArgs
-) => SnippetBase) & { lang: L }
+) => SnippetBase) & { lang: Lang }

--- a/deno/core/dsl/model/ModelDriver.test.ts
+++ b/deno/core/dsl/model/ModelDriver.test.ts
@@ -5,7 +5,8 @@ import type { ModelProjection } from './types.ts'
 import type { GenerateContextType } from '../../context/generateTypes.ts'
 import type { ContentSettings } from '@/dsl/ContentSettings.ts'
 import { DefinitionBase } from '@/dsl/Definition.ts'
-import { TsDefinition, createType } from '@skmtc/lang-typescript'
+import { TsDefinition, TsIdentifier, createType } from '@skmtc/lang-typescript'
+import invariant from 'tiny-invariant'
 import type { GeneratedValue } from '../GeneratedValue.ts'
 import type { RefName } from '@/types/RefName.ts'
 import { toModelGeneratorKey } from '../GeneratorKeys.ts'
@@ -21,8 +22,12 @@ import { typescript } from '@skmtc/lang-typescript'
 // which Definition subclass flows through.
 const coreDefLang: Lang = {
   ...typescript,
-  toDefinition: ({ context, identifier, value, noExport }) =>
-    new TsDefinition({ context, identifier, value, noExport })
+  toDefinition: ({ context, identifier, value, noExport }) => {
+    // The engine holds the identifier neutrally; TsDefinition needs the
+    // concrete TsIdentifier — narrow exactly as the real `typescript` lang does.
+    invariant(identifier instanceof TsIdentifier, 'expected a TsIdentifier')
+    return new TsDefinition({ context, identifier, value, noExport })
+  }
 }
 
 class MockGeneratedValue implements GeneratedValue {

--- a/deno/core/dsl/model/ModelDriver.variants.test.ts
+++ b/deno/core/dsl/model/ModelDriver.variants.test.ts
@@ -77,7 +77,7 @@ Deno.test(
     const ZodVariants = class extends toTsModelProjectionBase({
       id: '@scope/gen-zod-variants',
       toIdentifierName: ({ refName, variant }) => withVariant(refName, variant),
-      toIdentifierType: () => ({ kind: 'variable' }),
+      toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ refName, variant }) => `@/schemas/${withVariant(refName, variant)}.ts`,
       toEnrichmentSchema: () => emptyEnrichmentSchema
     }) {
@@ -108,7 +108,7 @@ Deno.test(
     const ZodVariants = class extends toTsModelProjectionBase({
       id: '@scope/gen-zod-variants',
       toIdentifierName: ({ refName, variant }) => withVariant(refName, variant),
-      toIdentifierType: () => ({ kind: 'variable' }),
+      toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ refName, variant }) => `@/schemas/${withVariant(refName, variant)}.ts`,
       toEnrichmentSchema: () => emptyEnrichmentSchema
     }) {
@@ -149,7 +149,7 @@ Deno.test(
     const ZodGen = class extends toTsModelProjectionBase({
       id: '@scope/gen-zod',
       toIdentifierName: ({ refName }) => refName,
-      toIdentifierType: () => ({ kind: 'variable' }),
+      toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ refName }) => `@/schemas/${refName}.ts`,
       toEnrichmentSchema: () => emptyEnrichmentSchema
     }) {
@@ -186,7 +186,7 @@ Deno.test(
     const BrokenZod = class extends toTsModelProjectionBase({
       id: '@scope/gen-broken-zod',
       toIdentifierName: ({ refName }) => refName, // ← ignores variant
-      toIdentifierType: () => ({ kind: 'variable' }),
+      toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ refName }) => `@/schemas/${refName}.ts`,         // ← ignores variant
       toEnrichmentSchema: () => variantPlaceholderEnrichmentSchema
     }) {
@@ -236,7 +236,7 @@ Deno.test(
     const CorrectZod = class extends toTsModelProjectionBase({
       id: '@scope/gen-correct-zod',
       toIdentifierName: ({ refName, variant }) => withVariant(refName, variant),
-      toIdentifierType: () => ({ kind: 'variable' }),
+      toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ refName, variant }) => `@/schemas/${withVariant(refName, variant)}.ts`,
       toEnrichmentSchema: () => variantPlaceholderEnrichmentSchema
     }) {
@@ -282,7 +282,7 @@ Deno.test(
     const Zod = class extends toTsModelProjectionBase({
       id: '@scope/gen-cache-zod',
       toIdentifierName: ({ refName }) => refName,
-      toIdentifierType: () => ({ kind: 'variable' }),
+      toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ refName }) => `@/schemas/${refName}.ts`,
       toEnrichmentSchema: () => emptyEnrichmentSchema
     }) {

--- a/deno/core/dsl/model/option2.spike.test.ts
+++ b/deno/core/dsl/model/option2.spike.test.ts
@@ -60,7 +60,7 @@ class SpikeField extends TsSnippet {
 const SpikeModelBase = toTsModelProjectionBase({
   id: '@spike/gen-option2',
   toIdentifierName: ({ refName }) => `${refName}Spike`,
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
   toExportPath: () => '@/spike/models.generated.ts',
   toEnrichmentSchema: () => emptyEnrichmentSchema
 })

--- a/deno/core/dsl/model/toModelProjectionBase.test.ts
+++ b/deno/core/dsl/model/toModelProjectionBase.test.ts
@@ -25,7 +25,7 @@ Deno.test('toModelProjectionBase - returns a class constructor', () => {
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -38,7 +38,7 @@ Deno.test('toModelProjectionBase - sets static id from config', () => {
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'typescript-models',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -50,7 +50,7 @@ Deno.test('toModelProjectionBase - sets static type to model', () => {
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -64,7 +64,7 @@ Deno.test('toModelProjectionBase - sets static toIdentifierName from config', ()
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: identifierNameFn,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -81,13 +81,13 @@ Deno.test('toModelProjectionBase - sets static toIdentifierType from config', ()
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
 
   const identifierType = ModelClass.toIdentifierType('User' as RefName, {} as GenerateContextType)
-  assertEquals(identifierType.kind, 'type')
+  assertEquals(identifierType.type, 'type')
 })
 
 Deno.test('toModelProjectionBase - sets static toExportPath from config', () => {
@@ -96,7 +96,7 @@ Deno.test('toModelProjectionBase - sets static toExportPath from config', () => 
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: exportPathFn,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -113,7 +113,7 @@ Deno.test('toModelProjectionBase - toEnrichments returns the empty umbrella with
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -131,7 +131,7 @@ Deno.test('toModelProjectionBase - toEnrichments returns the empty umbrella when
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -149,7 +149,7 @@ Deno.test('toModelProjectionBase - static isSupported defaults to true when not 
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -167,7 +167,7 @@ Deno.test('toModelProjectionBase - static isSupported reflects the configured pr
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema,
     // Only object-named models supported in this fixture.
@@ -183,7 +183,7 @@ Deno.test('toModelProjectionBase - toIdentifierName works with different refName
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => `${refName}Model`,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -207,7 +207,7 @@ Deno.test('toModelProjectionBase - toExportPath works with different refNames', 
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./types/${refName.toLowerCase()}.d.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -230,7 +230,7 @@ Deno.test('toModelProjectionBase - constructor creates correct generatorKey', ()
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'typescript-models',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -256,7 +256,7 @@ Deno.test('toModelProjectionBase - constructor threads non-default variant into 
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'zod-schemas',
     toIdentifierName: ({ refName, variant }) => withVariant(refName, variant),
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ refName, variant }) => `./schemas/${withVariant(refName, variant)}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -281,7 +281,7 @@ Deno.test('toModelProjectionBase - instance is ModelProjectionBase', () => {
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -311,7 +311,7 @@ Deno.test('toModelProjectionBase - toEnrichments validates with schema', () => {
   }>(TsSnippet, {
     id: 'typescript-interfaces',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () =>
       v.object({
@@ -361,7 +361,7 @@ Deno.test('toModelProjectionBase - toEnrichments retrieves from correct nested p
   }>(TsSnippet, {
     id: 'zod-schemas',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./schemas/${refName}.ts`,
     toEnrichmentSchema: () =>
       v.object({
@@ -406,7 +406,7 @@ Deno.test('toModelProjectionBase - toEnrichments resolves per-variant payloads i
   }>(TsSnippet, {
     id: '@scope/gen-zod-variants',
     toIdentifierName: ({ refName, variant }) => withVariant(refName, variant),
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ refName, variant }) => `./schemas/${withVariant(refName, variant)}.ts`,
     toEnrichmentSchema: () =>
       v.object({
@@ -452,7 +452,7 @@ Deno.test('toModelProjectionBase - toEnrichmentDefaults returns undefined when n
   const ModelClass = toModelProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -474,7 +474,7 @@ Deno.test('toModelProjectionBase - toEnrichmentDefaults returns the computed see
   }>(TsSnippet, {
     id: 'test-model',
     toIdentifierName: ({ refName }) => refName,
-    toIdentifierType: () => ({ kind: 'type' }),
+    toIdentifierType: () => ({ type: 'type' }),
     toExportPath: ({ refName }) => `./models/${refName}.ts`,
     toEnrichmentSchema: () =>
       v.object({

--- a/deno/core/dsl/model/toModelProjectionBase.ts
+++ b/deno/core/dsl/model/toModelProjectionBase.ts
@@ -7,7 +7,7 @@ import type {
 import { toModelGeneratorKey } from '@/dsl/GeneratorKeys.ts'
 import type { RefName } from '@/types/RefName.ts'
 import type { ContentSettings } from '@/dsl/ContentSettings.ts'
-import type { Lang, LangSnippetConstructor } from '@/dsl/Lang.ts'
+import type { LangSnippetConstructor } from '@/dsl/Lang.ts'
 import type { IdentifierType } from '@/dsl/IdentifierType.ts'
 import type { GeneratedValue } from '@/dsl/GeneratedValue.ts'
 import type { Inserted } from '@/dsl/Inserted.ts'
@@ -47,24 +47,27 @@ type ToEnrichmentsArgs = {
 /**
  * Configuration for {@link toModelProjectionBase}.
  *
- * Generic over the language `L`: a language veneer parameterizes this config
- * (`ModelProjectionBaseConfig<E, KtLang>`) so `toIdentifierType`'s return
- * tightens to that language's `IdentifierType<L>` — no recast. A bare
- * config (`L = Lang`) keeps the loose `kind: string` boundary.
+ * Generic over the identifier-type shape `IdType`: a language veneer
+ * parameterizes this config with its own `XxIdentifierType`
+ * (`ModelProjectionBaseConfig<E, KtIdentifierType>`) so `toIdentifierType`'s
+ * return tightens to that language's `type` vocabulary — no recast. The
+ * default keeps the loose `kind: string` boundary.
  */
-export type ModelProjectionBaseConfig<EnrichmentType = undefined, L extends Lang = Lang> = {
+export type ModelProjectionBaseConfig<
+  EnrichmentType = undefined,
+  IdType extends IdentifierType = IdentifierType
+> = {
   id: string
   /** Pure: the cache-key name (the cache-check path runs this). */
   toIdentifierName: (args: ToModelIdentifierNameArgs<EnrichmentType>) => string
   /**
    * Context-aware, overridable: the non-`name` parts of the identifier
-   * (`kind` / `typeName` / `exported`), derived from the schema. Runs only
-   * on cache-miss. Returns this language's `IdentifierType<L>` — the `kind`
-   * is bound to `L`'s `EntityKind` vocabulary (the loose `string` when
-   * `L = Lang`). The tightening rides the type argument, replacing the old
-   * veneer recast.
+   * (`type` / `typeName` / `exported`), derived from the schema. Runs only
+   * on cache-miss. Returns `IdType` — the veneer's `XxIdentifierType`, whose
+   * `type` is bound to that language's `EntityType` vocabulary (the loose
+   * `string` by default). The tightening rides the type argument.
    */
-  toIdentifierType: (refName: RefName, context: GenerateContextType) => IdentifierType<L>
+  toIdentifierType: (refName: RefName, context: GenerateContextType) => IdType
   toExportPath: (args: ToModelExportPathArgs<EnrichmentType>) => string
   /**
    * Required composite schema for the `{ subject, generator, stack }`
@@ -110,9 +113,12 @@ export type ModelProjectionBaseConfig<EnrichmentType = undefined, L extends Lang
  * The projection machinery previously hosted on `ModelProjectionBase` lives
  * here now, because the base class is no longer statically known.
  */
-export const toModelProjectionBase = <EnrichmentType = undefined, L extends Lang = Lang>(
-  base: LangSnippetConstructor<L>,
-  config: ModelProjectionBaseConfig<EnrichmentType, L>
+export const toModelProjectionBase = <
+  EnrichmentType = undefined,
+  IdType extends IdentifierType = IdentifierType
+>(
+  base: LangSnippetConstructor,
+  config: ModelProjectionBaseConfig<EnrichmentType, IdType>
 ) => {
   return class extends base {
     static id = config.id

--- a/deno/core/dsl/model/toModelProjectionBase.ts
+++ b/deno/core/dsl/model/toModelProjectionBase.ts
@@ -51,7 +51,7 @@ type ToEnrichmentsArgs = {
  * parameterizes this config with its own `XxIdentifierType`
  * (`ModelProjectionBaseConfig<E, KtIdentifierType>`) so `toIdentifierType`'s
  * return tightens to that language's `type` vocabulary — no recast. The
- * default keeps the loose `kind: string` boundary.
+ * default keeps the loose `type: string` boundary.
  */
 export type ModelProjectionBaseConfig<
   EnrichmentType = undefined,

--- a/deno/core/dsl/model/types.ts
+++ b/deno/core/dsl/model/types.ts
@@ -123,7 +123,7 @@ export type ModelProjection<V extends GeneratedValue, EnrichmentType = undefined
   toIdentifierName: (args: ToModelIdentifierNameArgs<EnrichmentType>) => string
   /**
    * Context-aware, overridable: the non-`name` parts of the identifier
-   * (`kind` / `typeName` / `exported`), derived from the schema. The engine
+   * (`type` / `typeName` / `exported`), derived from the schema. The engine
    * assembles `lang.toIdentifier({ name: toIdentifierName(args),
    * ...toIdentifierType(refName, context) })`.
    */

--- a/deno/core/dsl/operation/gql/GqlOperationDriver.test.ts
+++ b/deno/core/dsl/operation/gql/GqlOperationDriver.test.ts
@@ -103,7 +103,7 @@ const createMockProjection = (options?: {
     }
 
     static toIdentifierType(): IdentifierType {
-      return { kind: 'variable' }
+      return { type: 'variable' }
     }
 
     static toExportPath({ operation }: ToGqlOperationExportPathArgs): string {
@@ -517,7 +517,7 @@ Deno.test('GqlOperationDriver', async t => {
         static type = 'gqlOperation' as const
         static toIdentifierName = ({ operation }: ToGqlOperationIdentifierNameArgs) =>
           operation.fieldName
-        static toIdentifierType = (): IdentifierType => ({ kind: 'variable' })
+        static toIdentifierType = (): IdentifierType => ({ type: 'variable' })
         static toExportPath = (_args: ToGqlOperationExportPathArgs) => './test.ts'
         static toEnrichments = () => undefined
         static createIdentifier = (name: string) => createVariable(name)
@@ -664,7 +664,7 @@ Deno.test('GqlOperationDriver', async t => {
         static type = 'gqlOperation' as const
         static toIdentifierName = ({ operation }: ToGqlOperationIdentifierNameArgs) =>
           operation.fieldName
-        static toIdentifierType = (): IdentifierType => ({ kind: 'variable' })
+        static toIdentifierType = (): IdentifierType => ({ type: 'variable' })
         static toExportPath = (_args: ToGqlOperationExportPathArgs) => './test.ts'
         static toEnrichments = () => undefined
         static createIdentifier = (name: string) => createVariable(name)

--- a/deno/core/dsl/operation/gql/toGqlOperationProjectionBase.test.ts
+++ b/deno/core/dsl/operation/gql/toGqlOperationProjectionBase.test.ts
@@ -29,7 +29,7 @@ Deno.test('toGqlOperationProjectionBase - returns a class constructor', () => {
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -42,7 +42,7 @@ Deno.test('toGqlOperationProjectionBase - sets static id from config', () => {
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'graphql-operations',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -54,7 +54,7 @@ Deno.test('toGqlOperationProjectionBase - sets static type to operation', () => 
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -69,7 +69,7 @@ Deno.test('toGqlOperationProjectionBase - sets static toIdentifierName from conf
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: identifierNameFn,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -78,7 +78,7 @@ Deno.test('toGqlOperationProjectionBase - sets static toIdentifierName from conf
 
   const name = OperationClass.toIdentifierName({ operation: mockOperation, enrichments: { subject: undefined, generator: undefined, stack: undefined }, variant: 'main' })
   assertEquals(name, 'getUsers')
-  assertEquals(OperationClass.toIdentifierType(mockOperation, {} as GenerateContextType).kind, 'variable')
+  assertEquals(OperationClass.toIdentifierType(mockOperation, {} as GenerateContextType).type, 'variable')
 })
 
 Deno.test('toGqlOperationProjectionBase - sets static toExportPath from config', () => {
@@ -88,7 +88,7 @@ Deno.test('toGqlOperationProjectionBase - sets static toExportPath from config',
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: exportPathFn,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -108,7 +108,7 @@ Deno.test(
     const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
       id: 'test-operation',
       toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
       toEnrichmentSchema: () => emptyEnrichmentSchema
     })
@@ -131,7 +131,7 @@ Deno.test(
     const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
       id: 'test-operation',
       toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
       toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
       toEnrichmentSchema: () => emptyEnrichmentSchema
     })
@@ -152,7 +152,7 @@ Deno.test('toGqlOperationProjectionBase - toIdentifierName works with different 
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => `${operation.rootKind}${operation.fieldName}`,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -173,7 +173,7 @@ Deno.test('toGqlOperationProjectionBase - toExportPath works with different oper
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./types/${operation.rootKind}-${operation.fieldName}.d.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -192,7 +192,7 @@ Deno.test('toGqlOperationProjectionBase - constructor creates correct generatorK
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'graphql-client',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -220,7 +220,7 @@ Deno.test('toGqlOperationProjectionBase - instance is GqlOperationProjectionBase
   const OperationClass = toGqlOperationProjectionBase(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -254,7 +254,7 @@ Deno.test('toGqlOperationProjectionBase - toEnrichments validates with schema', 
   }>(TsSnippet, {
     id: 'graphql-client',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () =>
       v.object({
@@ -306,7 +306,7 @@ Deno.test('toGqlOperationProjectionBase - toEnrichments retrieves from correct n
   }>(TsSnippet, {
     id: 'graphql-api',
     toIdentifierName: ({ operation }) => operation.fieldName,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.fieldName}.ts`,
     toEnrichmentSchema: () =>
       v.object({

--- a/deno/core/dsl/operation/gql/toGqlOperationProjectionBase.ts
+++ b/deno/core/dsl/operation/gql/toGqlOperationProjectionBase.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/context/generateTypes.ts'
 import type { GqlOperation } from '@/gql/operation/GqlOperation.ts'
 import type { ContentSettings } from '@/dsl/ContentSettings.ts'
-import type { Lang, LangSnippetConstructor } from '@/dsl/Lang.ts'
+import type { LangSnippetConstructor } from '@/dsl/Lang.ts'
 import type { IdentifierType } from '@/dsl/IdentifierType.ts'
 import type { GeneratedValue } from '@/dsl/GeneratedValue.ts'
 import type { Inserted } from '@/dsl/Inserted.ts'
@@ -33,20 +33,21 @@ import { GENERATOR_ENRICHMENT_KEY, STACK_ENRICHMENT_KEY } from '@/types/Enrichme
  * Configuration for {@link toGqlOperationProjectionBase}.
  *
  * Generic over the language `L`: a language veneer parameterizes this config
- * (`GqlOperationProjectionBaseConfig<E, KtLang>`) so `toIdentifierType`'s
- * return tightens to that language's `IdentifierType<L>` — no recast.
+ * (`GqlOperationProjectionBaseConfig<E, KtIdentifierType>`) so
+ * `toIdentifierType`'s return tightens to that language's `type` vocabulary —
+ * no recast.
  */
-export type GqlOperationProjectionBaseConfig<EnrichmentType = undefined, L extends Lang = Lang> = {
+export type GqlOperationProjectionBaseConfig<EnrichmentType = undefined, IdType extends IdentifierType = IdentifierType> = {
   id: string
   /** Pure: the cache-key name (the cache-check path runs this). */
   toIdentifierName: (args: ToGqlOperationIdentifierNameArgs<EnrichmentType>) => string
   /**
    * Context-aware, overridable: the non-`name` parts of the identifier,
    * derived from the operation/schema. Runs only on cache-miss. Returns this
-   * language's `IdentifierType<L>` (the loose `kind: string` when `L = Lang`);
-   * the tightening rides the type argument, replacing the old veneer recast.
+   * language's `XxIdentifierType` (`IdType`; the loose `kind: string` by
+   * default); the tightening rides the type argument.
    */
-  toIdentifierType: (operation: GqlOperation, context: GenerateContextType) => IdentifierType<L>
+  toIdentifierType: (operation: GqlOperation, context: GenerateContextType) => IdType
   toExportPath: (args: ToGqlOperationExportPathArgs<EnrichmentType>) => string
   /**
    * Required composite schema for the `{ subject, generator, stack }`
@@ -92,9 +93,9 @@ type ToEnrichmentsArgs = {
  * `GqlOperationProjectionBase` lives here now, because the base class is no
  * longer statically known.
  */
-export const toGqlOperationProjectionBase = <EnrichmentType = undefined, L extends Lang = Lang>(
-  base: LangSnippetConstructor<L>,
-  config: GqlOperationProjectionBaseConfig<EnrichmentType, L>
+export const toGqlOperationProjectionBase = <EnrichmentType = undefined, IdType extends IdentifierType = IdentifierType>(
+  base: LangSnippetConstructor,
+  config: GqlOperationProjectionBaseConfig<EnrichmentType, IdType>
 ) => {
   return class extends base {
     static id = config.id

--- a/deno/core/dsl/operation/oas/OasOperationDriver.test.ts
+++ b/deno/core/dsl/operation/oas/OasOperationDriver.test.ts
@@ -101,7 +101,7 @@ const createMockProjection = (options?: {
     }
 
     static toIdentifierType(): IdentifierType {
-      return { kind: 'variable' }
+      return { type: 'variable' }
     }
 
     static toExportPath({ operation }: ToOasOperationExportPathArgs): string {
@@ -530,7 +530,7 @@ Deno.test('OasOperationDriver', async t => {
         static lang = typescript
         static toIdentifierName = ({ operation }: ToOasOperationIdentifierNameArgs) =>
           operation.operationId ?? 'op'
-        static toIdentifierType = (): IdentifierType => ({ kind: 'variable' })
+        static toIdentifierType = (): IdentifierType => ({ type: 'variable' })
         static toExportPath = (_args: ToOasOperationExportPathArgs) => './test.ts'
         static toEnrichments = () => undefined
         static createIdentifier = (name: string) => createVariable(name)
@@ -686,7 +686,7 @@ Deno.test('OasOperationDriver', async t => {
         static lang = typescript
         static toIdentifierName = ({ operation }: ToOasOperationIdentifierNameArgs) =>
           operation.operationId ?? 'op'
-        static toIdentifierType = (): IdentifierType => ({ kind: 'variable' })
+        static toIdentifierType = (): IdentifierType => ({ type: 'variable' })
         static toExportPath = (_args: ToOasOperationExportPathArgs) => './test.ts'
         static toEnrichments = () => undefined
         static createIdentifier = (name: string) => createVariable(name)

--- a/deno/core/dsl/operation/oas/toOasOperationProjectionBase.test.ts
+++ b/deno/core/dsl/operation/oas/toOasOperationProjectionBase.test.ts
@@ -27,7 +27,7 @@ Deno.test('toOasOperationProjectionBase - returns a class constructor', () => {
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -40,7 +40,7 @@ Deno.test('toOasOperationProjectionBase - sets static id from config', () => {
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'typescript-operations',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -52,7 +52,7 @@ Deno.test('toOasOperationProjectionBase - sets static type to operation', () => 
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -67,7 +67,7 @@ Deno.test('toOasOperationProjectionBase - sets static toIdentifierName from conf
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: identifierNameFn,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -82,7 +82,7 @@ Deno.test('toOasOperationProjectionBase - sets static toIdentifierName from conf
 
   const name = OperationClass.toIdentifierName({ operation: mockOperation, enrichments: emptyEnrichments, variant: 'main' })
   assertEquals(name, 'getUsers')
-  assertEquals(OperationClass.toIdentifierType(mockOperation, {} as GenerateContextType).kind, 'variable')
+  assertEquals(OperationClass.toIdentifierType(mockOperation, {} as GenerateContextType).type, 'variable')
 })
 
 Deno.test('toOasOperationProjectionBase - sets static toExportPath from config', () => {
@@ -92,7 +92,7 @@ Deno.test('toOasOperationProjectionBase - sets static toExportPath from config',
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: exportPathFn,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -113,7 +113,7 @@ Deno.test('toOasOperationProjectionBase - toEnrichments returns an all-undefined
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -139,7 +139,7 @@ Deno.test('toOasOperationProjectionBase - toEnrichments returns an all-undefined
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -165,7 +165,7 @@ Deno.test('toOasOperationProjectionBase - toIdentifierName works with different 
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => `${operation.method}${operation.operationId}`,
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -195,7 +195,7 @@ Deno.test('toOasOperationProjectionBase - toExportPath works with different oper
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./types/${operation.method}-${operation.operationId}.d.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -223,7 +223,7 @@ Deno.test('toOasOperationProjectionBase - constructor creates correct generatorK
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'api-client',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -257,7 +257,7 @@ Deno.test('toOasOperationProjectionBase - instance is OasOperationProjectionBase
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -294,7 +294,7 @@ Deno.test('toOasOperationProjectionBase - toEnrichments validates with schema', 
   }>(TsSnippet, {
     id: 'api-client',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () =>
       v.object({
@@ -354,7 +354,7 @@ Deno.test('toOasOperationProjectionBase - toEnrichments retrieves from correct n
   }>(TsSnippet, {
     id: 'rest-api',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () =>
       v.object({
@@ -404,7 +404,7 @@ Deno.test('toOasOperationProjectionBase - toEnrichmentDefaults returns undefined
   const OperationClass = toOasOperationProjectionBase<Enrichments>(TsSnippet, {
     id: 'test-operation',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () => emptyEnrichmentSchema
   })
@@ -434,7 +434,7 @@ Deno.test('toOasOperationProjectionBase - toEnrichmentDefaults returns the compu
   }>(TsSnippet, {
     id: 'forms',
     toIdentifierName: ({ operation }) => operation.operationId || 'operation',
-    toIdentifierType: () => ({ kind: 'variable' }),
+    toIdentifierType: () => ({ type: 'variable' }),
     toExportPath: ({ operation }) => `./operations/${operation.operationId}.ts`,
     toEnrichmentSchema: () =>
       v.object({

--- a/deno/core/dsl/operation/oas/toOasOperationProjectionBase.ts
+++ b/deno/core/dsl/operation/oas/toOasOperationProjectionBase.ts
@@ -8,7 +8,7 @@ import type {
 } from '@/context/generateTypes.ts'
 import type { OasOperation } from '@/oas/operation/Operation.ts'
 import type { ContentSettings } from '@/dsl/ContentSettings.ts'
-import type { Lang, LangSnippetConstructor } from '@/dsl/Lang.ts'
+import type { LangSnippetConstructor } from '@/dsl/Lang.ts'
 import type { IdentifierType } from '@/dsl/IdentifierType.ts'
 import type { GeneratedValue } from '@/dsl/GeneratedValue.ts'
 import type { Inserted } from '@/dsl/Inserted.ts'
@@ -33,20 +33,21 @@ import { GENERATOR_ENRICHMENT_KEY, STACK_ENRICHMENT_KEY } from '@/types/Enrichme
  * Configuration for {@link toOasOperationProjectionBase}.
  *
  * Generic over the language `L`: a language veneer parameterizes this config
- * (`OasOperationProjectionBaseConfig<E, KtLang>`) so `toIdentifierType`'s
- * return tightens to that language's `IdentifierType<L>` — no recast.
+ * (`OasOperationProjectionBaseConfig<E, KtIdentifierType>`) so
+ * `toIdentifierType`'s return tightens to that language's `type` vocabulary —
+ * no recast.
  */
-export type OasOperationProjectionBaseConfig<EnrichmentType = undefined, L extends Lang = Lang> = {
+export type OasOperationProjectionBaseConfig<EnrichmentType = undefined, IdType extends IdentifierType = IdentifierType> = {
   id: string
   /** Pure: the cache-key name (the cache-check path runs this). */
   toIdentifierName: (args: ToOasOperationIdentifierNameArgs<EnrichmentType>) => string
   /**
    * Context-aware, overridable: the non-`name` parts of the identifier,
    * derived from the operation/schema. Runs only on cache-miss. Returns this
-   * language's `IdentifierType<L>` (the loose `kind: string` when `L = Lang`);
-   * the tightening rides the type argument, replacing the old veneer recast.
+   * language's `XxIdentifierType` (`IdType`; the loose `kind: string` by
+   * default); the tightening rides the type argument.
    */
-  toIdentifierType: (operation: OasOperation, context: GenerateContextType) => IdentifierType<L>
+  toIdentifierType: (operation: OasOperation, context: GenerateContextType) => IdType
   toExportPath: (args: ToOasOperationExportPathArgs<EnrichmentType>) => string
   /**
    * Required composite schema for the `{ subject, generator, stack }`
@@ -101,9 +102,9 @@ type ToEnrichmentsArgs = {
  * `OasOperationProjectionBase` lives here now, because the base class is no
  * longer statically known.
  */
-export const toOasOperationProjectionBase = <EnrichmentType = undefined, L extends Lang = Lang>(
-  base: LangSnippetConstructor<L>,
-  config: OasOperationProjectionBaseConfig<EnrichmentType, L>
+export const toOasOperationProjectionBase = <EnrichmentType = undefined, IdType extends IdentifierType = IdentifierType>(
+  base: LangSnippetConstructor,
+  config: OasOperationProjectionBaseConfig<EnrichmentType, IdType>
 ) => {
   return class extends base {
     static id = config.id

--- a/deno/core/dsl/operation/oas/toOasOperationProjectionBase.ts
+++ b/deno/core/dsl/operation/oas/toOasOperationProjectionBase.ts
@@ -44,7 +44,7 @@ export type OasOperationProjectionBaseConfig<EnrichmentType = undefined, IdType 
   /**
    * Context-aware, overridable: the non-`name` parts of the identifier,
    * derived from the operation/schema. Runs only on cache-miss. Returns this
-   * language's `XxIdentifierType` (`IdType`; the loose `kind: string` by
+   * language's `XxIdentifierType` (`IdType`; the loose `type: string` by
    * default); the tightening rides the type argument.
    */
   toIdentifierType: (operation: OasOperation, context: GenerateContextType) => IdType

--- a/deno/core/dsl/webhook/WebhookDriver.test.ts
+++ b/deno/core/dsl/webhook/WebhookDriver.test.ts
@@ -117,7 +117,7 @@ const createMockProjection = (options?: {
     }
 
     static toIdentifierType(): IdentifierType {
-      return { kind: 'type' }
+      return { type: 'type' }
     }
 
     static toExportPath({ webhook }: ToWebhookExportPathArgs): string {
@@ -266,7 +266,7 @@ Deno.test('WebhookDriver', async t => {
       const importCall = registerSpy.calls.find(call => call.args[0].imports !== undefined)
       assertExists(importCall)
       assertEquals(importCall.args[0].imports[0].mergeKey(), './webhooks/newPet.ts')
-      // The handler identifier is `kind: 'type'`, so the import collapses to
+      // The handler identifier is `type: 'type'`, so the import collapses to
       // a statement-level `import type { … }` (the representative form for a
       // generator emitting `export type`).
       assertEquals(
@@ -358,7 +358,7 @@ Deno.test('WebhookDriver', async t => {
         static type = 'webhook' as const
         static lang = typescript
         static toIdentifierName = ({ webhook }: ToWebhookIdentifierNameArgs) => webhook.name
-        static toIdentifierType = (): IdentifierType => ({ kind: 'type' })
+        static toIdentifierType = (): IdentifierType => ({ type: 'type' })
         static toExportPath = (_args: ToWebhookExportPathArgs) => './test.ts'
         static toEnrichments = () => undefined
         static createIdentifier = (name: string) => createVariable(name)
@@ -434,7 +434,7 @@ Deno.test('WebhookDriver', async t => {
         static type = 'webhook' as const
         static lang = typescript
         static toIdentifierName = ({ webhook }: ToWebhookIdentifierNameArgs) => webhook.name
-        static toIdentifierType = (): IdentifierType => ({ kind: 'type' })
+        static toIdentifierType = (): IdentifierType => ({ type: 'type' })
         static toExportPath = (_args: ToWebhookExportPathArgs) => './test.ts'
         static toEnrichments = () => undefined
         static isSupported = () => true

--- a/deno/core/dsl/webhook/toWebhookProjectionBase.ts
+++ b/deno/core/dsl/webhook/toWebhookProjectionBase.ts
@@ -46,7 +46,7 @@ export type WebhookProjectionBaseConfig<EnrichmentType = undefined, IdType exten
   /**
    * Context-aware, overridable: the non-`name` parts of the identifier,
    * derived from the webhook. Runs only on cache-miss. Returns this
-   * language's `XxIdentifierType` (`IdType`; the loose `kind: string` by default).
+   * language's `XxIdentifierType` (`IdType`; the loose `type: string` by default).
    */
   toIdentifierType: (webhook: OasWebhook, context: GenerateContextType) => IdType
   toExportPath: (args: ToWebhookExportPathArgs<EnrichmentType>) => string

--- a/deno/core/dsl/webhook/toWebhookProjectionBase.ts
+++ b/deno/core/dsl/webhook/toWebhookProjectionBase.ts
@@ -9,7 +9,7 @@ import type {
 import type { OasWebhook } from '@/oas/webhook/Webhook.ts'
 import type { OasOperation } from '@/oas/operation/Operation.ts'
 import type { ContentSettings } from '@/dsl/ContentSettings.ts'
-import type { Lang, LangSnippetConstructor } from '@/dsl/Lang.ts'
+import type { LangSnippetConstructor } from '@/dsl/Lang.ts'
 import type { IdentifierType } from '@/dsl/IdentifierType.ts'
 import type { GeneratedValue } from '@/dsl/GeneratedValue.ts'
 import type { Inserted } from '@/dsl/Inserted.ts'
@@ -34,20 +34,21 @@ import { GENERATOR_ENRICHMENT_KEY, STACK_ENRICHMENT_KEY } from '@/types/Enrichme
  * Configuration for {@link toWebhookProjectionBase}.
  *
  * Sibling of `OasOperationProjectionBaseConfig` for the webhook subject.
- * Generic over the language `L`: a language veneer parameterizes this config
- * (`WebhookProjectionBaseConfig<E, KtLang>`) so `toIdentifierType`'s return
- * tightens to that language's `IdentifierType<L>` — no recast.
+ * Generic over the identifier-type shape `IdType`: a language veneer
+ * parameterizes this config with its own `XxIdentifierType`
+ * (`WebhookProjectionBaseConfig<E, KtIdentifierType>`) so `toIdentifierType`'s
+ * return tightens to that language's `type` vocabulary — no recast.
  */
-export type WebhookProjectionBaseConfig<EnrichmentType = undefined, L extends Lang = Lang> = {
+export type WebhookProjectionBaseConfig<EnrichmentType = undefined, IdType extends IdentifierType = IdentifierType> = {
   id: string
   /** Pure: the cache-key name (the cache-check path runs this). */
   toIdentifierName: (args: ToWebhookIdentifierNameArgs<EnrichmentType>) => string
   /**
    * Context-aware, overridable: the non-`name` parts of the identifier,
    * derived from the webhook. Runs only on cache-miss. Returns this
-   * language's `IdentifierType<L>` (the loose `kind: string` when `L = Lang`).
+   * language's `XxIdentifierType` (`IdType`; the loose `kind: string` by default).
    */
-  toIdentifierType: (webhook: OasWebhook, context: GenerateContextType) => IdentifierType<L>
+  toIdentifierType: (webhook: OasWebhook, context: GenerateContextType) => IdType
   toExportPath: (args: ToWebhookExportPathArgs<EnrichmentType>) => string
   /**
    * Required composite schema for the `{ subject, generator, stack }`
@@ -91,9 +92,9 @@ type ToEnrichmentsArgs = {
  * Defines NO `register` / `registerInto` — those live in the language
  * package's projection-base veneer over this factory.
  */
-export const toWebhookProjectionBase = <EnrichmentType = undefined, L extends Lang = Lang>(
-  base: LangSnippetConstructor<L>,
-  config: WebhookProjectionBaseConfig<EnrichmentType, L>
+export const toWebhookProjectionBase = <EnrichmentType = undefined, IdType extends IdentifierType = IdentifierType>(
+  base: LangSnippetConstructor,
+  config: WebhookProjectionBaseConfig<EnrichmentType, IdType>
 ) => {
   return class extends base {
     static id = config.id

--- a/deno/core/enrichments/toEnrichmentDescriptor.test.ts
+++ b/deno/core/enrichments/toEnrichmentDescriptor.test.ts
@@ -43,7 +43,7 @@ Deno.test('toEnrichmentFields — picklist becomes select with options', () => {
   ])
 })
 
-Deno.test('toEnrichmentFields — moduleExport identity-matches to module kind', () => {
+Deno.test('toEnrichmentFields — moduleExport identity-matches to module type', () => {
   const schema = v.object({ input: v.optional(moduleExport) })
   assertEquals(toEnrichmentFields(schema), [
     { key: 'input', label: 'Input', optional: true, type: 'module' }
@@ -113,7 +113,7 @@ Deno.test('toEnrichmentDescriptor — surfaces the subject scope of the umbrella
   }
   assertEquals(toEnrichmentDescriptor(entry), {
     generator: '@skmtc/gen-shadcn-form',
-    subjectKind: 'operation',
+    subjectType: 'operation',
     supportsVariant: false,
     fields: [
       {
@@ -139,13 +139,13 @@ Deno.test('toEnrichmentDescriptor — collapses gqlOperation to operation', () =
     })
   }
   const descriptor = toEnrichmentDescriptor(entry)
-  assertEquals(descriptor.subjectKind, 'operation')
+  assertEquals(descriptor.subjectType, 'operation')
 })
 
-Deno.test('toEnrichmentDescriptor — maps webhook to its own subject kind', () => {
+Deno.test('toEnrichmentDescriptor — maps webhook to its own subject type', () => {
   // A webhook generator (type 'webhook') resembles an operation but is a
   // distinct subject (addressed by webhook name, not request path), so its
-  // descriptor's subjectKind is 'webhook', not 'operation'.
+  // descriptor's subjectType is 'webhook', not 'operation'.
   const entry: EnrichmentSource = {
     id: '@skmtc/gen-ts-webhook',
     type: 'webhook',
@@ -157,7 +157,7 @@ Deno.test('toEnrichmentDescriptor — maps webhook to its own subject kind', () 
     })
   }
   const descriptor = toEnrichmentDescriptor(entry)
-  assertEquals(descriptor.subjectKind, 'webhook')
+  assertEquals(descriptor.subjectType, 'webhook')
 })
 
 Deno.test('toEnrichmentDescriptor — surfaces subject + generator scopes (model entry)', () => {
@@ -173,7 +173,7 @@ Deno.test('toEnrichmentDescriptor — surfaces subject + generator scopes (model
   }
   assertEquals(toEnrichmentDescriptor(entry), {
     generator: '@skmtc/gen-kotlin',
-    subjectKind: 'model',
+    subjectType: 'model',
     supportsVariant: false,
     fields: [
       {
@@ -203,7 +203,7 @@ Deno.test('toEnrichmentDescriptor — empty umbrella (emptyEnrichmentSchema) yie
   }
   assertEquals(toEnrichmentDescriptor(entry), {
     generator: '@skmtc/gen-typescript',
-    subjectKind: 'model',
+    subjectType: 'model',
     supportsVariant: false,
     fields: []
   })
@@ -217,7 +217,7 @@ Deno.test('toEnrichmentDescriptor — entry without toEnrichmentSchema yields em
   }
   assertEquals(toEnrichmentDescriptor(entry), {
     generator: '@skmtc/gen-bare',
-    subjectKind: 'operation',
+    subjectType: 'operation',
     supportsVariant: false,
     fields: []
   })
@@ -262,7 +262,7 @@ Deno.test('toEnrichmentDescriptor — gen-shadcn-form realistic subject leaf', (
   const descriptor = toEnrichmentDescriptor(entry)
 
   assertEquals(descriptor.generator, '@skmtc/gen-shadcn-form')
-  assertEquals(descriptor.subjectKind, 'operation')
+  assertEquals(descriptor.subjectType, 'operation')
   // The umbrella surfaces a single `subject` scope; the form leaf is nested.
   assertEquals(descriptor.fields.length, 1)
   const subject = descriptor.fields[0]

--- a/deno/core/enrichments/toEnrichmentDescriptor.ts
+++ b/deno/core/enrichments/toEnrichmentDescriptor.ts
@@ -36,7 +36,7 @@ export type EnrichmentField = {
    * For `type: 'array'` — a one-element list describing the item shape.
    * If the item is an object, the synthesised field carries the nested
    * `fields`; if it is a primitive, the synthesised field carries the
-   * appropriate primitive kind. The single-element convention matches
+   * appropriate primitive type. The single-element convention matches
    * the contract's `EnrichmentField[]` shape.
    */
   item?: EnrichmentField[]
@@ -44,8 +44,8 @@ export type EnrichmentField = {
   fields?: EnrichmentField[]
 }
 
-/** Which subject kind a generator enriches — operations, webhooks, or models. */
-export type SubjectKind = 'operation' | 'model' | 'webhook'
+/** Which subject type a generator enriches — operations, webhooks, or models. */
+export type SubjectType = 'operation' | 'model' | 'webhook'
 
 /**
  * A generator's enrichment schema, projected for the CMS. The same
@@ -54,7 +54,7 @@ export type SubjectKind = 'operation' | 'model' | 'webhook'
  */
 export type EnrichmentDescriptor = {
   generator: string
-  subjectKind: SubjectKind
+  subjectType: SubjectType
   /**
    * Whether this generator's entry declares variant support
    * (`supportsVariant: () => true`). The CMS reads it to decide whether to
@@ -220,7 +220,7 @@ const walkEntries = (entries: Record<string, v.GenericSchema>): EnrichmentField[
  * umbrella yields `[]`.
  *
  * Generally callers should prefer {@link toEnrichmentDescriptor}, which
- * takes a generator entry and fills in `generator` / `subjectKind`
+ * takes a generator entry and fills in `generator` / `subjectType`
  * automatically. This lower-level entry point is useful in tests and
  * when only the field shape is needed.
  */
@@ -231,7 +231,7 @@ export const toEnrichmentFields = (schema: v.GenericSchema | undefined): Enrichm
   return walkEntries(inner.entries)
 }
 
-const toSubjectKind = (entryType: EnrichmentSource['type']): SubjectKind => {
+const toSubjectType = (entryType: EnrichmentSource['type']): SubjectType => {
   switch (entryType) {
     case 'model':
       return 'model'
@@ -240,7 +240,7 @@ const toSubjectKind = (entryType: EnrichmentSource['type']): SubjectKind => {
       return 'operation'
     // A webhook resembles an operation (a path-item keyed by HTTP method) but
     // is a DISTINCT subject: it is addressed by webhook name, not request path,
-    // and has no request URL. It is its own SubjectKind so the editor and the
+    // and has no request URL. It is its own SubjectType so the editor and the
     // hub treat it truthfully rather than conflating it with an operation.
     case 'webhook':
       return 'webhook'
@@ -255,7 +255,7 @@ const toSubjectKind = (entryType: EnrichmentSource['type']): SubjectKind => {
  * Project a generator entry's enrichment schema into a serialisable
  * `EnrichmentDescriptor` the CMS can render as a form. The entry's
  * `id` becomes `descriptor.generator`; its `type` discriminator maps
- * to `subjectKind` (`'oasOperation' | 'gqlOperation'` → `'operation'`;
+ * to `subjectType` (`'oasOperation' | 'gqlOperation'` → `'operation'`;
  * `'webhook'` → `'webhook'`; `'model'` → `'model'`). If the entry has no
  * `toEnrichmentSchema`, or
  * declares the empty umbrella, the descriptor has an empty `fields`
@@ -271,7 +271,7 @@ const toSubjectKind = (entryType: EnrichmentSource['type']): SubjectKind => {
  */
 export const toEnrichmentDescriptor = (entry: EnrichmentSource): EnrichmentDescriptor => ({
   generator: entry.id,
-  subjectKind: toSubjectKind(entry.type),
+  subjectType: toSubjectType(entry.type),
   supportsVariant: entry.supportsVariant(),
   fields: toEnrichmentFields(entry.toEnrichmentSchema?.())
 })

--- a/deno/core/enrichments/validateConfig.test.ts
+++ b/deno/core/enrichments/validateConfig.test.ts
@@ -74,7 +74,7 @@ Deno.test('validateConfig — model routing tags refName + variant, no method', 
 
 Deno.test('validateConfig — a model whose only variant is non-main is NOT mis-walked as an operation', () => {
   // The retired `'main' in value` heuristic would misclassify this (no `main`
-  // key) as an operation and drop it. With kind-driven routing it validates
+  // key) as an operation and drop it. With type-driven routing it validates
   // correctly as a model subject.
   const enrichments = {
     'gen-zod': { Customer: { coercive: { coerce: 'nope' } } }

--- a/deno/core/enrichments/validateConfig.ts
+++ b/deno/core/enrichments/validateConfig.ts
@@ -21,7 +21,7 @@ export type EnrichmentValidationScope = 'subject' | 'generator' | 'stack'
  *
  *  - **operation subject** — `subject` = path, `method` = HTTP method
  *  - **model subject** — `subject` = refName (no `method`)
- *  - **gql operation subject** — `subject` = field name, `method` = root kind
+ *  - **gql operation subject** — `subject` = field name, `method` = root type
  *  - **generator** run-constant — `scope: 'generator'` (no subject routing)
  *  - **stack** run-constant — `scope: 'stack'` (no subject routing)
  *
@@ -54,7 +54,7 @@ const fieldPath = (
         .join('.')
     : undefined
 
-/** Routing identity for one subject leaf, derived from the generator kind. */
+/** Routing identity for one subject leaf, derived from the generator type. */
 type SubjectLeaf = {
   subject: string
   method?: string
@@ -64,10 +64,10 @@ type SubjectLeaf = {
 
 /**
  * Collect every `{ subject, method?, variant, values }` leaf from a
- * generator's enrichment slot, walking the routing depth its **kind**
+ * generator's enrichment slot, walking the routing depth its **type**
  * dictates — model (`refName → variant`), oas operation
  * (`path → method → variant`), gql operation
- * (`rootKind → fieldName → variant`). Because the kind is read from the
+ * (`rootKind → fieldName → variant`). Because the type is read from the
  * generator entry, operation-vs-model is known authoritatively — there is
  * no `'main' in value` shape-guessing. Reserved keys (`_generator`) are
  * skipped; malformed nodes are skipped (they surface elsewhere, never here

--- a/deno/core/oas/union/Union.test.ts
+++ b/deno/core/oas/union/Union.test.ts
@@ -78,7 +78,7 @@ Deno.test('OasUnion', async (t) => {
 
     await t.step('should handle discriminator for tagged unions', () => {
       const discriminator = new OasDiscriminator({
-        propertyName: 'kind',
+        propertyName: 'type',
         mapping: {
           'typeA': '#/components/schemas/TypeA',
           'typeB': '#/components/schemas/TypeB',
@@ -91,7 +91,7 @@ Deno.test('OasUnion', async (t) => {
       })
 
       assertEquals(union.discriminator, discriminator)
-      assertEquals(union.discriminator?.propertyName, 'kind')
+      assertEquals(union.discriminator?.propertyName, 'type')
       assertEquals(union.discriminator?.mapping?.['typeA'], '#/components/schemas/TypeA')
     })
 
@@ -195,7 +195,7 @@ Deno.test('OasUnion', async (t) => {
 
     await t.step('should maintain all properties after resolve', () => {
       const discriminator = new OasDiscriminator({
-        propertyName: 'kind',
+        propertyName: 'type',
         mapping: { 'a': '#/a', 'b': '#/b' },
       })
 
@@ -505,7 +505,7 @@ Deno.test('OasUnion', async (t) => {
 
     await t.step('should handle discriminator with mapping', () => {
       const discriminator = new OasDiscriminator({
-        propertyName: 'kind',
+        propertyName: 'type',
         mapping: {
           'user': '#/components/schemas/User',
           'admin': '#/components/schemas/Admin',
@@ -518,7 +518,7 @@ Deno.test('OasUnion', async (t) => {
         members: [new OasObject(), new OasObject(), new OasObject()],
       })
 
-      assertEquals(union.discriminator?.propertyName, 'kind')
+      assertEquals(union.discriminator?.propertyName, 'type')
       assertEquals(union.discriminator?.mapping?.['user'], '#/components/schemas/User')
       assertEquals(union.discriminator?.mapping?.['admin'], '#/components/schemas/Admin')
       assertEquals(union.discriminator?.mapping?.['guest'], '#/components/schemas/Guest')

--- a/deno/core/parse/v3-0/_merge-all-of/decompose-union.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/decompose-union.test.ts
@@ -70,15 +70,15 @@ Deno.test('decomposeUnion - discriminator and default are excluded onto the wrap
   const result = decomposeUnion({
     schema: {
       oneOf: [{ $ref: '#/components/schemas/Dog' }, { $ref: '#/components/schemas/Cat' }],
-      discriminator: { propertyName: 'kind' },
-      default: { kind: 'dog' }
+      discriminator: { propertyName: 'type' },
+      default: { type: 'dog' }
     },
     groupType: 'oneOf'
   })
 
   assertEquals(result.afterExcluded, {
-    discriminator: { propertyName: 'kind' },
-    default: { kind: 'dog' }
+    discriminator: { propertyName: 'type' },
+    default: { type: 'dog' }
   })
   assertEquals(result.decomposed, [
     { oneOf: [{ $ref: '#/components/schemas/Dog' }, { $ref: '#/components/schemas/Cat' }] }

--- a/deno/core/parse/v3-0/_merge-all-of/merge-intersection.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge-intersection.test.ts
@@ -918,9 +918,9 @@ Deno.test("mergeAllOf - simpler allOf", () => {
       },
       {
         type: "object",
-        required: ["kind"],
+        required: ["type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["symlink"],
           },
@@ -931,9 +931,9 @@ Deno.test("mergeAllOf - simpler allOf", () => {
 
   const expected: SchemaObject = {
     type: "object",
-    required: ["target", "kind"],
+    required: ["target", "type"],
     properties: {
-      kind: {
+      type: {
         type: "string",
         enum: ["symlink"],
       },

--- a/deno/core/parse/v3-0/_merge-all-of/merge-union.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge-union.test.ts
@@ -60,9 +60,9 @@ const input: SchemaObject = {
         },
         {
           type: "object",
-          required: ["kind"],
+          required: ["type"],
           properties: {
-            kind: {
+            type: {
               type: "string",
               enum: ["file"],
             },
@@ -77,9 +77,9 @@ const input: SchemaObject = {
         },
         {
           type: "object",
-          required: ["kind"],
+          required: ["type"],
           properties: {
-            kind: {
+            type: {
               type: "string",
               enum: ["symlink"],
             },
@@ -89,7 +89,7 @@ const input: SchemaObject = {
     },
   ],
   discriminator: {
-    propertyName: "kind",
+    propertyName: "type",
   },
 };
 
@@ -97,7 +97,7 @@ const expected: SchemaObject = {
   oneOf: [
     {
       type: "object",
-      required: ["content", "kind"],
+      required: ["content", "type"],
       properties: {
         content: {
           type: "string",
@@ -105,7 +105,7 @@ const expected: SchemaObject = {
         encoding: {
           $ref: "#/components/schemas/Encoding",
         },
-        kind: {
+        type: {
           type: "string",
           enum: ["file"],
         },
@@ -113,12 +113,12 @@ const expected: SchemaObject = {
     },
     {
       type: "object",
-      required: ["gitSha1", "kind"],
+      required: ["gitSha1", "type"],
       properties: {
         gitSha1: {
           type: "string",
         },
-        kind: {
+        type: {
           type: "string",
           enum: ["file"],
         },
@@ -126,12 +126,12 @@ const expected: SchemaObject = {
     },
     {
       type: "object",
-      required: ["target", "kind"],
+      required: ["target", "type"],
       properties: {
         target: {
           type: "string",
         },
-        kind: {
+        type: {
           type: "string",
           enum: ["symlink"],
         },
@@ -140,7 +140,7 @@ const expected: SchemaObject = {
     },
   ],
   discriminator: {
-    propertyName: "kind",
+    propertyName: "type",
   },
 };
 

--- a/deno/core/parse/v3-0/_merge-all-of/with-complex-one-of.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/with-complex-one-of.test.ts
@@ -60,9 +60,9 @@ Deno.test("mergeAllOf - complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["kind"],
+        required: ["type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -75,9 +75,9 @@ Deno.test("mergeAllOf - complex oneOf", () => {
     oneOf: [
       {
         type: "object",
-        required: ["content", "kind"],
+        required: ["content", "type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -91,9 +91,9 @@ Deno.test("mergeAllOf - complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["gitSha1", "kind"],
+        required: ["gitSha1", "type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -120,9 +120,9 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
           },
           {
             type: "object",
-            required: ["kind"],
+            required: ["type"],
             properties: {
-              kind: {
+              type: {
                 type: "string",
                 enum: ["file"],
               },
@@ -137,9 +137,9 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
           },
           {
             type: "object",
-            required: ["kind"],
+            required: ["type"],
             properties: {
-              kind: {
+              type: {
                 type: "string",
                 enum: ["symlink"],
               },
@@ -149,7 +149,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
     ],
     discriminator: {
-      propertyName: "kind",
+      propertyName: "type",
     },
   };
 
@@ -157,7 +157,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
     oneOf: [
       {
         type: "object",
-        required: ["content", "kind"],
+        required: ["content", "type"],
         properties: {
           content: {
             type: "string",
@@ -165,7 +165,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
           encoding: {
             $ref: "#/components/schemas/Encoding",
           },
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -173,12 +173,12 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["gitSha1", "kind"],
+        required: ["gitSha1", "type"],
         properties: {
           gitSha1: {
             type: "string",
           },
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -186,12 +186,12 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["target", "kind"],
+        required: ["target", "type"],
         properties: {
           target: {
             type: "string",
           },
-          kind: {
+          type: {
             type: "string",
             enum: ["symlink"],
           },
@@ -200,7 +200,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
     ],
     discriminator: {
-      propertyName: "kind",
+      propertyName: "type",
     },
   };
 

--- a/deno/core/parse/v3-0/discriminator/toDiscriminatorV3.test.ts
+++ b/deno/core/parse/v3-0/discriminator/toDiscriminatorV3.test.ts
@@ -124,7 +124,7 @@ Deno.test('toDiscriminatorV3', async (t) => {
         'typeB': '#/components/schemas/TypeB',
       }
       const discriminator: OpenAPIV3.DiscriminatorObject = {
-        propertyName: 'kind',
+        propertyName: 'type',
         mapping,
       }
       const result = toDiscriminatorV3({
@@ -249,7 +249,7 @@ Deno.test('toDiscriminatorV3', async (t) => {
   await t.step('field preservation', async (t) => {
     await t.step('should correctly extract propertyName field', () => {
       const stackTrail = new StackTrail(['TEST'])
-      const propertyNames = ['type', 'kind', 'discriminatorField', '@type', 'object_type']
+      const propertyNames = ['type', 'type', 'discriminatorField', '@type', 'object_type']
 
       propertyNames.forEach((name) => {
         const discriminator: OpenAPIV3.DiscriminatorObject = {

--- a/deno/core/parse/v3-1/_merge-all-of/merge-intersection.test.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/merge-intersection.test.ts
@@ -918,9 +918,9 @@ Deno.test("mergeAllOf - simpler allOf", () => {
       },
       {
         type: "object",
-        required: ["kind"],
+        required: ["type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["symlink"],
           },
@@ -931,9 +931,9 @@ Deno.test("mergeAllOf - simpler allOf", () => {
 
   const expected: SchemaObject = {
     type: "object",
-    required: ["target", "kind"],
+    required: ["target", "type"],
     properties: {
-      kind: {
+      type: {
         type: "string",
         enum: ["symlink"],
       },

--- a/deno/core/parse/v3-1/_merge-all-of/merge-union.test.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/merge-union.test.ts
@@ -60,9 +60,9 @@ const input: SchemaObject = {
         },
         {
           type: "object",
-          required: ["kind"],
+          required: ["type"],
           properties: {
-            kind: {
+            type: {
               type: "string",
               enum: ["file"],
             },
@@ -77,9 +77,9 @@ const input: SchemaObject = {
         },
         {
           type: "object",
-          required: ["kind"],
+          required: ["type"],
           properties: {
-            kind: {
+            type: {
               type: "string",
               enum: ["symlink"],
             },
@@ -89,7 +89,7 @@ const input: SchemaObject = {
     },
   ],
   discriminator: {
-    propertyName: "kind",
+    propertyName: "type",
   },
 };
 
@@ -97,7 +97,7 @@ const expected: SchemaObject = {
   oneOf: [
     {
       type: "object",
-      required: ["content", "kind"],
+      required: ["content", "type"],
       properties: {
         content: {
           type: "string",
@@ -105,7 +105,7 @@ const expected: SchemaObject = {
         encoding: {
           $ref: "#/components/schemas/Encoding",
         },
-        kind: {
+        type: {
           type: "string",
           enum: ["file"],
         },
@@ -113,12 +113,12 @@ const expected: SchemaObject = {
     },
     {
       type: "object",
-      required: ["gitSha1", "kind"],
+      required: ["gitSha1", "type"],
       properties: {
         gitSha1: {
           type: "string",
         },
-        kind: {
+        type: {
           type: "string",
           enum: ["file"],
         },
@@ -126,12 +126,12 @@ const expected: SchemaObject = {
     },
     {
       type: "object",
-      required: ["target", "kind"],
+      required: ["target", "type"],
       properties: {
         target: {
           type: "string",
         },
-        kind: {
+        type: {
           type: "string",
           enum: ["symlink"],
         },
@@ -140,7 +140,7 @@ const expected: SchemaObject = {
     },
   ],
   discriminator: {
-    propertyName: "kind",
+    propertyName: "type",
   },
 };
 

--- a/deno/core/parse/v3-1/_merge-all-of/with-complex-one-of.test.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/with-complex-one-of.test.ts
@@ -60,9 +60,9 @@ Deno.test("mergeAllOf - complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["kind"],
+        required: ["type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -75,9 +75,9 @@ Deno.test("mergeAllOf - complex oneOf", () => {
     oneOf: [
       {
         type: "object",
-        required: ["content", "kind"],
+        required: ["content", "type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -91,9 +91,9 @@ Deno.test("mergeAllOf - complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["gitSha1", "kind"],
+        required: ["gitSha1", "type"],
         properties: {
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -120,9 +120,9 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
           },
           {
             type: "object",
-            required: ["kind"],
+            required: ["type"],
             properties: {
-              kind: {
+              type: {
                 type: "string",
                 enum: ["file"],
               },
@@ -137,9 +137,9 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
           },
           {
             type: "object",
-            required: ["kind"],
+            required: ["type"],
             properties: {
-              kind: {
+              type: {
                 type: "string",
                 enum: ["symlink"],
               },
@@ -149,7 +149,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
     ],
     discriminator: {
-      propertyName: "kind",
+      propertyName: "type",
     },
   };
 
@@ -157,7 +157,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
     oneOf: [
       {
         type: "object",
-        required: ["content", "kind"],
+        required: ["content", "type"],
         properties: {
           content: {
             type: "string",
@@ -165,7 +165,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
           encoding: {
             $ref: "#/components/schemas/Encoding",
           },
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -173,12 +173,12 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["gitSha1", "kind"],
+        required: ["gitSha1", "type"],
         properties: {
           gitSha1: {
             type: "string",
           },
-          kind: {
+          type: {
             type: "string",
             enum: ["file"],
           },
@@ -186,12 +186,12 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
       {
         type: "object",
-        required: ["target", "kind"],
+        required: ["target", "type"],
         properties: {
           target: {
             type: "string",
           },
-          kind: {
+          type: {
             type: "string",
             enum: ["symlink"],
           },
@@ -200,7 +200,7 @@ Deno.test("mergeAllOf - even more complex oneOf", () => {
       },
     ],
     discriminator: {
-      propertyName: "kind",
+      propertyName: "type",
     },
   };
 

--- a/deno/core/parse/v3-1/discriminator/toDiscriminatorV3.test.ts
+++ b/deno/core/parse/v3-1/discriminator/toDiscriminatorV3.test.ts
@@ -124,7 +124,7 @@ Deno.test('toDiscriminatorV3', async (t) => {
         'typeB': '#/components/schemas/TypeB',
       }
       const discriminator: OpenAPIV3.DiscriminatorObject = {
-        propertyName: 'kind',
+        propertyName: 'type',
         mapping,
       }
       const result = toDiscriminatorV3({
@@ -249,7 +249,7 @@ Deno.test('toDiscriminatorV3', async (t) => {
   await t.step('field preservation', async (t) => {
     await t.step('should correctly extract propertyName field', () => {
       const stackTrail = new StackTrail(['TEST'])
-      const propertyNames = ['type', 'kind', 'discriminatorField', '@type', 'object_type']
+      const propertyNames = ['type', 'type', 'discriminatorField', '@type', 'object_type']
 
       propertyNames.forEach((name) => {
         const discriminator: OpenAPIV3.DiscriminatorObject = {

--- a/deno/core/run/toArtifacts.attribution.test.ts
+++ b/deno/core/run/toArtifacts.attribution.test.ts
@@ -20,7 +20,7 @@ import type { OpenAPIV3 } from 'openapi-types'
 const ModelBase = toTsModelProjectionBase({
   id: '@test/gen-model',
   toIdentifierName: ({ refName }) => refName,
-  toIdentifierType: () => ({ kind: 'type' }),
+  toIdentifierType: () => ({ type: 'type' }),
   toExportPath: ({ refName }) => `@/types/${refName}.generated.ts`,
   toEnrichmentSchema: () => emptyEnrichmentSchema
 })

--- a/deno/core/run/toArtifacts.attribution.test.ts
+++ b/deno/core/run/toArtifacts.attribution.test.ts
@@ -179,7 +179,7 @@ Deno.test('toArtifacts - generatorMeta lookup flows through to sidecar entries',
         schemaSrc: 'openapi.json',
         generatorMeta: (genId) => ({
           version: genId === '@test/gen-model' ? '1.2.3' : '',
-          registry: { host: 'jsr.skmtc.dev', kind: 'jsr-private' }
+          registry: { host: 'jsr.skmtc.dev', type: 'jsr-private' }
         })
       }
     }
@@ -191,5 +191,5 @@ Deno.test('toArtifacts - generatorMeta lookup flows through to sidecar entries',
   const ourGen = sidecar.G.find(g => g.name === '@test/gen-model')
   assert(ourGen !== undefined)
   assertEquals(ourGen!.version, '1.2.3')
-  assertEquals(sidecar.R[ourGen!.r], { host: 'jsr.skmtc.dev', kind: 'jsr-private' })
+  assertEquals(sidecar.R[ourGen!.r], { host: 'jsr.skmtc.dev', type: 'jsr-private' })
 })

--- a/deno/core/run/toArtifacts.regression.test.ts
+++ b/deno/core/run/toArtifacts.regression.test.ts
@@ -57,7 +57,7 @@ const variantEnrichmentSchema = v.object({
 const HookBase = toTsOasOperationProjectionBase({
   id: '@test/hook-gen',
   toIdentifierName: () => 'usePatchQuote',
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
   toExportPath: () => '@/hooks/usePatchQuote.generated.ts',
   toEnrichmentSchema: () => emptyEnrichmentSchema
 })
@@ -75,7 +75,7 @@ class HookProjection extends HookBase {
 const FormBase = toTsOasOperationProjectionBase({
   id: '@test/form-gen',
   toIdentifierName: ({ variant }) => withVariant('PatchQuoteForm', variant),
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
   toExportPath: ({ variant }) =>
     `@/forms/${withVariant('PatchQuoteForm', variant)}.generated.tsx`,
   toEnrichmentSchema: () => variantEnrichmentSchema

--- a/deno/core/test/MockFile.ts
+++ b/deno/core/test/MockFile.ts
@@ -24,7 +24,7 @@ export class MockDefinition<V extends GeneratedValue = GeneratedValue> extends D
  * A neutral {@link CodeFileBase} for core tests — a stand-in for a
  * `@skmtc/lang-*` package's file so core tests exercise engine, render, and
  * capture behavior WITHOUT naming a concrete lang File class. Bound to the
- * bare {@link Lang} (opaque-`string` kind), since the mock has no declaration
+ * bare {@link Lang} (opaque-`string` type), since the mock has no declaration
  * vocabulary; tests filter by name or list all, never by `type`.
  *
  * Lang-specific dedup/merge/render policy is tested in each lang package; this

--- a/deno/core/test/MockFile.ts
+++ b/deno/core/test/MockFile.ts
@@ -3,7 +3,6 @@ import { DefinitionBase } from '@/dsl/Definition.ts'
 import type { FindDefinitionsQuery } from '@/dsl/CodeFileBase.ts'
 import type { GeneratedValue } from '@/dsl/GeneratedValue.ts'
 import type { ImportBase } from '@/dsl/ImportBase.ts'
-import type { Lang } from '@/dsl/Lang.ts'
 import type { ReExportBase } from '@/dsl/ReExportBase.ts'
 
 /**
@@ -32,7 +31,7 @@ export class MockDefinition<V extends GeneratedValue = GeneratedValue> extends D
  * mock keeps the simplest neutral behavior (name-keyed definitions, per-module
  * import/re-export merge, definitions joined by blank lines).
  */
-export class MockFile extends CodeFileBase<Lang> {
+export class MockFile extends CodeFileBase {
   definitions: Map<string, DefinitionBase> = new Map()
   imports: Map<string, ImportBase> = new Map()
   reExports: Map<string, ReExportBase> = new Map()
@@ -63,7 +62,7 @@ export class MockFile extends CodeFileBase<Lang> {
     }
   }
 
-  override findDefinitions(query?: FindDefinitionsQuery<Lang>): DefinitionBase[] | undefined {
+  override findDefinitions(query?: FindDefinitionsQuery): DefinitionBase[] | undefined {
     return matchDefinitions([...this.definitions.values()], query, () => undefined)
   }
 

--- a/deno/core/types/Enrichments.ts
+++ b/deno/core/types/Enrichments.ts
@@ -7,7 +7,7 @@
  *   - **Models** are keyed by name (component schema name in OAS;
  *     registry-named type in GraphQL).
  *   - **OAS operations** are keyed by HTTP path → method.
- *   - **GraphQL operations** are keyed by root kind → field name.
+ *   - **GraphQL operations** are keyed by root type → field name.
  *
  * The leaf at the bottom of each hierarchy is opaque to core — its
  * shape is owned by the generator that consumes it. Each generator
@@ -78,7 +78,7 @@ export const oasOperationEnrichments: v.GenericSchema<OasOperationEnrichments> =
  * Structurally identical to {@link OasOperationEnrichments} — an OpenAPI 3.1
  * webhook is a path-item keyed by method, the same shape as an operation — but
  * named distinctly so a webhook generator's slot reads as webhook-scoped (the
- * `webhook` subject kind) rather than operation-scoped. The leaf is opaque to
+ * `webhook` subject type) rather than operation-scoped. The leaf is opaque to
  * core.
  */
 export type OasWebhookEnrichments = Record<string, EnrichmentLeaf>
@@ -109,7 +109,7 @@ export const gqlFieldEnrichments: v.GenericSchema<GqlFieldEnrichments> = v.recor
 )
 
 /**
- * GraphQL root-kind enrichments: `query` / `mutation` / `subscription`
+ * GraphQL root-type enrichments: `query` / `mutation` / `subscription`
  * → field enrichments.
  */
 export type GqlRootKindEnrichments = Record<string, GqlFieldEnrichments>
@@ -150,7 +150,7 @@ export const isReservedEnrichmentKey = (key: string): boolean => key.startsWith(
  * Top-level enrichments: generator id → hierarchy, plus the reserved
  * `_stack` key (stack-scoped leaf). Each generator's slot is one of
  * three structurally-distinct hierarchies depending on the generator's
- * entry kind:
+ * entry type:
  *  - `ModelEnrichments` for `toModelEntry`
  *  - `OasPathEnrichments` for `toOasOperationEntry`
  *  - `GqlRootKindEnrichments` for `toGqlOperationEntry`

--- a/deno/core/types/SchemaPath.ts
+++ b/deno/core/types/SchemaPath.ts
@@ -12,7 +12,7 @@ export type SchemaPath = string[]
  * Canonical Valibot schema for an `SchemaPath`. Generators should
  * import this rather than write `v.array(v.string())` inline — the
  * descriptor walker identity-matches the exported value and emits a
- * schema-aware path-picker widget (`kind: "schemaPath"`) instead of
+ * schema-aware path-picker widget (`type: "schemaPath"`) instead of
  * a generic array of strings.
  */
 export const schemaPath: v.GenericSchema<SchemaPath> = v.array(v.string())

--- a/deno/core/types/SkmtcDocument.ts
+++ b/deno/core/types/SkmtcDocument.ts
@@ -62,7 +62,7 @@ export const toGqlParsedDocument = (value: GqlDocument): SkmtcParsedDocument => 
 /**
  * Discriminated union representing a *raw* source document accepted by
  * `CoreContext.toArtifacts`. This is the public input shape — callers
- * supply the schema as the protocol-specific source kind, and the
+ * supply the schema as the protocol-specific source type, and the
  * pipeline runs the protocol-appropriate parser before handing the
  * post-parse {@link SkmtcParsedDocument} to the generate phase.
  *

--- a/deno/core/types/SupportedSubjects.ts
+++ b/deno/core/types/SupportedSubjects.ts
@@ -17,7 +17,7 @@ export type SupportedWebhook = { name: string; method: string }
 /** A supported GraphQL operation. */
 export type SupportedGqlOperation = { rootKind: string; fieldName: string }
 
-/** What one generator supports, discriminated by its subject kind. */
+/** What one generator supports, discriminated by its subject type. */
 export type GeneratorSupport =
   | { type: 'oasOperation'; operations: SupportedOasOperation[] }
   | { type: 'webhook'; webhooks: SupportedWebhook[] }

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -16,10 +16,10 @@
  *      `declares no 'lang'`) are banned across the doc surfaces; a
  *      mention is allowed only on a line that marks it as historical
  *      ("no longer", "deleted", "superseded", …).
- *   3. LANG-KOTLIN SOURCE↔SKILL SYNC — the kind vocabulary count, the
+ *   3. LANG-KOTLIN SOURCE↔SKILL SYNC — the type vocabulary count, the
  *      identifier-factory names, and the value-protocol exports in
  *      `lang-kotlin` source must all appear in the skmtc-lang-kotlin
- *      skill (catches "six-kind" wording and missing-protocol drift).
+ *      skill (catches "six-type" wording and missing-protocol drift).
  *
  *   exit 0 — all checks hold.
  *   exit 1 — one or more failed; each failure names file + expectation.
@@ -221,7 +221,7 @@ for (const { packageDirectory, skillName, guardPrefix } of languageSyncTargets) 
         `(${packageDirectory} exports ${factoryNames.length} identifier factories: ${factoryNames.join(', ')})`
     )
   } else {
-    pass(`${packageDirectory} kind vocabulary: skill says "${kindWord} entity kinds" matching ${factoryNames.length} factories`)
+    pass(`${packageDirectory} type vocabulary: skill says "${kindWord} entity kinds" matching ${factoryNames.length} factories`)
   }
 
   for (const factory of factoryNames) {

--- a/deno/gen-ts-webhook/src/base.ts
+++ b/deno/gen-ts-webhook/src/base.ts
@@ -7,7 +7,7 @@ import denoJson from '../deno.json' with { type: 'json' }
 /**
  * Projection base for the TypeScript webhook-handler generator.
  *
- * Identifier: `<PascalName>WebhookHandler`, emitted as `export type` (kind
+ * Identifier: `<PascalName>WebhookHandler`, emitted as `export type` (type
  * `'type'`). Export path: `@/webhooks/<PascalName>.generated.ts`. No
  * enrichments (emptyEnrichmentSchema).
  */
@@ -16,7 +16,7 @@ export const WebhookHandlerBase = toTsWebhookProjectionBase({
   toIdentifierName({ webhook }) {
     return `${toPascalCase(webhook.name)}WebhookHandler`
   },
-  toIdentifierType: () => ({ kind: 'type' }),
+  toIdentifierType: () => ({ type: 'type' }),
   toExportPath({ webhook }) {
     return join('@', 'webhooks', `${toPascalCase(webhook.name)}.generated.ts`)
   },

--- a/deno/lang-csharp/mod.ts
+++ b/deno/lang-csharp/mod.ts
@@ -6,7 +6,7 @@
  *
  * Contents (arc spec: ../../notes/lang/31-csharp-kickoff.md → CS-A
  * binding spec):
- *   - the naming layer: `CsEntityKind` (`record` / `enum` at CS-A) with
+ *   - the naming layer: `CsEntityType` (`record` / `enum` at CS-A) with
  *     spelled-out identifier factories, `sanitizePropertyName` (the `@`
  *     verbatim-identifier escape), `toNamespaceName` (export path →
  *     dotted namespace), enum member naming with full-set dedup
@@ -47,9 +47,9 @@ export {
   createInterface,
   createRecord,
   toCsKeyword,
-  toCsEntityKind,
+  toCsEntityType,
   type CreateCsIdentifierArgs,
-  type CsEntityKind
+  type CsEntityType
 } from './src/createIdentifier.ts'
 export {
   CsIdentifier,
@@ -87,7 +87,7 @@ export { isCsDocumented, type CsDocumented } from './src/CsDocumented.ts'
 export { isCsBased, type CsBased } from './src/CsBased.ts'
 export { withDescription, type WithDescriptionArgs } from './src/withDescription.ts'
 
-export { csharp, type CsLang } from './src/csLang.ts'
+export { csharp } from './src/csLang.ts'
 export { CsSnippet } from './src/CsSnippet.ts'
 export {
   register,

--- a/deno/lang-csharp/src/CsDefinition.ts
+++ b/deno/lang-csharp/src/CsDefinition.ts
@@ -24,11 +24,11 @@ export type CsDefinitionArgs<Value extends GeneratedValue> = {
 /**
  * C#'s concrete {@link DefinitionBase}: assembles the declaration shell
  * around the generated value, dispatching on the identifier's opaque
- * `kind` — exhaustive over this language's vocabulary, throwing outside
+ * `type` — exhaustive over this language's vocabulary, throwing outside
  * it (no silent fallback; {@link toCsKeyword} is the single source for
  * both the throw and the keyword chain).
  *
- * | kind | shell |
+ * | type | shell |
  * |---|---|
  * | `record` | `sealed partial record Name[ : A, B]\n{\n…\n}` (bodyless collapse to `…Name[ : A, B];` when the value renders empty) |
  * | `abstract-record` | `abstract partial record Name[ : A, B]\n{\n…\n}` (same bodyless collapse — the polymorphic parent is normally bodyless) |
@@ -64,7 +64,7 @@ export class CsDefinition<Value extends GeneratedValue = GeneratedValue> extends
 
   override toString(): string {
     // The engine holds the identifier as the neutral `IdentifierBase`;
-    // narrow to `CsIdentifier` cast-free to read the typed `kind`.
+    // narrow to `CsIdentifier` cast-free to read the typed `type`.
     const identifier = this.identifier
     invariant(
       isCsIdentifier(identifier),
@@ -88,17 +88,17 @@ export class CsDefinition<Value extends GeneratedValue = GeneratedValue> extends
   }
 
   private toShell(identifier: CsIdentifier): string {
-    const { name, kind } = identifier
+    const { name, type } = identifier
 
-    const keyword = toCsKeyword(kind)
+    const keyword = toCsKeyword(type)
 
-    switch (kind) {
+    switch (type) {
       case 'record':
       case 'abstract-record':
       case 'class':
       case 'interface': {
         const constructorClause =
-          kind === 'class' && isCsConstructed(this.value)
+          type === 'class' && isCsConstructed(this.value)
             ? `(${this.value.constructorParameters})`
             : ''
         const clause =
@@ -114,7 +114,7 @@ export class CsDefinition<Value extends GeneratedValue = GeneratedValue> extends
       case 'enum':
         return `${keyword} ${name}\n{\n${this.value}\n}`
       default:
-        throw new Error(`Unknown C# entity kind: ${kind}`)
+        throw new Error(`Unknown C# entity type: ${type}`)
     }
   }
 }

--- a/deno/lang-csharp/src/CsFile.ts
+++ b/deno/lang-csharp/src/CsFile.ts
@@ -3,12 +3,11 @@ import type {
   ClientSettings,
   DefinitionBase,
   ImportBase,
-  ReExportBase,
-  FindDefinitionsQuery
+  ReExportBase
 } from '@skmtc/core'
 import { CsImport } from './CsImport.ts'
 import { CsIdentifier } from './CsIdentifier.ts'
-import type { CsLang } from './csLang.ts'
+import type { CsEntityType } from './createIdentifier.ts'
 import { toNamespaceName } from './toNamespaceName.ts'
 
 /**
@@ -52,7 +51,7 @@ export type CsFileArgs = {
  * and the Driver never registers them — so rendering ignores the
  * (always empty) neutral map.
  */
-export class CsFile extends CodeFileBase<CsLang> {
+export class CsFile extends CodeFileBase {
   /** The namespace this file declares — derived from `path`; `''` is the global namespace (no directive rendered). */
   namespaceName: string
   /** Held for the multi-package (`settings.packages`) story; unused in v1. */
@@ -96,12 +95,12 @@ export class CsFile extends CodeFileBase<CsLang> {
   }
 
   override findDefinitions(
-    query?: FindDefinitionsQuery<CsLang>
+    query?: { name?: string; type?: CsEntityType }
   ): DefinitionBase[] | undefined {
     return matchDefinitions(
       [...this.definitions.values()],
       query,
-      identifier => (identifier instanceof CsIdentifier ? identifier.kind : undefined)
+      identifier => (identifier instanceof CsIdentifier ? identifier.type : undefined)
     )
   }
 

--- a/deno/lang-csharp/src/CsIdentifier.ts
+++ b/deno/lang-csharp/src/CsIdentifier.ts
@@ -1,49 +1,48 @@
 import { IdentifierBase } from '@skmtc/core'
 import type { IdentifierBaseArgs, IdentifierType } from '@skmtc/core'
-import type { CsEntityKind } from './createIdentifier.ts'
-import type { CsLang } from './csLang.ts'
+import type { CsEntityType } from './createIdentifier.ts'
 
 /**
- * The non-`name` parts of a C# identifier — the tightened
- * `IdentifierType` a C# projection's `toIdentifierType` returns. Core's
- * `IdentifierType<CsLang>` recovers the `kind` from {@link CsLang}'s
- * identifier ({@link CsEntityKind}); this alias is the named form generators
- * annotate with. The engine spreads it into
+ * The non-`name` parts of a C# identifier — core's neutral
+ * {@link IdentifierType} with its `type` narrowed to C#'s fixed
+ * {@link CsEntityType} vocabulary. This is the named form generators annotate
+ * `toIdentifierType` with; a projection-base veneer threads it as the config's
+ * `IdType` so the return tightens with no recast. The engine spreads it into
  * `lang.toIdentifier({ name, ...identifierType })`.
  */
-export type CsIdentifierType = IdentifierType<CsLang>
+export type CsIdentifierType = IdentifierType & { type: CsEntityType }
 
 /**
  * Constructor arguments for {@link CsIdentifier} — the neutral
- * {@link IdentifierBaseArgs} plus this language's typed `kind`.
+ * {@link IdentifierBaseArgs} plus this language's typed `type`.
  */
 export type CsIdentifierArgs = IdentifierBaseArgs & {
-  kind: CsEntityKind
+  type: CsEntityType
 }
 
 /**
- * C#'s concrete {@link IdentifierBase}: adds the typed `kind`
- * ({@link CsEntityKind}) the renderer reads to pick its declaration shell
+ * C#'s concrete {@link IdentifierBase}: adds the typed `type`
+ * ({@link CsEntityType}) the renderer reads to pick its declaration shell
  * (`sealed partial record` / `abstract partial record` / `enum` /
  * `sealed partial class` / `interface`).
  *
  * The engine holds it as the neutral `IdentifierBase` (reading only
  * `.name`); `CsDefinition` narrows back to `CsIdentifier` via
- * {@link isCsIdentifier} to read `kind`.
+ * {@link isCsIdentifier} to read `type`.
  */
 export class CsIdentifier extends IdentifierBase {
-  /** Per-language declaration kind — drives the declaration shell. */
-  kind: CsEntityKind
+  /** Per-language declaration type — drives the declaration shell. */
+  type: CsEntityType
 
-  constructor({ name, typeName, exported, kind }: CsIdentifierArgs) {
+  constructor({ name, typeName, exported, type }: CsIdentifierArgs) {
     super({ name, typeName, exported })
-    this.kind = kind
+    this.type = type
   }
 }
 
 /**
  * Type guard narrowing a neutral {@link IdentifierBase} to a
- * {@link CsIdentifier} — the cast-free way the renderer reads `kind`.
+ * {@link CsIdentifier} — the cast-free way the renderer reads `type`.
  */
 export const isCsIdentifier = (identifier: IdentifierBase): identifier is CsIdentifier => {
   return identifier instanceof CsIdentifier

--- a/deno/lang-csharp/src/CsImport.ts
+++ b/deno/lang-csharp/src/CsImport.ts
@@ -71,7 +71,7 @@ export class CsImport extends ImportBase {
   /**
    * Build the import of a single {@link IdentifierBase} from `module` — the
    * cross-file import a Driver registers when a generator references a
-   * peer's Definition. The identifier's `kind` is ignored: every C#
+   * peer's Definition. The identifier's `type` is ignored: every C#
    * using has the same form, so the neutral `IdentifierBase` (which the
    * engine holds) is all that's needed — no narrowing.
    */

--- a/deno/lang-csharp/src/CsSnippet.ts
+++ b/deno/lang-csharp/src/CsSnippet.ts
@@ -1,5 +1,5 @@
-import { SnippetBase, type GeneratedValue } from '@skmtc/core'
-import { csharp, type CsLang } from './csLang.ts'
+import { SnippetBase, type GeneratedValue, type Lang } from '@skmtc/core'
+import { csharp } from './csLang.ts'
 import {
   register,
   defineAndRegister,
@@ -29,12 +29,11 @@ import type { CsDefinition } from './CsDefinition.ts'
  */
 export class CsSnippet extends SnippetBase {
   /**
-   * The language every class built on this base renders into. Typed
-   * {@link CsLang} (not the loose `Lang`) so a projection-base veneer
-   * inferring `L` from `base: CsSnippet` lands on `CsLang` — the tightening
-   * that lets `toIdentifierType` return `IdentifierType<CsLang>`.
+   * The language every class built on this base renders into. The neutral
+   * {@link Lang} — the engine reads it language-blind; C#'s fixed `type`
+   * vocabulary lives on this package's concrete types, not here.
    */
-  static lang: CsLang = csharp
+  static lang: Lang = csharp
 
   /**
    * Register imports / definitions into the file at `destinationPath`,

--- a/deno/lang-csharp/src/createIdentifier.test.ts
+++ b/deno/lang-csharp/src/createIdentifier.test.ts
@@ -6,26 +6,26 @@ import {
   toCsKeyword
 } from './createIdentifier.ts'
 
-Deno.test('createRecord writes the record kind', () => {
+Deno.test('createRecord writes the record type', () => {
   const identifier = createRecord('User')
 
   assertEquals(identifier.name, 'User')
-  assertEquals(identifier.kind, 'record')
+  assertEquals(identifier.type, 'record')
   assertEquals(identifier.exported, true)
 })
 
-Deno.test('createAbstractRecord writes the abstract-record kind', () => {
+Deno.test('createAbstractRecord writes the abstract-record type', () => {
   const identifier = createAbstractRecord('Animal')
 
   assertEquals(identifier.name, 'Animal')
-  assertEquals(identifier.kind, 'abstract-record')
+  assertEquals(identifier.type, 'abstract-record')
 })
 
-Deno.test('createEnum writes the enum kind', () => {
+Deno.test('createEnum writes the enum type', () => {
   const identifier = createEnum('Status')
 
   assertEquals(identifier.name, 'Status')
-  assertEquals(identifier.kind, 'enum')
+  assertEquals(identifier.type, 'enum')
 })
 
 Deno.test('factories honor exported: false (renders internal downstream)', () => {
@@ -34,7 +34,7 @@ Deno.test('factories honor exported: false (renders internal downstream)', () =>
   assertEquals(identifier.exported, false)
 })
 
-Deno.test('toCsKeyword maps the vocabulary with the D3/D14/CC3 modifiers riding the kind', () => {
+Deno.test('toCsKeyword maps the vocabulary with the D3/D14/CC3 modifiers riding the type', () => {
   assertEquals(toCsKeyword('record'), 'sealed partial record')
   assertEquals(toCsKeyword('abstract-record'), 'abstract partial record')
   assertEquals(toCsKeyword('enum'), 'enum')
@@ -43,13 +43,13 @@ Deno.test('toCsKeyword maps the vocabulary with the D3/D14/CC3 modifiers riding 
 })
 
 Deno.test('toCsKeyword throws outside the vocabulary (foreign-language identifier; no alias/val kinds — the distinctive constraint)', () => {
-  assertThrows(() => toCsKeyword('variable'), Error, 'Unknown C# entity kind: variable')
-  assertThrows(() => toCsKeyword('data-class'), Error, 'Unknown C# entity kind: data-class')
-  assertThrows(() => toCsKeyword('typealias'), Error, 'Unknown C# entity kind')
-  assertThrows(() => toCsKeyword('val'), Error, 'Unknown C# entity kind')
+  assertThrows(() => toCsKeyword('variable'), Error, 'Unknown C# entity type: variable')
+  assertThrows(() => toCsKeyword('data-class'), Error, 'Unknown C# entity type: data-class')
+  assertThrows(() => toCsKeyword('typealias'), Error, 'Unknown C# entity type')
+  assertThrows(() => toCsKeyword('val'), Error, 'Unknown C# entity type')
 })
 
-Deno.test('toCsKeyword has no alias kind and no file-scope-value kind (the distinctive constraint)', () => {
-  assertThrows(() => toCsKeyword('typealias'), Error, 'Unknown C# entity kind')
-  assertThrows(() => toCsKeyword('val'), Error, 'Unknown C# entity kind')
+Deno.test('toCsKeyword has no alias type and no file-scope-value type (the distinctive constraint)', () => {
+  assertThrows(() => toCsKeyword('typealias'), Error, 'Unknown C# entity type')
+  assertThrows(() => toCsKeyword('val'), Error, 'Unknown C# entity type')
 })

--- a/deno/lang-csharp/src/createIdentifier.ts
+++ b/deno/lang-csharp/src/createIdentifier.ts
@@ -1,7 +1,7 @@
 import { CsIdentifier } from './CsIdentifier.ts'
 
 /**
- * C#'s declaration-kind vocabulary — the typed `kind` this package writes
+ * C#'s declaration-type vocabulary — the typed `type` this package writes
  * onto its {@link CsIdentifier} and the discriminator its renderers
  * narrow against.
  *
@@ -19,15 +19,15 @@ import { CsIdentifier } from './CsIdentifier.ts'
  * - `'interface'` — an `interface IName { … }` declaration (CS-C: the
  *   service seam the consumer implements).
  *
- * Deliberately NO alias kind (C# has no exported type alias — `using X
- * = …` is file-scoped, D6) and NO `val`-analog kind: C#'s distinctive
+ * Deliberately NO alias type (C# has no exported type alias — `using X
+ * = …` is file-scoped, D6) and NO `val`-analog type: C#'s distinctive
  * constraint is *types only at namespace scope*. {@link toCsKeyword}
  * throwing on anything else is that constraint's test.
  *
- * Unlike TypeScript, the kind does NOT drive import form — every C#
+ * Unlike TypeScript, the type does NOT drive import form — every C#
  * using is namespace-level. It drives only the declaration shell.
  */
-export type CsEntityKind = 'record' | 'abstract-record' | 'enum' | 'class' | 'interface'
+export type CsEntityType = 'record' | 'abstract-record' | 'enum' | 'class' | 'interface'
 
 /**
  * Options shared by the identifier factories — every field optional, so
@@ -48,7 +48,7 @@ export type CreateCsIdentifierArgs = {
  * ```
  */
 export const createRecord = (name: string, args: CreateCsIdentifierArgs = {}): CsIdentifier => {
-  return new CsIdentifier({ name, exported: args.exported, kind: 'record' })
+  return new CsIdentifier({ name, exported: args.exported, type: 'record' })
 }
 
 /**
@@ -64,7 +64,7 @@ export const createAbstractRecord = (
   name: string,
   args: CreateCsIdentifierArgs = {}
 ): CsIdentifier => {
-  return new CsIdentifier({ name, exported: args.exported, kind: 'abstract-record' })
+  return new CsIdentifier({ name, exported: args.exported, type: 'abstract-record' })
 }
 
 /**
@@ -77,7 +77,7 @@ export const createAbstractRecord = (
  * ```
  */
 export const createEnum = (name: string, args: CreateCsIdentifierArgs = {}): CsIdentifier => {
-  return new CsIdentifier({ name, exported: args.exported, kind: 'enum' })
+  return new CsIdentifier({ name, exported: args.exported, type: 'enum' })
 }
 
 /**
@@ -90,7 +90,7 @@ export const createEnum = (name: string, args: CreateCsIdentifierArgs = {}): CsI
  * ```
  */
 export const createClass = (name: string, args: CreateCsIdentifierArgs = {}): CsIdentifier => {
-  return new CsIdentifier({ name, exported: args.exported, kind: 'class' })
+  return new CsIdentifier({ name, exported: args.exported, type: 'class' })
 }
 
 /**
@@ -103,24 +103,24 @@ export const createClass = (name: string, args: CreateCsIdentifierArgs = {}): Cs
  * ```
  */
 export const createInterface = (name: string, args: CreateCsIdentifierArgs = {}): CsIdentifier => {
-  return new CsIdentifier({ name, exported: args.exported, kind: 'interface' })
+  return new CsIdentifier({ name, exported: args.exported, type: 'interface' })
 }
 
 /**
- * Maps an identifier's opaque `kind` to its C# declaration keyword
+ * Maps an identifier's opaque `type` to its C# declaration keyword
  * chain. The D3 modifiers ride the mapping — `'record'` renders `sealed
  * partial record`, so "sealed by default, partial always" is a property
- * of the kind, not a flag (the CS-B `abstract-record` becomes a distinct
- * kind rendering `abstract partial record`, not a toggle).
+ * of the type, not a flag (the CS-B `abstract-record` becomes a distinct
+ * type rendering `abstract partial record`, not a toggle).
  *
- * Throws on a kind outside this language's vocabulary — a loud signal
- * that an identifier built for another language (or with a typo'd kind)
+ * Throws on a type outside this language's vocabulary — a loud signal
+ * that an identifier built for another language (or with a typo'd type)
  * reached the C# renderer. This throw is also the
  * types-only-at-namespace-scope distinctive-constraint test: there is no
- * alias kind and no file-scope-value kind to map.
+ * alias type and no file-scope-value type to map.
  */
-export const toCsKeyword = (kind: string): string => {
-  switch (kind) {
+export const toCsKeyword = (type: string): string => {
+  switch (type) {
     case 'record':
       return 'sealed partial record'
     case 'abstract-record':
@@ -132,18 +132,18 @@ export const toCsKeyword = (kind: string): string => {
     case 'interface':
       return 'interface'
     default:
-      throw new Error(`Unknown C# entity kind: ${kind}`)
+      throw new Error(`Unknown C# entity type: ${type}`)
   }
 }
 
 /**
- * Narrow the engine's opaque `kind: string` (from `Lang.toIdentifier`'s
- * neutral args) to this language's {@link CsEntityKind} — cast-free, via a
- * validating switch. Throws on a kind outside the vocabulary, the same loud
+ * Narrow the engine's opaque `type: string` (from `Lang.toIdentifier`'s
+ * neutral args) to this language's {@link CsEntityType} — cast-free, via a
+ * validating switch. Throws on a type outside the vocabulary, the same loud
  * signal {@link toCsKeyword} gives.
  */
-export const toCsEntityKind = (kind: string): CsEntityKind => {
-  switch (kind) {
+export const toCsEntityType = (type: string): CsEntityType => {
+  switch (type) {
     case 'record':
       return 'record'
     case 'abstract-record':
@@ -155,6 +155,6 @@ export const toCsEntityKind = (kind: string): CsEntityKind => {
     case 'interface':
       return 'interface'
     default:
-      throw new Error(`Unknown C# entity kind: ${kind}`)
+      throw new Error(`Unknown C# entity type: ${type}`)
   }
 }

--- a/deno/lang-csharp/src/csLang.ts
+++ b/deno/lang-csharp/src/csLang.ts
@@ -3,16 +3,7 @@ import { CsFile } from './CsFile.ts'
 import { CsDefinition } from './CsDefinition.ts'
 import { CsImport } from './CsImport.ts'
 import { CsIdentifier } from './CsIdentifier.ts'
-import { toCsEntityKind } from './createIdentifier.ts'
-
-/**
- * The C# {@link Lang}, specialized to this language's concrete
- * {@link CsIdentifier}. Threaded as the `L` type argument through the
- * projection-base veneers so core's config tightens `toIdentifierType`'s
- * return to {@link import('./CsIdentifier.ts').CsIdentifierType} (the `kind`
- * bound to `CsEntityKind`) with no recast.
- */
-export type CsLang = Lang<CsIdentifier>
+import { toCsEntityType } from './createIdentifier.ts'
 
 /**
  * The C# {@link Lang} — carried as the static `lang` on
@@ -22,7 +13,7 @@ export type CsLang = Lang<CsIdentifier>
  * site. The engine reaches C# only through these neutral factories;
  * it never names `CsFile` / `CsDefinition` / `CsImport` itself.
  */
-export const csharp: CsLang = {
+export const csharp: Lang = {
   createFile: ({ path, settings }) => new CsFile({ path, settings }),
 
   toDefinition: ({ context, identifier, value, noExport, description }) =>
@@ -34,8 +25,8 @@ export const csharp: CsLang = {
   toImport: ({ identifier, module }) => CsImport.fromIdentifier(module, identifier),
 
   // The engine's identifier-assembly seam: `name` from `toIdentifierName`,
-  // the rest spread from `toIdentifierType`. Narrows the opaque `kind`
-  // string to this language's typed `CsEntityKind`.
-  toIdentifier: ({ name, kind, typeName, exported }) =>
-    new CsIdentifier({ name, typeName, exported, kind: toCsEntityKind(kind) })
+  // the rest spread from `toIdentifierType`. Narrows the opaque `type`
+  // string to this language's typed `CsEntityType`.
+  toIdentifier: ({ name, type, typeName, exported }) =>
+    new CsIdentifier({ name, typeName, exported, type: toCsEntityType(type) })
 }

--- a/deno/lang-csharp/src/option2.csharp.test.ts
+++ b/deno/lang-csharp/src/option2.csharp.test.ts
@@ -78,7 +78,7 @@ class SpikeField extends CsSnippet {
 const SpikeModelBase = toCsModelProjectionBase({
   id: '@spike/gen-csharp-option2',
   toIdentifierName: ({ refName }) => `${refName}Spike`,
-  toIdentifierType: () => ({ kind: 'record' }),
+  toIdentifierType: () => ({ type: 'record' }),
   toExportPath: () => '@/Spike/Models/Models.generated.cs',
   toEnrichmentSchema: () => emptyEnrichmentSchema
 })

--- a/deno/lang-csharp/src/toCsModelProjectionBase.ts
+++ b/deno/lang-csharp/src/toCsModelProjectionBase.ts
@@ -2,7 +2,7 @@ import { toModelProjectionBase } from '@skmtc/core'
 import type { ModelProjectionBaseConfig } from '@skmtc/core'
 import { CsSnippet } from './CsSnippet.ts'
 import { register, type CsRegisterArgs } from './register.ts'
-import type { CsLang } from './csLang.ts'
+import type { CsIdentifierType } from './CsIdentifier.ts'
 
 /**
  * Build a C# model projection base class.
@@ -22,8 +22,8 @@ import type { CsLang } from './csLang.ts'
  * result).
  *
  * The config is core's `ModelProjectionBaseConfig` parameterized over
- * {@link CsLang} (so `toIdentifierType` returns `IdentifierType<CsLang>` — the
- * `kind` bound to `CsEntityKind`). The base is the factory's first argument,
+ * {@link CsIdentifierType} (so `toIdentifierType`'s return tightens to the
+ * `type` bound to `CsEntityType`). The base is the factory's first argument,
  * not a config field.
  *
  * Operation veneers (`toOasOperationProjectionBase`,
@@ -32,7 +32,7 @@ import type { CsLang } from './csLang.ts'
  * the Kotlin precedent.
  */
 export const toCsModelProjectionBase = <EnrichmentType = undefined>(
-  config: ModelProjectionBaseConfig<EnrichmentType, CsLang>
+  config: ModelProjectionBaseConfig<EnrichmentType, CsIdentifierType>
 ) => {
   return class extends toModelProjectionBase(CsSnippet, config) {
     /**

--- a/deno/lang-go/mod.ts
+++ b/deno/lang-go/mod.ts
@@ -10,7 +10,7 @@
  *     subclasses of the abstract bases in `@skmtc/core` — each renders
  *     itself in its own `toString()`
  *   - the `register` family (`register`, `defineAndRegister`)
- *   - this language's `EntityKind` vocabulary
+ *   - this language's `EntityType` vocabulary
  *   - `sanitizePropertyName` + identifier/casing/visibility rules
  *   - syntax helpers
  *
@@ -27,5 +27,5 @@ export const fileExtensions = ['.go'] as const
 
 export { GoFile, type GoFileArgs } from './src/GoFile.ts'
 export { GoDefinition } from './src/GoDefinition.ts'
-export { GoIdentifier, isGoIdentifier, type GoEntityKind } from './src/GoIdentifier.ts'
+export { GoIdentifier, isGoIdentifier, type GoEntityType } from './src/GoIdentifier.ts'
 export { GoStruct, type GoFieldArgs } from './src/GoStruct.ts'

--- a/deno/lang-go/src/GoFile.ts
+++ b/deno/lang-go/src/GoFile.ts
@@ -1,6 +1,7 @@
 import { CodeFileBase, matchDefinitions } from '@skmtc/core'
-import type { DefinitionBase, ImportBase, ReExportBase, Lang, FindDefinitionsQuery } from '@skmtc/core'
+import type { DefinitionBase, ImportBase, ReExportBase } from '@skmtc/core'
 import { GoIdentifier } from './GoIdentifier.ts'
+import type { GoEntityType } from './GoIdentifier.ts'
 
 /** Constructor arguments for {@link GoFile}. */
 export type GoFileArgs = {
@@ -22,7 +23,7 @@ export type GoFileArgs = {
  * but not yet wired (no Go generator registers imports). `use`-style
  * imports land as the seam matures.
  */
-export class GoFile extends CodeFileBase<Lang<GoIdentifier>> {
+export class GoFile extends CodeFileBase {
   packageName: string
 
   /** Definitions keyed by identifier name (first write wins). */
@@ -48,12 +49,12 @@ export class GoFile extends CodeFileBase<Lang<GoIdentifier>> {
   }
 
   override findDefinitions(
-    query?: FindDefinitionsQuery<Lang<GoIdentifier>>
+    query?: { name?: string; type?: GoEntityType }
   ): DefinitionBase[] | undefined {
     return matchDefinitions(
       [...this.definitions.values()],
       query,
-      identifier => (identifier instanceof GoIdentifier ? identifier.kind : undefined)
+      identifier => (identifier instanceof GoIdentifier ? identifier.type : undefined)
     )
   }
 

--- a/deno/lang-go/src/GoIdentifier.ts
+++ b/deno/lang-go/src/GoIdentifier.ts
@@ -2,36 +2,36 @@ import { IdentifierBase } from '@skmtc/core'
 import type { IdentifierBaseArgs } from '@skmtc/core'
 
 /**
- * Go's declaration-kind vocabulary. Go declares every named type with the
+ * Go's declaration-type vocabulary. Go declares every named type with the
  * uniform `type` keyword, so the vocabulary is a single member — but
  * {@link GoIdentifier} still carries it for symmetry with the other
  * languages (and {@link GoDefinition} reads only the neutral base fields,
- * never `kind`).
+ * never `type`).
  */
-export type GoEntityKind = 'type'
+export type GoEntityType = 'type'
 
 /**
  * Constructor arguments for {@link GoIdentifier} — the neutral
- * {@link IdentifierBaseArgs} plus this language's typed `kind`.
+ * {@link IdentifierBaseArgs} plus this language's typed `type`.
  */
 export type GoIdentifierArgs = IdentifierBaseArgs & {
-  kind: GoEntityKind
+  type: GoEntityType
 }
 
 /**
- * Go's concrete {@link IdentifierBase}: carries the typed `kind`
- * ({@link GoEntityKind}) for symmetry with the other language subclasses.
+ * Go's concrete {@link IdentifierBase}: carries the typed `type`
+ * ({@link GoEntityType}) for symmetry with the other language subclasses.
  * {@link GoDefinition} reads only the neutral `.name`/`.exported` fields —
- * Go's uniform `type` keyword needs no discriminant — so `kind` is here for
+ * Go's uniform `type` keyword needs no discriminant — so `type` is here for
  * shape parity, not for rendering.
  */
 export class GoIdentifier extends IdentifierBase {
-  /** Per-language declaration kind — uniform `type` for Go. */
-  kind: GoEntityKind
+  /** Per-language declaration type — uniform `type` for Go. */
+  type: GoEntityType
 
-  constructor({ name, typeName, exported, kind }: GoIdentifierArgs) {
+  constructor({ name, typeName, exported, type }: GoIdentifierArgs) {
     super({ name, typeName, exported })
-    this.kind = kind
+    this.type = type
   }
 }
 

--- a/deno/lang-go/src/render.test.ts
+++ b/deno/lang-go/src/render.test.ts
@@ -11,7 +11,7 @@ const context = {} as unknown as GenerateContextType
 Deno.test('GoDefinition + GoStruct render the User DTO as a struct', () => {
   const definition = new GoDefinition({
     context,
-    identifier: new GoIdentifier({ name: 'User', kind: 'type' }),
+    identifier: new GoIdentifier({ name: 'User', type: 'type' }),
     value: new GoStruct([
       { name: 'id', type: 'string' },
       { name: 'name', type: 'string' },
@@ -48,7 +48,7 @@ Deno.test('GoDefinition casing follows Identifier.exported, not input name casin
   // Exported intent + lowercase input → Go capitalizes it.
   const exported = new GoDefinition({
     context,
-    identifier: new GoIdentifier({ name: 'user', exported: true, kind: 'type' }),
+    identifier: new GoIdentifier({ name: 'user', exported: true, type: 'type' }),
     value: new GoStruct([{ name: 'id', type: 'string' }])
   })
   assertEquals(exported.toString().startsWith('type User struct {'), true)
@@ -56,7 +56,7 @@ Deno.test('GoDefinition casing follows Identifier.exported, not input name casin
   // Unexported intent + capitalized input → Go lowercases it.
   const unexported = new GoDefinition({
     context,
-    identifier: new GoIdentifier({ name: 'Secret', exported: false, kind: 'type' }),
+    identifier: new GoIdentifier({ name: 'Secret', exported: false, type: 'type' }),
     value: new GoStruct([{ name: 'id', type: 'string' }])
   })
   assertEquals(unexported.toString().startsWith('type secret struct {'), true)

--- a/deno/lang-java/mod.ts
+++ b/deno/lang-java/mod.ts
@@ -10,7 +10,7 @@
  *     subclasses of the abstract bases in `@skmtc/core` — each renders
  *     itself in its own `toString()`
  *   - the `register` family (`register`, `defineAndRegister`)
- *   - this language's `EntityKind` vocabulary
+ *   - this language's `EntityType` vocabulary
  *   - `sanitizePropertyName` + identifier/casing/visibility rules
  *   - syntax helpers
  *

--- a/deno/lang-kotlin/mod.ts
+++ b/deno/lang-kotlin/mod.ts
@@ -11,7 +11,7 @@
  * `reExports` field), the model projection-base veneer, `KtFile`
  * (path-derived `package` directive, sorted imports, same-package
  * suppression), `KtImport` (symbol-level, `as` aliases), `KtDefinition`
- * (exhaustive seven-kind shells; the `KtAnnotated` / `KtSupertyped` /
+ * (exhaustive seven-type shells; the `KtAnnotated` / `KtSupertyped` /
  * `KtConstructed` / `KtDocumented` value protocols), the
  * function-signature grammar (`KtFunctionSignature` /
  * `KtFunctionParameter` — interface/class methods incl. KDoc,
@@ -62,15 +62,15 @@ export {
   createValue,
   createVerbatim,
   toKtKeyword,
-  toKtEntityKind,
-  type KtEntityKind,
+  toKtEntityType,
+  type KtEntityType,
   type CreateKtIdentifierArgs,
   type CreateValueArgs
 } from './src/createIdentifier.ts'
 export { sanitizePropertyName } from './src/sanitizePropertyName.ts'
 export { toPackageName } from './src/toPackageName.ts'
 export { ktHardKeywords, isKtIdentifierName } from './src/hardKeywords.ts'
-export { kotlin, type KtLang } from './src/ktLang.ts'
+export { kotlin } from './src/ktLang.ts'
 export { KtSnippet } from './src/KtSnippet.ts'
 export {
   register,

--- a/deno/lang-kotlin/src/KtConstructed.ts
+++ b/deno/lang-kotlin/src/KtConstructed.ts
@@ -15,7 +15,7 @@ import type { Stringable } from '@skmtc/core'
  * Grammar only: the lang renders the clause; WHAT is injected is
  * generator policy.
  *
- * Read for the `class` kind only in v1 (`data-class` keeps its
+ * Read for the `class` type only in v1 (`data-class` keeps its
  * value-IS-the-parameter-list shape).
  */
 export type KtConstructed = {

--- a/deno/lang-kotlin/src/KtDefinition.test.ts
+++ b/deno/lang-kotlin/src/KtDefinition.test.ts
@@ -134,11 +134,11 @@ Deno.test('sealed-interface shell renders bodyless when the value is empty', () 
   const withBody = new KtDefinition({
     context,
     identifier: createSealedInterface('Animal'),
-    value: '    val kind: String'
+    value: '    val type: String'
   })
 
   assertEquals(bodyless.toString(), 'sealed interface Animal')
-  assertEquals(withBody.toString(), 'sealed interface Animal {\n    val kind: String\n}')
+  assertEquals(withBody.toString(), 'sealed interface Animal {\n    val type: String\n}')
 })
 
 Deno.test('typealias shell renders the assignment form', () => {
@@ -364,7 +364,7 @@ Deno.test('KtDocumented value supplies the KDoc; constructor description wins', 
   )
 })
 
-Deno.test('verbatim kind renders the value as-is — no shell, visibility, or annotations', () => {
+Deno.test('verbatim type renders the value as-is — no shell, visibility, or annotations', () => {
   const body =
     'internal fun add(a: Int, b: Int): Int = a + b\n\ninternal fun sub(a: Int, b: Int): Int = a - b'
 

--- a/deno/lang-kotlin/src/KtDefinition.ts
+++ b/deno/lang-kotlin/src/KtDefinition.ts
@@ -23,10 +23,10 @@ export type KtDefinitionArgs<Value extends GeneratedValue> = {
 /**
  * Kotlin's concrete {@link DefinitionBase}: assembles the declaration
  * shell around the generated value, dispatching on the identifier's
- * opaque `kind` — exhaustive over this language's vocabulary, throwing
+ * opaque `type` — exhaustive over this language's vocabulary, throwing
  * outside it (no silent fallback).
  *
- * | kind | shell |
+ * | type | shell |
  * |---|---|
  * | `class` | `class Name` (+ `(\n…\n)` via the `KtConstructed` protocol; + ` {\n…\n}` when the value renders non-empty) |
  * | `data-class` | `data class Name(\n…\n)` (+ ` : A, B` via the supertype protocol) |
@@ -41,7 +41,7 @@ export type KtDefinitionArgs<Value extends GeneratedValue> = {
  * `Lang.toDefinition` signature has no annotations slot) and render one
  * per line above the shell; a supertype clause rides the same way via
  * {@link import('./KtSupertyped.ts').KtSupertyped} (rendered for the
- * `data-class` kind only in v1); a `description` renders as a KDoc block
+ * `data-class` type only in v1); a `description` renders as a KDoc block
  * above the annotations.
  *
  * Visibility: Kotlin defaults to `public`, so the neutral `exported`
@@ -61,14 +61,14 @@ export class KtDefinition<Value extends GeneratedValue = GeneratedValue> extends
 
   override toString(): string {
     // The engine holds the identifier as the neutral `IdentifierBase`;
-    // narrow to `KtIdentifier` cast-free to read the typed `kind`.
+    // narrow to `KtIdentifier` cast-free to read the typed `type`.
     const identifier = this.identifier
     invariant(
       isKtIdentifier(identifier),
       `KtDefinition needs a KtIdentifier to render '${identifier.name}', got a foreign identifier`
     )
 
-    if (identifier.kind === 'verbatim') {
+    if (identifier.type === 'verbatim') {
       // The value IS the declaration text (template files, multi-
       // declaration bodies) — no shell, no visibility, no annotations.
       return `${this.value}`
@@ -91,9 +91,9 @@ export class KtDefinition<Value extends GeneratedValue = GeneratedValue> extends
   }
 
   private toShell(identifier: KtIdentifier): string {
-    const { name, kind, typeName } = identifier
+    const { name, type, typeName } = identifier
 
-    switch (kind) {
+    switch (type) {
       case 'class': {
         const constructorClause = isKtConstructed(this.value)
           ? `${toConstructorKeyword(this.value.constructorModifiers)}(\n${this.value.constructorParameters}\n)`
@@ -133,7 +133,7 @@ export class KtDefinition<Value extends GeneratedValue = GeneratedValue> extends
       case 'val':
         return `val ${name}${typeName ? `: ${typeName}` : ''} = ${this.value}`
       default:
-        throw new Error(`Unknown Kotlin entity kind: ${kind}`)
+        throw new Error(`Unknown Kotlin entity type: ${type}`)
     }
   }
 }

--- a/deno/lang-kotlin/src/KtFile.ts
+++ b/deno/lang-kotlin/src/KtFile.ts
@@ -3,12 +3,11 @@ import type {
   ClientSettings,
   DefinitionBase,
   ImportBase,
-  ReExportBase,
-  FindDefinitionsQuery
+  ReExportBase
 } from '@skmtc/core'
 import { KtImport } from './KtImport.ts'
 import { KtIdentifier } from './KtIdentifier.ts'
-import type { KtLang } from './ktLang.ts'
+import type { KtEntityType } from './createIdentifier.ts'
 import { toPackageName } from './toPackageName.ts'
 
 /**
@@ -52,7 +51,7 @@ export type KtFileArgs = {
  * vocabulary has no `reExports` field and the Driver never registers
  * them — so rendering ignores the (always empty) neutral map.
  */
-export class KtFile extends CodeFileBase<KtLang> {
+export class KtFile extends CodeFileBase {
   /**
    * The `package` this file declares — derived from `path`, with the
    * owning package's `rootPath` stripped first in multi-package mode
@@ -103,12 +102,12 @@ export class KtFile extends CodeFileBase<KtLang> {
   }
 
   override findDefinitions(
-    query?: FindDefinitionsQuery<KtLang>
+    query?: { name?: string; type?: KtEntityType }
   ): DefinitionBase[] | undefined {
     return matchDefinitions(
       [...this.definitions.values()],
       query,
-      identifier => (identifier instanceof KtIdentifier ? identifier.kind : undefined)
+      identifier => (identifier instanceof KtIdentifier ? identifier.type : undefined)
     )
   }
 

--- a/deno/lang-kotlin/src/KtIdentifier.ts
+++ b/deno/lang-kotlin/src/KtIdentifier.ts
@@ -1,49 +1,48 @@
 import { IdentifierBase } from '@skmtc/core'
 import type { IdentifierBaseArgs, IdentifierType } from '@skmtc/core'
-import type { KtEntityKind } from './createIdentifier.ts'
-import type { KtLang } from './ktLang.ts'
+import type { KtEntityType } from './createIdentifier.ts'
 
 /**
  * The non-`name` parts of a Kotlin identifier — the tightened
  * `IdentifierType` a Kotlin projection's `toIdentifierType` returns.
- * Core's `IdentifierType<KtLang>` recovers the `kind` from {@link KtLang}'s
- * identifier ({@link KtEntityKind}); this alias is the named form generators
+ * Core's neutral {@link IdentifierType} carries an opaque `type: string`;
+ * this alias narrows it to {@link KtEntityType}, the named form generators
  * annotate with. The engine spreads it into
  * `lang.toIdentifier({ name, ...identifierType })`.
  */
-export type KtIdentifierType = IdentifierType<KtLang>
+export type KtIdentifierType = IdentifierType & { type: KtEntityType }
 
 /**
  * Constructor arguments for {@link KtIdentifier} — the neutral
- * {@link IdentifierBaseArgs} plus this language's typed `kind`.
+ * {@link IdentifierBaseArgs} plus this language's typed `type`.
  */
 export type KtIdentifierArgs = IdentifierBaseArgs & {
-  kind: KtEntityKind
+  type: KtEntityType
 }
 
 /**
- * Kotlin's concrete {@link IdentifierBase}: adds the typed `kind`
- * ({@link KtEntityKind}) the renderer reads to pick its declaration shell
+ * Kotlin's concrete {@link IdentifierBase}: adds the typed `type`
+ * ({@link KtEntityType}) the renderer reads to pick its declaration shell
  * (`data class` / `enum class` / `sealed interface` / `typealias` / `val`
  * / …).
  *
  * The engine holds it as the neutral `IdentifierBase` (reading only
  * `.name`); `KtDefinition` narrows back to `KtIdentifier` via
- * {@link isKtIdentifier} to read `kind`.
+ * {@link isKtIdentifier} to read `type`.
  */
 export class KtIdentifier extends IdentifierBase {
-  /** Per-language declaration kind — drives the declaration shell. */
-  kind: KtEntityKind
+  /** Per-language declaration type — drives the declaration shell. */
+  type: KtEntityType
 
-  constructor({ name, typeName, exported, kind }: KtIdentifierArgs) {
+  constructor({ name, typeName, exported, type }: KtIdentifierArgs) {
     super({ name, typeName, exported })
-    this.kind = kind
+    this.type = type
   }
 }
 
 /**
  * Type guard narrowing a neutral {@link IdentifierBase} to a
- * {@link KtIdentifier} — the cast-free way the renderer reads `kind`.
+ * {@link KtIdentifier} — the cast-free way the renderer reads `type`.
  */
 export const isKtIdentifier = (identifier: IdentifierBase): identifier is KtIdentifier => {
   return identifier instanceof KtIdentifier

--- a/deno/lang-kotlin/src/KtImport.test.ts
+++ b/deno/lang-kotlin/src/KtImport.test.ts
@@ -19,7 +19,7 @@ Deno.test('aliases render via `as`', () => {
   assertEquals(ktImport.toString(), 'import com.example.models.User as UserModel')
 })
 
-Deno.test('fromIdentifier builds the Driver cross-file import; kind is ignored', () => {
+Deno.test('fromIdentifier builds the Driver cross-file import; type is ignored', () => {
   const ktImport = KtImport.fromIdentifier(
     '@/com/example/api/User.generated.kt',
     createDataClass('User')

--- a/deno/lang-kotlin/src/KtImport.ts
+++ b/deno/lang-kotlin/src/KtImport.ts
@@ -62,7 +62,7 @@ export class KtImport extends ImportBase {
   /**
    * Build the import of a single {@link IdentifierBase} from `module` — the
    * cross-file import a Driver registers when a generator references a
-   * peer's Definition. The identifier's `kind` is ignored: every Kotlin
+   * peer's Definition. The identifier's `type` is ignored: every Kotlin
    * import has the same form, so the neutral `IdentifierBase` (which the
    * engine holds) is all that's needed — no narrowing.
    */

--- a/deno/lang-kotlin/src/KtSnippet.ts
+++ b/deno/lang-kotlin/src/KtSnippet.ts
@@ -1,5 +1,5 @@
-import { SnippetBase, type GeneratedValue } from '@skmtc/core'
-import { kotlin, type KtLang } from './ktLang.ts'
+import { SnippetBase, type GeneratedValue, type Lang } from '@skmtc/core'
+import { kotlin } from './ktLang.ts'
 import {
   register,
   defineAndRegister,
@@ -29,12 +29,13 @@ import type { KtDefinition } from './KtDefinition.ts'
  */
 export class KtSnippet extends SnippetBase {
   /**
-   * The language every class built on this base renders into. Typed
-   * {@link KtLang} (not the loose `Lang`) so a projection-base veneer
-   * inferring `L` from `base: KtSnippet` lands on `KtLang` — the tightening
-   * that lets `toIdentifierType` return `IdentifierType<KtLang>`.
+   * The language every class built on this base renders into — the neutral
+   * {@link Lang}. Drivers read it off the projection class
+   * (`projection.lang`) pre-construction; a projection-base veneer carries
+   * the Kotlin identifier tightening ({@link import('./KtIdentifier.ts').KtIdentifierType})
+   * through its config's `toIdentifierType` rather than through this static.
    */
-  static lang: KtLang = kotlin
+  static lang: Lang = kotlin
 
   /**
    * Register imports / definitions into the file at `destinationPath`,

--- a/deno/lang-kotlin/src/KtSupertyped.ts
+++ b/deno/lang-kotlin/src/KtSupertyped.ts
@@ -16,7 +16,7 @@ import type { Stringable } from '@skmtc/core'
  * need no import, and cross-package supertypes are the caller's import
  * to register.
  *
- * Rendered for the `data-class` kind only in v1 (enum conformance and
+ * Rendered for the `data-class` type only in v1 (enum conformance and
  * sealed-extends-sealed arrive with a milestone that needs them).
  * Scratch-proved cast-free per the note-19 `KtAnnotated` precedent
  * (spec: `notes/lang/22-kotlin-sealed-oneof-architecture.md`).

--- a/deno/lang-kotlin/src/createIdentifier.test.ts
+++ b/deno/lang-kotlin/src/createIdentifier.test.ts
@@ -9,47 +9,47 @@ import {
   toKtKeyword
 } from './createIdentifier.ts'
 
-Deno.test('createDataClass writes the data-class kind', () => {
+Deno.test('createDataClass writes the data-class type', () => {
   const identifier = createDataClass('User')
 
   assertEquals(identifier.name, 'User')
-  assertEquals(identifier.kind, 'data-class')
+  assertEquals(identifier.type, 'data-class')
   assertEquals(identifier.exported, true)
 })
 
-Deno.test('createEnumClass writes the enum-class kind', () => {
+Deno.test('createEnumClass writes the enum-class type', () => {
   const identifier = createEnumClass('Status')
 
   assertEquals(identifier.name, 'Status')
-  assertEquals(identifier.kind, 'enum-class')
+  assertEquals(identifier.type, 'enum-class')
 })
 
-Deno.test('createInterface writes the interface kind', () => {
+Deno.test('createInterface writes the interface type', () => {
   const identifier = createInterface('UsersApi')
 
   assertEquals(identifier.name, 'UsersApi')
-  assertEquals(identifier.kind, 'interface')
+  assertEquals(identifier.type, 'interface')
 })
 
-Deno.test('createSealedInterface writes the sealed-interface kind', () => {
+Deno.test('createSealedInterface writes the sealed-interface type', () => {
   const identifier = createSealedInterface('Animal')
 
   assertEquals(identifier.name, 'Animal')
-  assertEquals(identifier.kind, 'sealed-interface')
+  assertEquals(identifier.type, 'sealed-interface')
 })
 
-Deno.test('createTypeAlias writes the typealias kind', () => {
+Deno.test('createTypeAlias writes the typealias type', () => {
   const identifier = createTypeAlias('UserList')
 
   assertEquals(identifier.name, 'UserList')
-  assertEquals(identifier.kind, 'typealias')
+  assertEquals(identifier.type, 'typealias')
 })
 
-Deno.test('createValue writes the val kind and carries an optional typeName', () => {
+Deno.test('createValue writes the val type and carries an optional typeName', () => {
   const untyped = createValue('MAX_RETRIES')
   const typed = createValue('timeout', { typeName: 'Long' })
 
-  assertEquals(untyped.kind, 'val')
+  assertEquals(untyped.type, 'val')
   assertEquals(untyped.typeName, undefined)
   assertEquals(typed.typeName, 'Long')
 })
@@ -70,6 +70,6 @@ Deno.test('toKtKeyword maps the full vocabulary', () => {
 })
 
 Deno.test('toKtKeyword throws outside the vocabulary (foreign-language identifier)', () => {
-  assertThrows(() => toKtKeyword('variable'), Error, 'Unknown Kotlin entity kind: variable')
-  assertThrows(() => toKtKeyword('type'), Error, 'Unknown Kotlin entity kind: type')
+  assertThrows(() => toKtKeyword('variable'), Error, 'Unknown Kotlin entity type: variable')
+  assertThrows(() => toKtKeyword('type'), Error, 'Unknown Kotlin entity type: type')
 })

--- a/deno/lang-kotlin/src/createIdentifier.ts
+++ b/deno/lang-kotlin/src/createIdentifier.ts
@@ -1,7 +1,7 @@
 import { KtIdentifier } from './KtIdentifier.ts'
 
 /**
- * Kotlin's declaration-kind vocabulary — the typed `kind` this package
+ * Kotlin's declaration-type vocabulary — the typed `type` this package
  * writes onto its {@link KtIdentifier} and the discriminator its renderers
  * narrow against.
  *
@@ -22,13 +22,13 @@ import { KtIdentifier } from './KtIdentifier.ts'
  *   template files, where the identifier serves cache identity only —
  *   the gen-kotlin-sdk static-runtime idiom, note `32` §A5).
  *
- * Unlike TypeScript, the kind does NOT drive import form — every Kotlin
+ * Unlike TypeScript, the type does NOT drive import form — every Kotlin
  * import is `import pkg.Name`. It drives only the declaration shell.
  * Deferred kinds (`object`, `fun`, `var`, `const-val`) arrive with the
  * milestones that need them; {@link toKtKeyword} throwing on them is the
  * desired behavior until then.
  */
-export type KtEntityKind =
+export type KtEntityType =
   | 'class'
   | 'data-class'
   | 'enum-class'
@@ -68,7 +68,7 @@ export type CreateValueArgs = {
  * ```
  */
 export const createClass = (name: string, args: CreateKtIdentifierArgs = {}): KtIdentifier => {
-  return new KtIdentifier({ name, exported: args.exported, kind: 'class' })
+  return new KtIdentifier({ name, exported: args.exported, type: 'class' })
 }
 
 /**
@@ -81,7 +81,7 @@ export const createClass = (name: string, args: CreateKtIdentifierArgs = {}): Kt
  * ```
  */
 export const createDataClass = (name: string, args: CreateKtIdentifierArgs = {}): KtIdentifier => {
-  return new KtIdentifier({ name, exported: args.exported, kind: 'data-class' })
+  return new KtIdentifier({ name, exported: args.exported, type: 'data-class' })
 }
 
 /**
@@ -94,7 +94,7 @@ export const createDataClass = (name: string, args: CreateKtIdentifierArgs = {})
  * ```
  */
 export const createEnumClass = (name: string, args: CreateKtIdentifierArgs = {}): KtIdentifier => {
-  return new KtIdentifier({ name, exported: args.exported, kind: 'enum-class' })
+  return new KtIdentifier({ name, exported: args.exported, type: 'enum-class' })
 }
 
 /**
@@ -107,7 +107,7 @@ export const createEnumClass = (name: string, args: CreateKtIdentifierArgs = {})
  * ```
  */
 export const createInterface = (name: string, args: CreateKtIdentifierArgs = {}): KtIdentifier => {
-  return new KtIdentifier({ name, exported: args.exported, kind: 'interface' })
+  return new KtIdentifier({ name, exported: args.exported, type: 'interface' })
 }
 
 /**
@@ -123,7 +123,7 @@ export const createSealedInterface = (
   name: string,
   args: CreateKtIdentifierArgs = {}
 ): KtIdentifier => {
-  return new KtIdentifier({ name, exported: args.exported, kind: 'sealed-interface' })
+  return new KtIdentifier({ name, exported: args.exported, type: 'sealed-interface' })
 }
 
 /**
@@ -136,7 +136,7 @@ export const createSealedInterface = (
  * ```
  */
 export const createTypeAlias = (name: string, args: CreateKtIdentifierArgs = {}): KtIdentifier => {
-  return new KtIdentifier({ name, exported: args.exported, kind: 'typealias' })
+  return new KtIdentifier({ name, exported: args.exported, type: 'typealias' })
 }
 
 /**
@@ -158,7 +158,7 @@ export const createTypeAlias = (name: string, args: CreateKtIdentifierArgs = {})
 export const createValue = (name: string, args: CreateValueArgs = {}): KtIdentifier => {
   const { typeName, exported } = args
 
-  return new KtIdentifier({ name, typeName, exported, kind: 'val' })
+  return new KtIdentifier({ name, typeName, exported, type: 'val' })
 }
 
 /**
@@ -175,17 +175,17 @@ export const createValue = (name: string, args: CreateValueArgs = {}): KtIdentif
  * ```
  */
 export const createVerbatim = (name: string): KtIdentifier => {
-  return new KtIdentifier({ name, kind: 'verbatim' })
+  return new KtIdentifier({ name, type: 'verbatim' })
 }
 
 /**
- * Maps an identifier's opaque `kind` to its Kotlin declaration keyword.
- * Throws on a kind outside this language's vocabulary — a loud signal
- * that an identifier built for another language (or with a typo'd kind)
+ * Maps an identifier's opaque `type` to its Kotlin declaration keyword.
+ * Throws on a type outside this language's vocabulary — a loud signal
+ * that an identifier built for another language (or with a typo'd type)
  * reached the Kotlin renderer.
  */
-export const toKtKeyword = (kind: string): string => {
-  switch (kind) {
+export const toKtKeyword = (type: string): string => {
+  switch (type) {
     case 'class':
       return 'class'
     case 'data-class':
@@ -203,18 +203,18 @@ export const toKtKeyword = (kind: string): string => {
     case 'verbatim':
       return ''
     default:
-      throw new Error(`Unknown Kotlin entity kind: ${kind}`)
+      throw new Error(`Unknown Kotlin entity type: ${type}`)
   }
 }
 
 /**
- * Narrow the engine's opaque `kind: string` (from `Lang.toIdentifier`'s
- * neutral args) to this language's {@link KtEntityKind} — cast-free, via a
- * validating switch. Throws on a kind outside the vocabulary, the same loud
+ * Narrow the engine's opaque `type: string` (from `Lang.toIdentifier`'s
+ * neutral args) to this language's {@link KtEntityType} — cast-free, via a
+ * validating switch. Throws on a type outside the vocabulary, the same loud
  * signal {@link toKtKeyword} gives.
  */
-export const toKtEntityKind = (kind: string): KtEntityKind => {
-  switch (kind) {
+export const toKtEntityType = (type: string): KtEntityType => {
+  switch (type) {
     case 'class':
       return 'class'
     case 'data-class':
@@ -232,6 +232,6 @@ export const toKtEntityKind = (kind: string): KtEntityKind => {
     case 'verbatim':
       return 'verbatim'
     default:
-      throw new Error(`Unknown Kotlin entity kind: ${kind}`)
+      throw new Error(`Unknown Kotlin entity type: ${type}`)
   }
 }

--- a/deno/lang-kotlin/src/ktLang.ts
+++ b/deno/lang-kotlin/src/ktLang.ts
@@ -3,16 +3,7 @@ import { KtFile } from './KtFile.ts'
 import { KtDefinition } from './KtDefinition.ts'
 import { KtImport } from './KtImport.ts'
 import { KtIdentifier } from './KtIdentifier.ts'
-import { toKtEntityKind } from './createIdentifier.ts'
-
-/**
- * The Kotlin {@link Lang}, specialized to this language's concrete
- * {@link KtIdentifier}. Threaded as the `L` type argument through the
- * projection-base veneers so core's config tightens `toIdentifierType`'s
- * return to {@link import('./KtIdentifier.ts').KtIdentifierType} (the `kind`
- * bound to `KtEntityKind`) with no recast.
- */
-export type KtLang = Lang<KtIdentifier>
+import { toKtEntityType } from './createIdentifier.ts'
 
 /**
  * The Kotlin {@link Lang} — carried as the static `lang` on
@@ -22,7 +13,7 @@ export type KtLang = Lang<KtIdentifier>
  * site. The engine reaches Kotlin only through these neutral factories;
  * it never names `KtFile` / `KtDefinition` / `KtImport` itself.
  */
-export const kotlin: KtLang = {
+export const kotlin: Lang = {
   createFile: ({ path, settings }) => new KtFile({ path, settings }),
 
   toDefinition: ({ context, identifier, value, noExport, description }) =>
@@ -34,8 +25,8 @@ export const kotlin: KtLang = {
   toImport: ({ identifier, module }) => KtImport.fromIdentifier(module, identifier),
 
   // The engine's identifier-assembly seam: `name` from `toIdentifierName`,
-  // the rest spread from `toIdentifierType`. Narrows the opaque `kind`
-  // string to this language's typed `KtEntityKind`.
-  toIdentifier: ({ name, kind, typeName, exported }) =>
-    new KtIdentifier({ name, typeName, exported, kind: toKtEntityKind(kind) })
+  // the rest spread from `toIdentifierType`. Narrows the opaque `type`
+  // string to this language's typed `KtEntityType`.
+  toIdentifier: ({ name, type, typeName, exported }) =>
+    new KtIdentifier({ name, typeName, exported, type: toKtEntityType(type) })
 }

--- a/deno/lang-kotlin/src/option2.kotlin.test.ts
+++ b/deno/lang-kotlin/src/option2.kotlin.test.ts
@@ -76,7 +76,7 @@ class SpikeField extends KtSnippet {
 const SpikeModelBase = toKtModelProjectionBase({
   id: '@spike/gen-kotlin-option2',
   toIdentifierName: ({ refName }) => `${refName}Spike`,
-  toIdentifierType: () => ({ kind: 'val' }),
+  toIdentifierType: () => ({ type: 'val' }),
   toExportPath: () => '@/spike/models/Models.generated.kt',
   toEnrichmentSchema: () => emptyEnrichmentSchema
 })

--- a/deno/lang-kotlin/src/toKtModelProjectionBase.ts
+++ b/deno/lang-kotlin/src/toKtModelProjectionBase.ts
@@ -2,7 +2,7 @@ import { toModelProjectionBase } from '@skmtc/core'
 import type { ModelProjectionBaseConfig } from '@skmtc/core'
 import { KtSnippet } from './KtSnippet.ts'
 import { register, type KtRegisterArgs } from './register.ts'
-import type { KtLang } from './ktLang.ts'
+import type { KtIdentifierType } from './KtIdentifier.ts'
 
 /**
  * Build a Kotlin model projection base class.
@@ -22,16 +22,16 @@ import type { KtLang } from './ktLang.ts'
  * result).
  *
  * The config is core's `ModelProjectionBaseConfig` parameterized over
- * {@link KtLang} (so `toIdentifierType` returns `IdentifierType<KtLang>` — the
- * `kind` bound to `KtEntityKind`). The base is the factory's first argument,
- * not a config field.
+ * {@link KtIdentifierType} (so `toIdentifierType` returns the `type` bound to
+ * `KtEntityType`). The base is the factory's first argument, not a config
+ * field.
  *
  * The companion operation veneer {@link toKtOasOperationProjectionBase} has
  * arrived (the OAS veneer now exists, driven by gen-kotlin-sdk's Response
  * models).
  */
 export const toKtModelProjectionBase = <EnrichmentType = undefined>(
-  config: ModelProjectionBaseConfig<EnrichmentType, KtLang>
+  config: ModelProjectionBaseConfig<EnrichmentType, KtIdentifierType>
 ) => {
   return class extends toModelProjectionBase(KtSnippet, config) {
     /**

--- a/deno/lang-kotlin/src/toKtOasOperationProjectionBase.ts
+++ b/deno/lang-kotlin/src/toKtOasOperationProjectionBase.ts
@@ -2,7 +2,7 @@ import { toOasOperationProjectionBase } from '@skmtc/core'
 import type { OasOperationProjectionBaseConfig } from '@skmtc/core'
 import { KtSnippet } from './KtSnippet.ts'
 import { register, type KtRegisterArgs } from './register.ts'
-import type { KtLang } from './ktLang.ts'
+import type { KtIdentifierType } from './KtIdentifier.ts'
 
 /**
  * Build a Kotlin OAS operation projection base class — the first
@@ -25,11 +25,12 @@ import type { KtLang } from './ktLang.ts'
  * result).
  *
  * The config is core's `OasOperationProjectionBaseConfig` parameterized over
- * {@link KtLang} (so `toIdentifierType` returns `IdentifierType<KtLang>`). The
- * base is the factory's first argument, not a config field.
+ * {@link KtIdentifierType} (so `toIdentifierType` returns the `type` bound to
+ * `KtEntityType`). The base is the factory's first argument, not a config
+ * field.
  */
 export const toKtOasOperationProjectionBase = <EnrichmentType = undefined>(
-  config: OasOperationProjectionBaseConfig<EnrichmentType, KtLang>
+  config: OasOperationProjectionBaseConfig<EnrichmentType, KtIdentifierType>
 ) => {
   return class extends toOasOperationProjectionBase(KtSnippet, config) {
     /**

--- a/deno/lang-php/mod.ts
+++ b/deno/lang-php/mod.ts
@@ -10,7 +10,7 @@
  *     subclasses of the abstract bases in `@skmtc/core` — each renders
  *     itself in its own `toString()`
  *   - the `register` family (`register`, `defineAndRegister`)
- *   - this language's `EntityKind` vocabulary
+ *   - this language's `EntityType` vocabulary
  *   - `sanitizePropertyName` + identifier/casing/visibility rules
  *   - syntax helpers
  *
@@ -20,7 +20,7 @@
  * the sharp test for the "Definition assembly" question. Outcome:
  * Definition assembles the *shell*, the value renders the *body* (the
  * same split Go/Rust already use). PHP is a second consumer of the opaque
- * `Identifier.kind` and a fourth `exported` behaviour (ignored at class
+ * `Identifier.type` and a fourth `exported` behaviour (ignored at class
  * level). Not yet wired into the engine.
  */
 
@@ -32,5 +32,5 @@ export const fileExtensions = ['.php'] as const
 
 export { PhpFile, type PhpFileArgs } from './src/PhpFile.ts'
 export { PhpDefinition } from './src/PhpDefinition.ts'
-export { PhpIdentifier, isPhpIdentifier, type PhpEntityKind } from './src/PhpIdentifier.ts'
+export { PhpIdentifier, isPhpIdentifier, type PhpEntityType } from './src/PhpIdentifier.ts'
 export { PhpClass, type PhpPropertyArgs } from './src/PhpClass.ts'

--- a/deno/lang-php/src/PhpDefinition.ts
+++ b/deno/lang-php/src/PhpDefinition.ts
@@ -16,7 +16,7 @@ import { isPhpIdentifier } from './PhpIdentifier.ts'
  *    (`pub struct X …`) already use — the shell was never universally
  *    `<kw> X = value`, so PHP fits the pattern rather than breaking it.
  *
- * 2. **The per-language `PhpIdentifier.kind` picks the keyword** (`class` /
+ * 2. **The per-language `PhpIdentifier.type` picks the keyword** (`class` /
  *    `interface` / `enum` / `trait`), exactly as Rust's does — a second
  *    independent consumer of the discriminant.
  *
@@ -36,7 +36,7 @@ export class PhpDefinition extends DefinitionBase {
     )
 
     let keyword: string
-    switch (identifier.kind) {
+    switch (identifier.type) {
       case 'interface':
         keyword = 'interface'
         break

--- a/deno/lang-php/src/PhpFile.ts
+++ b/deno/lang-php/src/PhpFile.ts
@@ -1,6 +1,7 @@
 import { CodeFileBase, matchDefinitions } from '@skmtc/core'
-import type { DefinitionBase, ImportBase, ReExportBase, Lang, FindDefinitionsQuery } from '@skmtc/core'
+import type { DefinitionBase, ImportBase, ReExportBase } from '@skmtc/core'
 import { PhpIdentifier } from './PhpIdentifier.ts'
+import type { PhpEntityType } from './PhpIdentifier.ts'
 
 /** Constructor arguments for {@link PhpFile}. */
 export type PhpFileArgs = {
@@ -23,7 +24,7 @@ export type PhpFileArgs = {
  * {@link CodeFileBase} are not yet wired (no PHP generator registers
  * imports).
  */
-export class PhpFile extends CodeFileBase<Lang<PhpIdentifier>> {
+export class PhpFile extends CodeFileBase {
   namespace: string
 
   /** Definitions keyed by identifier name (first write wins). */
@@ -49,12 +50,12 @@ export class PhpFile extends CodeFileBase<Lang<PhpIdentifier>> {
   }
 
   override findDefinitions(
-    query?: FindDefinitionsQuery<Lang<PhpIdentifier>>
+    query?: { name?: string; type?: PhpEntityType }
   ): DefinitionBase[] | undefined {
     return matchDefinitions(
       [...this.definitions.values()],
       query,
-      identifier => (identifier instanceof PhpIdentifier ? identifier.kind : undefined)
+      identifier => (identifier instanceof PhpIdentifier ? identifier.type : undefined)
     )
   }
 

--- a/deno/lang-php/src/PhpIdentifier.ts
+++ b/deno/lang-php/src/PhpIdentifier.ts
@@ -2,43 +2,43 @@ import { IdentifierBase } from '@skmtc/core'
 import type { IdentifierBaseArgs } from '@skmtc/core'
 
 /**
- * PHP's declaration-kind vocabulary — the discriminant {@link PhpDefinition}
+ * PHP's declaration-type vocabulary — the discriminant {@link PhpDefinition}
  * reads to pick its container keyword (`class` / `interface` / `enum` /
- * `trait`). A second independent consumer of the per-language `kind` after
+ * `trait`). A second independent consumer of the per-language `type` after
  * Rust.
  */
-export type PhpEntityKind = 'class' | 'interface' | 'enum' | 'trait'
+export type PhpEntityType = 'class' | 'interface' | 'enum' | 'trait'
 
 /**
  * Constructor arguments for {@link PhpIdentifier} — the neutral
- * {@link IdentifierBaseArgs} plus this language's typed `kind`.
+ * {@link IdentifierBaseArgs} plus this language's typed `type`.
  */
 export type PhpIdentifierArgs = IdentifierBaseArgs & {
-  kind: PhpEntityKind
+  type: PhpEntityType
 }
 
 /**
- * PHP's concrete {@link IdentifierBase}: adds the typed `kind`
- * ({@link PhpEntityKind}) the renderer reads to pick its container keyword
+ * PHP's concrete {@link IdentifierBase}: adds the typed `type`
+ * ({@link PhpEntityType}) the renderer reads to pick its container keyword
  * (`class` / `interface` / `enum` / `trait`).
  *
  * The engine holds it as the neutral `IdentifierBase` (reading only
  * `.name`); {@link PhpDefinition} narrows back to `PhpIdentifier` via
- * {@link isPhpIdentifier} to read `kind`.
+ * {@link isPhpIdentifier} to read `type`.
  */
 export class PhpIdentifier extends IdentifierBase {
-  /** Per-language declaration kind — drives the container keyword. */
-  kind: PhpEntityKind
+  /** Per-language declaration type — drives the container keyword. */
+  type: PhpEntityType
 
-  constructor({ name, typeName, exported, kind }: PhpIdentifierArgs) {
+  constructor({ name, typeName, exported, type }: PhpIdentifierArgs) {
     super({ name, typeName, exported })
-    this.kind = kind
+    this.type = type
   }
 }
 
 /**
  * Type guard narrowing a neutral {@link IdentifierBase} to a
- * {@link PhpIdentifier} — the cast-free way the renderer reads `kind`.
+ * {@link PhpIdentifier} — the cast-free way the renderer reads `type`.
  */
 export const isPhpIdentifier = (identifier: IdentifierBase): identifier is PhpIdentifier => {
   return identifier instanceof PhpIdentifier

--- a/deno/lang-php/src/render.test.ts
+++ b/deno/lang-php/src/render.test.ts
@@ -11,7 +11,7 @@ const context = {} as unknown as GenerateContextType
 Deno.test('PhpDefinition + PhpClass render the User DTO as a class container', () => {
   const definition = new PhpDefinition({
     context,
-    identifier: new PhpIdentifier({ name: 'User', kind: 'class' }),
+    identifier: new PhpIdentifier({ name: 'User', type: 'class' }),
     value: new PhpClass([
       { name: 'id', type: 'string' },
       { name: 'name', type: 'string' },
@@ -47,17 +47,17 @@ Deno.test('PhpClass renders private members for unexported properties', () => {
   )
 })
 
-Deno.test('declaration keyword follows opaque Identifier.kind', () => {
-  // Same value, different `kind` → different container keyword. PHP is a
+Deno.test('declaration keyword follows opaque Identifier.type', () => {
+  // Same value, different `type` → different container keyword. PHP is a
   // second consumer of the opaque discriminant (after Rust).
   const asInterface = new PhpDefinition({
     context,
-    identifier: new PhpIdentifier({ name: 'Named', kind: 'interface' }),
+    identifier: new PhpIdentifier({ name: 'Named', type: 'interface' }),
     value: new PhpClass([{ name: 'id', type: 'string' }])
   })
   const asClass = new PhpDefinition({
     context,
-    identifier: new PhpIdentifier({ name: 'Named', kind: 'class' }),
+    identifier: new PhpIdentifier({ name: 'Named', type: 'class' }),
     value: new PhpClass([{ name: 'id', type: 'string' }])
   })
 
@@ -70,12 +70,12 @@ Deno.test('exported is ignored at the class level (no file-private class in PHP)
   // top-level visibility keyword on a class — `exported` is a no-op here.
   const exported = new PhpDefinition({
     context,
-    identifier: new PhpIdentifier({ name: 'A', exported: true, kind: 'class' }),
+    identifier: new PhpIdentifier({ name: 'A', exported: true, type: 'class' }),
     value: new PhpClass([{ name: 'id', type: 'string' }])
   })
   const unexported = new PhpDefinition({
     context,
-    identifier: new PhpIdentifier({ name: 'A', exported: false, kind: 'class' }),
+    identifier: new PhpIdentifier({ name: 'A', exported: false, type: 'class' }),
     value: new PhpClass([{ name: 'id', type: 'string' }])
   })
 
@@ -89,7 +89,7 @@ Deno.test('PhpFile renders the <?php + namespace header', () => {
     'User',
     new PhpDefinition({
       context,
-      identifier: new PhpIdentifier({ name: 'User', kind: 'class' }),
+      identifier: new PhpIdentifier({ name: 'User', type: 'class' }),
       value: new PhpClass([{ name: 'id', type: 'string' }])
     })
   )

--- a/deno/lang-python/mod.ts
+++ b/deno/lang-python/mod.ts
@@ -10,7 +10,7 @@
  *     subclasses of the abstract bases in `@skmtc/core` — each renders
  *     itself in its own `toString()`
  *   - the `register` family (`register`, `defineAndRegister`)
- *   - this language's `EntityKind` vocabulary
+ *   - this language's `EntityType` vocabulary
  *   - `sanitizePropertyName` + identifier/casing/visibility rules
  *   - syntax helpers
  *

--- a/deno/lang-rust/mod.ts
+++ b/deno/lang-rust/mod.ts
@@ -10,14 +10,14 @@
  *     subclasses of the abstract bases in `@skmtc/core` — each renders
  *     itself in its own `toString()`
  *   - the `register` family (`register`, `defineAndRegister`)
- *   - this language's `EntityKind` vocabulary
+ *   - this language's `EntityType` vocabulary
  *   - `sanitizePropertyName` + identifier/casing/visibility rules
  *   - syntax helpers
  *
  * Status: **early spike.** `RsFile`/`RsDefinition`/`RsStruct`/`RsEnum`
  * prove the core `FileBase`/`DefinitionBase` seam reaches a language whose
  * declaration vocabulary (`struct`/`enum`/`type`) outgrows the binary
- * `EntityType` — the forcing case for the opaque `Identifier.kind`. Native
+ * `EntityType` — the forcing case for the opaque `Identifier.type`. Native
  * tagged enums exercise the `oneOf` distinctive constraint. Not yet wired
  * into the engine.
  */
@@ -30,6 +30,6 @@ export const fileExtensions = ['.rs'] as const
 
 export { RsFile, type RsFileArgs } from './src/RsFile.ts'
 export { RsDefinition } from './src/RsDefinition.ts'
-export { RsIdentifier, isRsIdentifier, type RsEntityKind } from './src/RsIdentifier.ts'
+export { RsIdentifier, isRsIdentifier, type RsEntityType } from './src/RsIdentifier.ts'
 export { RsStruct, type RsFieldArgs } from './src/RsStruct.ts'
 export { RsEnum, type RsVariantArgs } from './src/RsEnum.ts'

--- a/deno/lang-rust/src/RsDefinition.ts
+++ b/deno/lang-rust/src/RsDefinition.ts
@@ -6,17 +6,17 @@ import { isRsIdentifier } from './RsIdentifier.ts'
  * Rust rendering of a {@link DefinitionBase} — a `pub struct X { … }`,
  * `pub enum X { … }`, or `pub type X = …;` declaration.
  *
- * The forcing case for the per-language `RsIdentifier` `kind`. TypeScript's
+ * The forcing case for the per-language `RsIdentifier` `type`. TypeScript's
  * binary `entityType` (`const`/`type`) and Go's uniform `type` keyword both
  * let the `Definition` pick its keyword without extra metadata. Rust cannot:
  * `struct`, `enum`, and `type` alias are all *type* entities, so the
  * keyword is recoverable only from a per-language discriminant the
- * engine never interprets — `RsIdentifier.kind`.
+ * engine never interprets — `RsIdentifier.type`.
  *
  * Visibility comes from the neutral `exported` fact, rendered as Rust's
  * `pub` keyword (leaving the name untouched — unlike Go's casing).
  *
- * `kind` is a fixed {@link import('./RsIdentifier.ts').RsEntityKind} union,
+ * `type` is a fixed {@link import('./RsIdentifier.ts').RsEntityType} union,
  * so the switch has a real `default` (the `type`-alias fallback) rather
  * than a `never` exhaustiveness guard: the language package, not core, owns
  * the keyword vocabulary.
@@ -32,7 +32,7 @@ export class RsDefinition extends DefinitionBase {
     const vis = identifier.exported ? 'pub ' : ''
     const name = identifier.name
 
-    switch (identifier.kind) {
+    switch (identifier.type) {
       case 'struct':
         return `${vis}struct ${name} ${this.value}`
       case 'enum':

--- a/deno/lang-rust/src/RsEnum.ts
+++ b/deno/lang-rust/src/RsEnum.ts
@@ -21,7 +21,7 @@ export type RsVariantArgs = {
  * `FileBase`/`DefinitionBase` seam confirms the abstraction reaches a
  * language whose declaration vocabulary (`struct` vs `enum` vs `type`) is
  * richer than the binary `EntityType` can express — which is what forces
- * the per-language `RsIdentifier.kind`.
+ * the per-language `RsIdentifier.type`.
  */
 export class RsEnum {
   variants: RsVariantArgs[]

--- a/deno/lang-rust/src/RsFile.ts
+++ b/deno/lang-rust/src/RsFile.ts
@@ -1,6 +1,7 @@
 import { CodeFileBase, matchDefinitions } from '@skmtc/core'
-import type { DefinitionBase, ImportBase, ReExportBase, Lang, FindDefinitionsQuery } from '@skmtc/core'
+import type { DefinitionBase, ImportBase, ReExportBase } from '@skmtc/core'
 import { RsIdentifier } from './RsIdentifier.ts'
+import type { RsEntityType } from './RsIdentifier.ts'
 
 /** Constructor arguments for {@link RsFile}. */
 export type RsFileArgs = {
@@ -21,7 +22,7 @@ export type RsFileArgs = {
  * (no Rust generator registers imports). Structured imports + `pub use`
  * re-exports land as the seam matures.
  */
-export class RsFile extends CodeFileBase<Lang<RsIdentifier>> {
+export class RsFile extends CodeFileBase {
   uses: string[] = []
 
   /** Definitions keyed by identifier name (first write wins). */
@@ -50,12 +51,12 @@ export class RsFile extends CodeFileBase<Lang<RsIdentifier>> {
   }
 
   override findDefinitions(
-    query?: FindDefinitionsQuery<Lang<RsIdentifier>>
+    query?: { name?: string; type?: RsEntityType }
   ): DefinitionBase[] | undefined {
     return matchDefinitions(
       [...this.definitions.values()],
       query,
-      identifier => (identifier instanceof RsIdentifier ? identifier.kind : undefined)
+      identifier => (identifier instanceof RsIdentifier ? identifier.type : undefined)
     )
   }
 

--- a/deno/lang-rust/src/RsIdentifier.ts
+++ b/deno/lang-rust/src/RsIdentifier.ts
@@ -2,43 +2,43 @@ import { IdentifierBase } from '@skmtc/core'
 import type { IdentifierBaseArgs } from '@skmtc/core'
 
 /**
- * Rust's declaration-kind vocabulary — the discriminant {@link RsDefinition}
+ * Rust's declaration-type vocabulary — the discriminant {@link RsDefinition}
  * reads to pick its keyword. All three are *type*-level entities (`struct`,
  * `enum`, and a `type` alias), so the keyword is recoverable only from this
- * per-language `kind`, not from a binary variable/type split.
+ * per-language `type`, not from a binary variable/type split.
  */
-export type RsEntityKind = 'struct' | 'enum' | 'type'
+export type RsEntityType = 'struct' | 'enum' | 'type'
 
 /**
  * Constructor arguments for {@link RsIdentifier} — the neutral
- * {@link IdentifierBaseArgs} plus this language's typed `kind`.
+ * {@link IdentifierBaseArgs} plus this language's typed `type`.
  */
 export type RsIdentifierArgs = IdentifierBaseArgs & {
-  kind: RsEntityKind
+  type: RsEntityType
 }
 
 /**
- * Rust's concrete {@link IdentifierBase}: adds the typed `kind`
- * ({@link RsEntityKind}) the renderer reads to pick its declaration keyword
+ * Rust's concrete {@link IdentifierBase}: adds the typed `type`
+ * ({@link RsEntityType}) the renderer reads to pick its declaration keyword
  * (`struct` / `enum` / `type`).
  *
  * The engine holds it as the neutral `IdentifierBase` (reading only
  * `.name`); {@link RsDefinition} narrows back to `RsIdentifier` via
- * {@link isRsIdentifier} to read `kind`.
+ * {@link isRsIdentifier} to read `type`.
  */
 export class RsIdentifier extends IdentifierBase {
-  /** Per-language declaration kind — drives the declaration keyword. */
-  kind: RsEntityKind
+  /** Per-language declaration type — drives the declaration keyword. */
+  type: RsEntityType
 
-  constructor({ name, typeName, exported, kind }: RsIdentifierArgs) {
+  constructor({ name, typeName, exported, type }: RsIdentifierArgs) {
     super({ name, typeName, exported })
-    this.kind = kind
+    this.type = type
   }
 }
 
 /**
  * Type guard narrowing a neutral {@link IdentifierBase} to an
- * {@link RsIdentifier} — the cast-free way the renderer reads `kind`.
+ * {@link RsIdentifier} — the cast-free way the renderer reads `type`.
  */
 export const isRsIdentifier = (identifier: IdentifierBase): identifier is RsIdentifier => {
   return identifier instanceof RsIdentifier

--- a/deno/lang-rust/src/render.test.ts
+++ b/deno/lang-rust/src/render.test.ts
@@ -12,7 +12,7 @@ const context = {} as unknown as GenerateContextType
 Deno.test('RsDefinition + RsStruct render the User DTO as a pub struct', () => {
   const definition = new RsDefinition({
     context,
-    identifier: new RsIdentifier({ name: 'User', kind: 'struct' }),
+    identifier: new RsIdentifier({ name: 'User', type: 'struct' }),
     value: new RsStruct([
       { name: 'id', type: 'String' },
       { name: 'name', type: 'String' },
@@ -44,7 +44,7 @@ Deno.test('RsDefinition + RsEnum render a oneOf as a native tagged enum', () => 
   // enum, where TypeScript would emit a union and Go has no sum type.
   const definition = new RsDefinition({
     context,
-    identifier: new RsIdentifier({ name: 'Pet', kind: 'enum' }),
+    identifier: new RsIdentifier({ name: 'Pet', type: 'enum' }),
     value: new RsEnum([
       { name: 'Cat', payload: 'Cat' },
       { name: 'Dog', payload: 'Dog' }
@@ -54,23 +54,23 @@ Deno.test('RsDefinition + RsEnum render a oneOf as a native tagged enum', () => 
   assertEquals(definition.toString(), 'pub enum Pet {\n\tCat(Cat),\n\tDog(Dog),\n}')
 })
 
-Deno.test('declaration keyword follows the opaque Identifier.kind', () => {
-  // All three are type-level entities — only the opaque `kind` differs.
-  // This was the forcing proof for `kind`: the old binary entityType
+Deno.test('declaration keyword follows the opaque Identifier.type', () => {
+  // All three are type-level entities — only the opaque `type` differs.
+  // This was the forcing proof for `type`: the old binary entityType
   // (deleted under F6) could not tell struct from enum from alias.
   const asStruct = new RsDefinition({
     context,
-    identifier: new RsIdentifier({ name: 'Thing', kind: 'struct' }),
+    identifier: new RsIdentifier({ name: 'Thing', type: 'struct' }),
     value: new RsStruct([{ name: 'id', type: 'String' }])
   })
   const asEnum = new RsDefinition({
     context,
-    identifier: new RsIdentifier({ name: 'Thing', kind: 'enum' }),
+    identifier: new RsIdentifier({ name: 'Thing', type: 'enum' }),
     value: new RsEnum([{ name: 'A' }])
   })
   const asAlias = new RsDefinition({
     context,
-    identifier: new RsIdentifier({ name: 'Thing', kind: 'type' }),
+    identifier: new RsIdentifier({ name: 'Thing', type: 'type' }),
     value: 'String'
   })
 
@@ -85,7 +85,7 @@ Deno.test('exported renders as the `pub` keyword, name untouched (contrast Go ca
   // (Go would capitalize it; Rust does not).
   const exported = new RsDefinition({
     context,
-    identifier: new RsIdentifier({ name: 'user', exported: true, kind: 'struct' }),
+    identifier: new RsIdentifier({ name: 'user', exported: true, type: 'struct' }),
     value: new RsStruct([{ name: 'id', type: 'String' }])
   })
   assertEquals(exported.toString().startsWith('pub struct user '), true)
@@ -93,7 +93,7 @@ Deno.test('exported renders as the `pub` keyword, name untouched (contrast Go ca
   // Unexported intent → no `pub`, name kept verbatim.
   const private_ = new RsDefinition({
     context,
-    identifier: new RsIdentifier({ name: 'Secret', exported: false, kind: 'struct' }),
+    identifier: new RsIdentifier({ name: 'Secret', exported: false, type: 'struct' }),
     value: new RsStruct([{ name: 'id', type: 'String' }])
   })
   assertEquals(private_.toString().startsWith('struct Secret '), true)
@@ -112,7 +112,7 @@ Deno.test('RsFile assembles use imports + definitions', () => {
     'User',
     new RsDefinition({
       context,
-      identifier: new RsIdentifier({ name: 'User', kind: 'struct' }),
+      identifier: new RsIdentifier({ name: 'User', type: 'struct' }),
       value: new RsStruct([{ name: 'id', type: 'String' }])
     })
   )

--- a/deno/lang-typescript/mod.ts
+++ b/deno/lang-typescript/mod.ts
@@ -39,7 +39,7 @@ export const langId = 'typescript' as const
 /** File extensions this language package renders. */
 export const fileExtensions = ['.ts', '.tsx'] as const
 
-export { typescript, type TsLang } from './src/tsLang.ts'
+export { typescript } from './src/tsLang.ts'
 export { TsSnippet } from './src/TsSnippet.ts'
 export {
   register,
@@ -57,12 +57,7 @@ export { TsDefinition, type TsDefinitionArgs } from './src/TsDefinition.ts'
 export { TsImport, type TsImportSpecifier, type ImportNameArg } from './src/TsImport.ts'
 export { TsReExport } from './src/TsReExport.ts'
 export { TsObject, type TsPropertyArgs } from './src/TsObject.ts'
-export {
-  TsIdentifier,
-  isTsIdentifier,
-  type TsIdentifierType,
-  type TsIdentifierArgs
-} from './src/TsIdentifier.ts'
+export { TsIdentifier, type TsIdentifierType, type TsIdentifierArgs } from './src/TsIdentifier.ts'
 
 // TypeScript syntax helpers + naming layer (moved from @skmtc/core — F5/F6)
 export * from './src/List.ts'
@@ -82,11 +77,11 @@ export {
   createInterface,
   createNamespace,
   toTsKeyword,
-  toTsEntityKind,
-  isTsEntityKind,
-  isBlockKind,
-  isTypeOnlyKind,
-  type TsEntityKind,
+  toTsEntityType,
+  isTsEntityType,
+  isBlockType,
+  isTypeOnly,
+  type TsEntityType,
   type CreateVariableArgs,
   type CreateTypeArgs,
   type CreateDeclarationArgs

--- a/deno/lang-typescript/src/TsDefinition.ts
+++ b/deno/lang-typescript/src/TsDefinition.ts
@@ -1,16 +1,15 @@
 import { DefinitionBase } from '@skmtc/core'
-import invariant from 'npm:tiny-invariant@1.3.3'
 import { withDescription } from './withDescription.ts'
-import { toTsKeyword, isBlockKind } from './createIdentifier.ts'
-import { isTsIdentifier } from './TsIdentifier.ts'
-import type { GeneratedValue, GenerateContextType, IdentifierBase } from '@skmtc/core'
+import { toTsKeyword, isBlockType } from './createIdentifier.ts'
+import type { GeneratedValue, GenerateContextType } from '@skmtc/core'
+import type { TsIdentifier } from './TsIdentifier.ts'
 
 /**
  * Constructor arguments for {@link TsDefinition}.
  */
 export type TsDefinitionArgs<Value extends GeneratedValue> = {
   context: GenerateContextType
-  identifier: IdentifierBase
+  identifier: TsIdentifier
   value: Value
   description?: string
   /**
@@ -28,12 +27,25 @@ export type TsDefinitionArgs<Value extends GeneratedValue> = {
  * `description`). Owns the rendering that previously lived on the engine's
  * `Definition`, byte-for-byte.
  */
-export class TsDefinition<Value extends GeneratedValue = GeneratedValue> extends DefinitionBase<Value> {
+export class TsDefinition<
+  Value extends GeneratedValue = GeneratedValue
+> extends DefinitionBase<Value> {
+  /** Narrows the inherited neutral `identifier` to the concrete TS subclass
+   *  (the constructor only accepts a {@link TsIdentifier}). */
+  declare identifier: TsIdentifier
+
   description: string | undefined
   leadingComment: string | undefined
   noExport: boolean | undefined
 
-  constructor({ context, identifier, value, description, leadingComment, noExport }: TsDefinitionArgs<Value>) {
+  constructor({
+    context,
+    identifier,
+    value,
+    description,
+    leadingComment,
+    noExport
+  }: TsDefinitionArgs<Value>) {
     super({ context, identifier, value })
 
     this.description = description
@@ -42,32 +54,36 @@ export class TsDefinition<Value extends GeneratedValue = GeneratedValue> extends
   }
 
   override toString(): string {
-    invariant(
-      isTsIdentifier(this.identifier),
-      `TsDefinition needs a TsIdentifier to render '${this.identifier.name}', got a foreign identifier`
-    )
-
-    const { kind, name, typeName } = this.identifier
+    const { type, name, typeName } = this.identifier
     const exportPrefix = this.noExport ? '' : 'export '
-    const keyword = toTsKeyword(kind)
+    const keyword = toTsKeyword(type)
 
     const leadingComment = this.leadingComment
-      ? this.leadingComment.split('\n').map(line => `// ${line}\n`).join('')
+      ? this.leadingComment
+          .split('\n')
+          .map(line => `// ${line}\n`)
+          .join('')
       : ''
 
     // Block-form declarations (class / interface / declare namespace) take no
     // `= value` and no trailing `;` — the value carries the heritage and the
     // braced body.
-    if (isBlockKind(kind)) {
-      return leadingComment + withDescription(`${exportPrefix}${keyword} ${name} ${this.value}\n`, {
-        description: this.description
-      })
+    if (isBlockType(type)) {
+      return (
+        leadingComment +
+        withDescription(`${exportPrefix}${keyword} ${name} ${this.value}\n`, {
+          description: this.description
+        })
+      )
     }
 
     const identifier = typeName ? `${name}: ${typeName}` : name
 
-    return leadingComment + withDescription(`${exportPrefix}${keyword} ${identifier} = ${this.value};\n`, {
-      description: this.description
-    })
+    return (
+      leadingComment +
+      withDescription(`${exportPrefix}${keyword} ${identifier} = ${this.value};\n`, {
+        description: this.description
+      })
+    )
   }
 }

--- a/deno/lang-typescript/src/TsFile.test.ts
+++ b/deno/lang-typescript/src/TsFile.test.ts
@@ -178,7 +178,7 @@ Deno.test('toDefinition falls back to the value description for the JSDoc', () =
   )
 })
 
-Deno.test('TsFile renders same-name companions (declaration merging) after primaries', () => {
+Deno.test('TsFile renders declaration-merging slots — class + same-name namespace co-exist', () => {
   const tsFile = new TsFile({ path: '@/resources/models.generated.ts', settings: undefined })
 
   const classDef = new TsDefinition({
@@ -199,22 +199,22 @@ Deno.test('TsFile renders same-name companions (declaration merging) after prima
 
   tsFile.addDefinition(classDef)
   tsFile.addDefinition(interfaceDef)
-  tsFile.addDefinition(namespaceDef) // same name as the class → companion
+  tsFile.addDefinition(namespaceDef) // same name, different type → its own declaration slot
   tsFile.addDefinition(classDef) // exact re-add → idempotent no-op
 
-  assertEquals(tsFile.mergedDefinitions.length, 1)
+  assertEquals(tsFile.definitions.size, 3) // 'class Models', 'interface Model', 'declare namespace Models' — one map, no overflow lane
   assertEquals(
     tsFile.toString(),
     `export class Models extends APIResource {}\n\nexport interface Model { id: string }\n\nexport declare namespace Models { export { type Model as Model } }\n`
   )
 })
 
-Deno.test('TsFile collapses same-name + same-kind definitions (duplicate, not a companion)', () => {
+Deno.test('TsFile collapses same-name + same-type definitions into one slot', () => {
   const tsFile = new TsFile({ path: '@/tables/models.generated.tsx', settings: undefined })
 
-  // Two distinct objects, same identifier (name + kind) — e.g. a `columnHelper`
+  // Two distinct objects, same identifier (name + type) — e.g. a `columnHelper`
   // const each table column independently registers. They are the same `const`,
-  // so they collapse to one rather than piling up as merge companions.
+  // so they share one declaration slot and collapse to one.
   const first = new TsDefinition({
     context: mockContext,
     identifier: createVariable('columnHelper'),
@@ -229,14 +229,14 @@ Deno.test('TsFile collapses same-name + same-kind definitions (duplicate, not a 
   tsFile.addDefinition(first)
   tsFile.addDefinition(second)
 
-  assertEquals(tsFile.mergedDefinitions.length, 0)
+  assertEquals(tsFile.definitions.size, 1)
   assertEquals(tsFile.toString(), `export const columnHelper = createColumnHelper<Row>();\n`)
 })
 
-Deno.test('TsFile collapses same-name + same-kind even when the value differs (the identifier is the key)', () => {
+Deno.test('TsFile collapses same-name + same-type even when the value differs (the identifier is the key)', () => {
   const tsFile = new TsFile({ path: '@/types/models.generated.ts', settings: undefined })
 
-  // Same name + same kind (`type`) — TS cannot redeclare a type alias, so the
+  // Same name + same type (`type`) — TS cannot redeclare a type alias, so the
   // first wins and the second is dropped (not merged), regardless of value.
   tsFile.addDefinition(
     new TsDefinition({ context: mockContext, identifier: createType('Id'), value: value('string') })
@@ -245,7 +245,7 @@ Deno.test('TsFile collapses same-name + same-kind even when the value differs (t
     new TsDefinition({ context: mockContext, identifier: createType('Id'), value: value('number') })
   )
 
-  assertEquals(tsFile.mergedDefinitions.length, 0)
+  assertEquals(tsFile.definitions.size, 1)
   assertEquals(tsFile.toString(), `export type Id = string;\n`)
 })
 

--- a/deno/lang-typescript/src/TsFile.ts
+++ b/deno/lang-typescript/src/TsFile.ts
@@ -1,25 +1,11 @@
 import { CodeFileBase, matchDefinitions } from '@skmtc/core'
 import { normalizeModuleName } from './normalizeModuleName.ts'
-import type {
-  ClientSettings,
-  ModulePackage,
-  DefinitionBase,
-  ImportBase,
-  ReExportBase,
-  FindDefinitionsQuery
-} from '@skmtc/core'
+import type { ClientSettings, ModulePackage, DefinitionBase } from '@skmtc/core'
 import { TsImport } from './TsImport.ts'
+import type { TsDefinition } from './TsDefinition.ts'
 import { TsIdentifier } from './TsIdentifier.ts'
-import type { TsEntityKind } from './createIdentifier.ts'
-import type { TsLang } from './tsLang.ts'
+import type { TsEntityType } from './createIdentifier.ts'
 import { TsReExport } from './TsReExport.ts'
-
-/** A definition's TypeScript declaration kind, read off its identifier — the
- *  language-neutral `IdentifierBase` carries no `kind`, so narrow to the TS
- *  subclass. `undefined` for a non-TS identifier (shouldn't occur in a TsFile;
- *  treated as a kindless declaration). */
-const declarationKind = (definition: DefinitionBase): TsEntityKind | undefined =>
-  definition.identifier instanceof TsIdentifier ? definition.identifier.kind : undefined
 
 /**
  * Constructor arguments for {@link TsFile}.
@@ -31,35 +17,34 @@ export type TsFileArgs = {
 
 /**
  * TypeScript's concrete code file. Owns the storage AND the dedup/merge
- * policy that the neutral {@link CodeFileBase} only declares: the name-keyed
- * definition map (with declaration-merging companions), the per-module import
- * and re-export merges, package-aware module-name normalisation, and the
- * rendering arrangement (re-exports, then imports, then definitions). Owns
- * what the engine's `File` rendered, byte-for-byte.
+ * policy that the neutral {@link CodeFileBase} only declares: the definition
+ * map keyed by each identifier's declaration slot
+ * ({@link TsIdentifier.declarationKey}, so a `class Foo` and a `declare
+ * namespace Foo` co-exist), the per-module import and re-export merges,
+ * package-aware module-name normalisation, and the rendering arrangement
+ * (re-exports, then imports, then definitions). Owns what the engine's `File`
+ * rendered, byte-for-byte.
  */
-export class TsFile extends CodeFileBase<TsLang> {
+export class TsFile extends CodeFileBase {
   /** Package configuration for cross-package module-name resolution. */
   packages: ModulePackage[] | undefined
 
   /**
-   * Definitions keyed by identifier name — the cross-generator cache's
-   * one-definition-per-name surface, read through {@link findDefinition}.
+   * Definitions keyed by each identifier's declaration slot
+   * ({@link TsIdentifier.declarationKey} — `(type, name)`). A later definition
+   * for a slot already taken collapses into the first; distinct slots that
+   * share a name (a `class Foo` and a `declare namespace Foo`) both live here
+   * — that is how TypeScript declaration merging is represented, no separate
+   * collection needed. The cross-generator cache resolves a name to its
+   * first-registered definition through {@link findDefinitions}.
    */
-  definitions: Map<string, DefinitionBase> = new Map()
+  definitions: Map<string, TsDefinition> = new Map()
 
-  /** Imports keyed by {@link ImportBase.mergeKey} (the module path). */
-  imports: Map<string, ImportBase> = new Map()
+  /** Imports keyed by {@link TsImport.mergeKey} (the module path). */
+  imports: Map<string, TsImport> = new Map()
 
-  /** Re-exports keyed by {@link ReExportBase.mergeKey} (the module path). */
-  reExports: Map<string, ReExportBase> = new Map()
-
-  /**
-   * Same-name companion definitions — TypeScript declaration merging, e.g. a
-   * `class Foo` and its `export declare namespace Foo`. Kept apart from the
-   * name-keyed {@link definitions} map (so the cross-generator cache stays
-   * one-definition-per-name) and rendered after the primaries.
-   */
-  mergedDefinitions: DefinitionBase[] = []
+  /** Re-exports keyed by {@link TsReExport.mergeKey} (the module path). */
+  reExports: Map<string, TsReExport> = new Map()
 
   constructor({ path, settings }: TsFileArgs) {
     super({ path })
@@ -67,50 +52,31 @@ export class TsFile extends CodeFileBase<TsLang> {
   }
 
   /**
-   * TypeScript's duplication rule, keyed by the definition's *identifier*
-   * (name + kind), not its rendered value. The first definition for a name is
-   * the primary (the cross-generator cache resolves it). A later definition
-   * reusing the name is:
-   *
-   * - the **same declaration** (same kind) → an idempotent no-op. Generators
-   *   legitimately register the same helper from multiple call sites (e.g. a
-   *   `columnHelper` const built once per table column), producing distinct
-   *   objects that are the same `const` — those collapse to one.
-   * - a **different kind** → a declaration-merging companion (a `class` + its
-   *   `declare namespace`), rendered after the primaries.
+   * TypeScript's duplication rule, keyed by the identifier's declaration slot
+   * ({@link TsIdentifier.declarationKey} — `(type, name)`), not its rendered
+   * value. The first definition for a slot wins; a later definition for the
+   * same slot is the same declaration and collapses to a no-op — e.g. a
+   * `columnHelper` const independently registered per table column (distinct
+   * objects, same `const`), or a type alias re-registered with a different
+   * value (the identifier, not the value, is the key). Definitions that share
+   * a name but differ in type occupy *different* slots and both render — that
+   * is TypeScript declaration merging (a `class Foo` and its `declare
+   * namespace Foo`).
    */
-  override addDefinition(definition: DefinitionBase): void {
-    const name = definition.identifier.name
-    const kind = declarationKind(definition)
-    const existing = this.definitions.get(name)
+  override addDefinition(definition: TsDefinition): void {
+    const key = definition.identifier.declarationKey()
 
-    if (existing === undefined) {
-      this.definitions.set(name, definition)
-      return
+    if (!this.definitions.has(key)) {
+      this.definitions.set(key, definition)
     }
-
-    // Same name + same kind = the same declaration → collapse.
-    if (declarationKind(existing) === kind) {
-      return
-    }
-    // Already captured a companion of this kind for the name.
-    if (
-      this.mergedDefinitions.some(
-        merged => merged.identifier.name === name && declarationKind(merged) === kind
-      )
-    ) {
-      return
-    }
-
-    this.mergedDefinitions.push(definition)
   }
 
   /**
    * Merge imports in, collapsing any that share a `mergeKey()` (the module)
-   * with an existing entry via {@link ImportBase.merge}. The neutral
+   * with an existing entry via {@link TsImport.merge}. The neutral
    * `register` calls this; the keying + merge are TypeScript's own policy.
    */
-  override addImports(incoming: ImportBase[]): void {
+  override addImports(incoming: TsImport[]): void {
     for (const importEntry of incoming) {
       const key = importEntry.mergeKey()
       const existing = this.imports.get(key)
@@ -121,9 +87,9 @@ export class TsFile extends CodeFileBase<TsLang> {
 
   /**
    * Merge re-exports in, collapsing any that share a `mergeKey()` (the module)
-   * with an existing entry via {@link ReExportBase.merge}.
+   * with an existing entry via {@link TsReExport.merge}.
    */
-  override addReExports(incoming: ReExportBase[]): void {
+  override addReExports(incoming: TsReExport[]): void {
     for (const reExportEntry of incoming) {
       const key = reExportEntry.mergeKey()
       const existing = this.reExports.get(key)
@@ -133,29 +99,24 @@ export class TsFile extends CodeFileBase<TsLang> {
   }
 
   /**
-   * Query definitions by `name` and/or declaration `kind`. No query → all
-   * (primaries + declaration-merging companions). The engine's read seam
-   * (`findDefinitions({ name })?.[0]`) plus the generator/test inspection
-   * surface (`findDefinitions({ type: 'class' })`).
+   * Query definitions by `name` and/or declaration `type`. No query → every
+   * definition. The cross-generator cache's read seam
+   * (`findDefinitions({ name })?.[0]` → the first-registered definition for a
+   * name) plus the generator/test inspection surface
+   * (`findDefinitions({ type: 'class' })`).
    */
-  override findDefinitions(query?: FindDefinitionsQuery<TsLang>): DefinitionBase[] | undefined {
+  override findDefinitions(query?: { name?: string; type?: TsEntityType }): DefinitionBase[] | undefined {
     return matchDefinitions(
-      [...this.definitions.values(), ...this.mergedDefinitions],
+      [...this.definitions.values()],
       query,
-      identifier => (identifier instanceof TsIdentifier ? identifier.kind : undefined)
+      identifier => (identifier instanceof TsIdentifier ? identifier.type : undefined)
     )
   }
 
   override toString(): string {
     const reExports = Array.from(this.reExports.values()).map(reExportEntry => {
-      // Re-exports land here as the neutral `ReExportBase`; in a
-      // TypeScript file they are always `TsReExport`s. Re-key to the
-      // package-normalised module at render time — the same arrangement
-      // step the import section gets.
-      if (!(reExportEntry instanceof TsReExport)) {
-        return reExportEntry.toString()
-      }
-
+      // Re-key to the package-normalised module at render time — the same
+      // arrangement step the import section gets.
       const updatedModuleName = normalizeModuleName({
         destinationPath: this.path,
         exportPath: reExportEntry.module,
@@ -166,13 +127,8 @@ export class TsFile extends CodeFileBase<TsLang> {
     })
 
     const imports = Array.from(this.imports.values()).map(importEntry => {
-      // Imports land here as the neutral `ImportBase`; in a TypeScript file
-      // they are always `TsImport`s. Re-key to the package-normalised module
-      // at render time (the engine normalised per-import in `File.toString`).
-      if (!(importEntry instanceof TsImport)) {
-        return importEntry.toString()
-      }
-
+      // Re-key to the package-normalised module at render time (the engine
+      // normalised per-import in `File.toString`).
       const updatedModuleName = this.packages
         ? normalizeModuleName({
             destinationPath: this.path,
@@ -184,7 +140,7 @@ export class TsFile extends CodeFileBase<TsLang> {
       return new TsImport(updatedModuleName, importEntry.specifiers).toString()
     })
 
-    const definitions = [...this.definitions.values(), ...this.mergedDefinitions]
+    const definitions = [...this.definitions.values()]
 
     const body = [reExports, imports, definitions]
       .filter(section => Boolean(section.length))

--- a/deno/lang-typescript/src/TsIdentifier.ts
+++ b/deno/lang-typescript/src/TsIdentifier.ts
@@ -1,49 +1,47 @@
 import { IdentifierBase } from '@skmtc/core'
 import type { IdentifierBaseArgs, IdentifierType } from '@skmtc/core'
-import type { TsEntityKind } from './createIdentifier.ts'
-import type { TsLang } from './tsLang.ts'
+import { toTsKeyword, type TsEntityType } from './createIdentifier.ts'
 
 /**
- * The non-`name` parts of a TypeScript identifier — the tightened
- * `IdentifierType` a TS projection's `toIdentifierType` returns. Core's
- * `IdentifierType<TsLang>` recovers the `kind` from {@link TsLang}'s
- * identifier ({@link TsEntityKind}); this alias is the named form generators
- * annotate with. The engine spreads it into
+ * The non-`name` parts of a TypeScript identifier — core's neutral
+ * {@link IdentifierType} with its `type` narrowed to TypeScript's fixed
+ * {@link TsEntityType} vocabulary. This is the named form generators annotate
+ * `toIdentifierType` with; a projection-base veneer threads it as the config's
+ * `IdType` so the return tightens with no recast. The engine spreads it into
  * `lang.toIdentifier({ name, ...identifierType })`.
  */
-export type TsIdentifierType = IdentifierType<TsLang>
+export type TsIdentifierType = IdentifierType & { type: TsEntityType }
 
 /**
  * Constructor arguments for {@link TsIdentifier} — the neutral
- * {@link IdentifierBaseArgs} plus this language's typed `kind`.
+ * {@link IdentifierBaseArgs} plus this language's typed `type`.
  */
 export type TsIdentifierArgs = IdentifierBaseArgs & {
-  kind: TsEntityKind
+  type: TsEntityType
 }
 
 /**
- * TypeScript's concrete {@link IdentifierBase}: adds the typed `kind`
- * ({@link TsEntityKind}) the renderer reads to pick its declaration keyword
+ * TypeScript's concrete {@link IdentifierBase}: adds the typed `type`
+ * ({@link TsEntityType}) the renderer reads to pick its declaration keyword
  * (`const` / `type`) and its import form (plain / type-only).
- *
- * The engine holds it as the neutral `IdentifierBase` (reading only
- * `.name`); `TsDefinition` / `TsImport` narrow back to `TsIdentifier` via
- * {@link isTsIdentifier} to read `kind`.
  */
 export class TsIdentifier extends IdentifierBase {
-  /** Per-language declaration kind — `const` / `type` and import form. */
-  kind: TsEntityKind
+  /** Per-language declaration type — `const` / `type` and import form. */
+  type: TsEntityType
 
-  constructor({ name, typeName, exported, kind }: TsIdentifierArgs) {
+  constructor({ name, typeName, exported, type }: TsIdentifierArgs) {
     super({ name, typeName, exported })
-    this.kind = kind
+    this.type = type
   }
-}
 
-/**
- * Type guard narrowing a neutral {@link IdentifierBase} to a
- * {@link TsIdentifier} — the cast-free way the renderers read `kind`.
- */
-export const isTsIdentifier = (identifier: IdentifierBase): identifier is TsIdentifier => {
-  return identifier instanceof TsIdentifier
+  /**
+   * TypeScript's declaration slot is the declaration header `<keyword> <name>`
+   * (`const thing`, `class Thing`, `declare namespace Thing`) — exactly how
+   * the declaration opens. A `class Foo` and a `declare namespace Foo` are
+   * separate declarations the compiler merges, so the differing keyword keeps
+   * their keys distinct while exact repeats still collapse.
+   */
+  override declarationKey(): string {
+    return `${toTsKeyword(this.type)} ${this.name}`
+  }
 }

--- a/deno/lang-typescript/src/TsImport.ts
+++ b/deno/lang-typescript/src/TsImport.ts
@@ -1,9 +1,7 @@
 import { ImportBase } from '@skmtc/core'
-import invariant from 'npm:tiny-invariant@1.3.3'
 import { List } from './List.ts'
-import { isTsIdentifier } from './TsIdentifier.ts'
-import type { IdentifierBase } from '@skmtc/core'
-import { isTypeOnlyKind, type TsEntityKind } from './createIdentifier.ts'
+import type { TsIdentifier } from './TsIdentifier.ts'
+import { isTypeOnly, type TsEntityType } from './createIdentifier.ts'
 
 /**
  * The concise import form a TypeScript generator passes to `register` —
@@ -16,7 +14,7 @@ import { isTypeOnlyKind, type TsEntityKind } from './createIdentifier.ts'
 export type ImportNameArg =
   | string
   | { [name: string]: string }
-  | { name: string; alias?: string; type?: TsEntityKind }
+  | { name: string; alias?: string; type?: TsEntityType }
 
 /**
  * A single imported symbol on a {@link TsImport}.
@@ -82,20 +80,14 @@ export class TsImport extends ImportBase {
   }
 
   /**
-   * Build the import of a single {@link IdentifierBase} from `module` — the
+   * Build the import of a single {@link TsIdentifier} from `module` — the
    * cross-file import a Driver registers when a generator references a
-   * peer's Definition. The identifier's `kind` drives `typeOnly`
-   * (so a type identifier emits `import { type X }`), so it must be a
-   * {@link TsIdentifier}; narrowed cast-free via {@link isTsIdentifier}.
+   * peer's Definition. The identifier's `type` drives `typeOnly` (so a type
+   * identifier emits `import { type X }`).
    */
-  static fromIdentifier(module: string, identifier: IdentifierBase): TsImport {
-    invariant(
-      isTsIdentifier(identifier),
-      `TsImport needs a TsIdentifier to import '${identifier.name}', got a foreign identifier`
-    )
-
+  static fromIdentifier(module: string, identifier: TsIdentifier): TsImport {
     return new TsImport(module, [
-      { name: identifier.name, typeOnly: isTypeOnlyKind(identifier.kind) }
+      { name: identifier.name, typeOnly: isTypeOnly(identifier.type) }
     ])
   }
 
@@ -103,7 +95,7 @@ export class TsImport extends ImportBase {
     return this.module
   }
 
-  override merge(other: ImportBase): ImportBase {
+  override merge(other: ImportBase): TsImport {
     if (!(other instanceof TsImport)) {
       throw new Error(`Cannot merge a TsImport with a ${other.constructor.name}`)
     }
@@ -125,7 +117,11 @@ export class TsImport extends ImportBase {
     // Statement-level `import type { … }` when there's no namespace and
     // every named import is type-only. The per-name `type` form is equally
     // valid; this is purely the more readable output the engine emits.
-    if (named.length > 0 && namespace === undefined && named.every(specifier => specifier.typeOnly)) {
+    if (
+      named.length > 0 &&
+      namespace === undefined &&
+      named.every(specifier => specifier.typeOnly)
+    ) {
       const names = named.map(specifier =>
         specifier.alias ? `${specifier.name} as ${specifier.alias}` : specifier.name
       )
@@ -133,9 +129,14 @@ export class TsImport extends ImportBase {
     }
 
     const importObject =
-      named.length > 0 || namespace === undefined ? List.toObject(named.map(renderSpecifier)) : undefined
+      named.length > 0 || namespace === undefined
+        ? List.toObject(named.map(renderSpecifier))
+        : undefined
     const namespaceRender = namespace ? `* as ${namespace.alias}` : undefined
-    const importItems = new List([namespaceRender, importObject], { separator: ', ', skipEmpty: true })
+    const importItems = new List([namespaceRender, importObject], {
+      separator: ', ',
+      skipEmpty: true
+    })
 
     return `import ${importItems} from '${this.module}'`
   }

--- a/deno/lang-typescript/src/TsReExport.ts
+++ b/deno/lang-typescript/src/TsReExport.ts
@@ -26,9 +26,9 @@ export class TsReExport extends ReExportBase {
   static fromConcise(module: string, identifiers: TsIdentifier[]): TsReExport {
     const groups: Record<string, Set<string>> = {}
     for (const identifier of identifiers) {
-      const kind = identifier.kind
-      groups[kind] ??= new Set()
-      groups[kind].add(identifier.name)
+      const type = identifier.type
+      groups[type] ??= new Set()
+      groups[type].add(identifier.name)
     }
     return new TsReExport(module, groups)
   }
@@ -37,7 +37,7 @@ export class TsReExport extends ReExportBase {
     return this.module
   }
 
-  override merge(other: ReExportBase): ReExportBase {
+  override merge(other: ReExportBase): TsReExport {
     if (!(other instanceof TsReExport)) {
       throw new Error(`Cannot merge a TsReExport with a ${other.constructor.name}`)
     }

--- a/deno/lang-typescript/src/TsSnippet.ts
+++ b/deno/lang-typescript/src/TsSnippet.ts
@@ -1,5 +1,5 @@
-import { SnippetBase, type GeneratedValue } from '@skmtc/core'
-import { typescript, type TsLang } from './tsLang.ts'
+import { SnippetBase, type GeneratedValue, type Lang } from '@skmtc/core'
+import { typescript } from './tsLang.ts'
 import {
   register,
   defineAndRegister,
@@ -29,12 +29,11 @@ import type { TsDefinition } from './TsDefinition.ts'
  */
 export class TsSnippet extends SnippetBase {
   /**
-   * The language every class built on this base renders into. Typed
-   * {@link TsLang} (not the loose `Lang`) so a projection-base veneer
-   * inferring `L` from `base: TsSnippet` lands on `TsLang` — the tightening
-   * that lets `toIdentifierType` return `IdentifierType<TsLang>`.
+   * The language every class built on this base renders into. The neutral
+   * {@link Lang} — the engine reads it language-blind; TypeScript's fixed
+   * `type` vocabulary lives on this package's concrete types, not here.
    */
-  static lang: TsLang = typescript
+  static lang: Lang = typescript
 
   /**
    * Register imports / definitions into the file at `destinationPath`,

--- a/deno/lang-typescript/src/createIdentifier.test.ts
+++ b/deno/lang-typescript/src/createIdentifier.test.ts
@@ -6,10 +6,10 @@ import {
   createInterface,
   createNamespace,
   toTsKeyword,
-  toTsEntityKind,
-  isTsEntityKind,
-  isBlockKind,
-  isTypeOnlyKind
+  toTsEntityType,
+  isTsEntityType,
+  isBlockType,
+  isTypeOnly
 } from './createIdentifier.ts'
 
 Deno.test('createVariable - creates untyped variable', () => {
@@ -17,7 +17,7 @@ Deno.test('createVariable - creates untyped variable', () => {
 
   assertEquals(identifier.name, 'userName')
   assertEquals(identifier.typeName, undefined)
-  assertEquals(identifier.kind, 'variable')
+  assertEquals(identifier.type, 'variable')
   assertEquals(identifier.exported, true)
   assertEquals(identifier.toString(), 'userName')
 })
@@ -26,7 +26,7 @@ Deno.test('createVariable - creates typed variable', () => {
   const identifier = createVariable('userId', { typeName: 'string' })
 
   assertEquals(identifier.typeName, 'string')
-  assertEquals(identifier.kind, 'variable')
+  assertEquals(identifier.type, 'variable')
 })
 
 Deno.test('createVariable - exported can be switched off', () => {
@@ -40,7 +40,7 @@ Deno.test('createType - creates type identifier', () => {
 
   assertEquals(identifier.name, 'User')
   assertEquals(identifier.typeName, undefined)
-  assertEquals(identifier.kind, 'type')
+  assertEquals(identifier.type, 'type')
   assertEquals(identifier.toString(), 'User')
 })
 
@@ -48,7 +48,7 @@ Deno.test('createClass - creates class identifier', () => {
   const identifier = createClass('Models')
 
   assertEquals(identifier.name, 'Models')
-  assertEquals(identifier.kind, 'class')
+  assertEquals(identifier.type, 'class')
   assertEquals(identifier.exported, true)
   assertEquals(identifier.toString(), 'Models')
 })
@@ -57,17 +57,17 @@ Deno.test('createInterface - creates interface identifier', () => {
   const identifier = createInterface('Model')
 
   assertEquals(identifier.name, 'Model')
-  assertEquals(identifier.kind, 'interface')
+  assertEquals(identifier.type, 'interface')
 })
 
 Deno.test('createNamespace - creates namespace identifier', () => {
   const identifier = createNamespace('Models')
 
   assertEquals(identifier.name, 'Models')
-  assertEquals(identifier.kind, 'namespace')
+  assertEquals(identifier.type, 'namespace')
 })
 
-Deno.test('toTsKeyword - maps the TypeScript kind vocabulary', () => {
+Deno.test('toTsKeyword - maps the TypeScript type vocabulary', () => {
   assertEquals(toTsKeyword('variable'), 'const')
   assertEquals(toTsKeyword('type'), 'type')
   assertEquals(toTsKeyword('class'), 'class')
@@ -75,37 +75,37 @@ Deno.test('toTsKeyword - maps the TypeScript kind vocabulary', () => {
   assertEquals(toTsKeyword('namespace'), 'declare namespace')
 })
 
-Deno.test('toTsKeyword - throws on a kind outside the vocabulary', () => {
-  assertThrows(() => toTsKeyword('struct'), Error, 'Unknown TypeScript entity kind')
+Deno.test('toTsKeyword - throws on a type outside the vocabulary', () => {
+  assertThrows(() => toTsKeyword('struct'), Error, 'Unknown TypeScript entity type')
 })
 
-Deno.test('isTsEntityKind - guards the TypeScript kind vocabulary', () => {
-  assertEquals(isTsEntityKind('class'), true)
-  assertEquals(isTsEntityKind('namespace'), true)
-  assertEquals(isTsEntityKind('struct'), false)
+Deno.test('isTsEntityType - guards the TypeScript type vocabulary', () => {
+  assertEquals(isTsEntityType('class'), true)
+  assertEquals(isTsEntityType('namespace'), true)
+  assertEquals(isTsEntityType('struct'), false)
 })
 
-Deno.test('toTsEntityKind - narrows every TypeScript kind', () => {
-  assertEquals(toTsEntityKind('variable'), 'variable')
-  assertEquals(toTsEntityKind('type'), 'type')
-  assertEquals(toTsEntityKind('class'), 'class')
-  assertEquals(toTsEntityKind('interface'), 'interface')
-  assertEquals(toTsEntityKind('namespace'), 'namespace')
-  assertThrows(() => toTsEntityKind('struct'), Error, 'Unknown TypeScript entity kind')
+Deno.test('toTsEntityType - narrows every TypeScript type', () => {
+  assertEquals(toTsEntityType('variable'), 'variable')
+  assertEquals(toTsEntityType('type'), 'type')
+  assertEquals(toTsEntityType('class'), 'class')
+  assertEquals(toTsEntityType('interface'), 'interface')
+  assertEquals(toTsEntityType('namespace'), 'namespace')
+  assertThrows(() => toTsEntityType('struct'), Error, 'Unknown TypeScript entity type')
 })
 
-Deno.test('isBlockKind - class / interface / namespace render block-form', () => {
-  assertEquals(isBlockKind('class'), true)
-  assertEquals(isBlockKind('interface'), true)
-  assertEquals(isBlockKind('namespace'), true)
-  assertEquals(isBlockKind('variable'), false)
-  assertEquals(isBlockKind('type'), false)
+Deno.test('isBlockType - class / interface / namespace render block-form', () => {
+  assertEquals(isBlockType('class'), true)
+  assertEquals(isBlockType('interface'), true)
+  assertEquals(isBlockType('namespace'), true)
+  assertEquals(isBlockType('variable'), false)
+  assertEquals(isBlockType('type'), false)
 })
 
-Deno.test('isTypeOnlyKind - type and interface import type-only', () => {
-  assertEquals(isTypeOnlyKind('type'), true)
-  assertEquals(isTypeOnlyKind('interface'), true)
-  assertEquals(isTypeOnlyKind('variable'), false)
-  assertEquals(isTypeOnlyKind('class'), false)
-  assertEquals(isTypeOnlyKind('namespace'), false)
+Deno.test('isTypeOnly - type and interface import type-only', () => {
+  assertEquals(isTypeOnly('type'), true)
+  assertEquals(isTypeOnly('interface'), true)
+  assertEquals(isTypeOnly('variable'), false)
+  assertEquals(isTypeOnly('class'), false)
+  assertEquals(isTypeOnly('namespace'), false)
 })

--- a/deno/lang-typescript/src/createIdentifier.ts
+++ b/deno/lang-typescript/src/createIdentifier.ts
@@ -1,7 +1,7 @@
 import { TsIdentifier } from './TsIdentifier.ts'
 
 /**
- * TypeScript's declaration-kind vocabulary — the typed `kind` this package
+ * TypeScript's declaration-type vocabulary — the typed `type` this package
  * writes onto its {@link TsIdentifier} and the discriminator its renderers
  * narrow against.
  *
@@ -13,7 +13,7 @@ import { TsIdentifier } from './TsIdentifier.ts'
  *
  * **Block-form** kinds render `export <kw> Name <value>` — the value carries
  * any heritage and the braced body, with no `= …` and no trailing `;` (see
- * {@link isBlockKind}):
+ * {@link isBlockType}):
  * - `'class'` — value entity declared with `class`; plain import.
  * - `'interface'` — type-level entity declared with `interface`; type-only
  *   import (like `'type'`).
@@ -22,10 +22,10 @@ import { TsIdentifier } from './TsIdentifier.ts'
  *   Stainless-style SDK layout emits.
  *
  * (Formerly core's `EntityTypeValue` — moved here under F5/F6: each
- * language package owns its kind vocabulary; core's `IdentifierBase` no
- * longer carries a `kind` at all.)
+ * language package owns its type vocabulary; core's `IdentifierBase` no
+ * longer carries a `type` at all.)
  */
-export type TsEntityKind = 'variable' | 'type' | 'class' | 'interface' | 'namespace'
+export type TsEntityType = 'variable' | 'type' | 'class' | 'interface' | 'namespace'
 
 /**
  * Options for {@link createVariable} — every field optional, so the
@@ -55,7 +55,7 @@ export type CreateTypeArgs = {
  * ```typescript
  * const count = createVariable('count');
  * console.log(count.name); // 'count'
- * console.log(count.kind); // 'variable'
+ * console.log(count.type); // 'variable'
  * ```
  *
  * @example Typed variable
@@ -67,7 +67,7 @@ export type CreateTypeArgs = {
 export const createVariable = (name: string, args: CreateVariableArgs = {}): TsIdentifier => {
   const { typeName, exported } = args
 
-  return new TsIdentifier({ name, typeName, exported, kind: 'variable' })
+  return new TsIdentifier({ name, typeName, exported, type: 'variable' })
 }
 
 /**
@@ -83,7 +83,7 @@ export const createVariable = (name: string, args: CreateVariableArgs = {}): TsI
 export const createType = (name: string, args: CreateTypeArgs = {}): TsIdentifier => {
   const { exported } = args
 
-  return new TsIdentifier({ name, exported, kind: 'type' })
+  return new TsIdentifier({ name, exported, type: 'type' })
 }
 
 /**
@@ -111,7 +111,7 @@ export type CreateDeclarationArgs = {
 export const createClass = (name: string, args: CreateDeclarationArgs = {}): TsIdentifier => {
   const { exported } = args
 
-  return new TsIdentifier({ name, exported, kind: 'class' })
+  return new TsIdentifier({ name, exported, type: 'class' })
 }
 
 /**
@@ -128,7 +128,7 @@ export const createClass = (name: string, args: CreateDeclarationArgs = {}): TsI
 export const createInterface = (name: string, args: CreateDeclarationArgs = {}): TsIdentifier => {
   const { exported } = args
 
-  return new TsIdentifier({ name, exported, kind: 'interface' })
+  return new TsIdentifier({ name, exported, type: 'interface' })
 }
 
 /**
@@ -146,14 +146,14 @@ export const createInterface = (name: string, args: CreateDeclarationArgs = {}):
 export const createNamespace = (name: string, args: CreateDeclarationArgs = {}): TsIdentifier => {
   const { exported } = args
 
-  return new TsIdentifier({ name, exported, kind: 'namespace' })
+  return new TsIdentifier({ name, exported, type: 'namespace' })
 }
 
 /**
  * Single source of truth for the TypeScript declaration vocabulary — each
- * {@link TsEntityKind} mapped to the keyword it renders with. `satisfies`
- * makes coverage exhaustive at compile time: a kind added to
- * {@link TsEntityKind} without a keyword here is a type error, not a
+ * {@link TsEntityType} mapped to the keyword it renders with. `satisfies`
+ * makes coverage exhaustive at compile time: a type added to
+ * {@link TsEntityType} without a keyword here is a type error, not a
  * runtime surprise.
  */
 const tsDeclarationKeywords = {
@@ -162,50 +162,50 @@ const tsDeclarationKeywords = {
   class: 'class',
   interface: 'interface',
   namespace: 'declare namespace'
-} as const satisfies Record<TsEntityKind, string>
+} as const satisfies Record<TsEntityType, string>
 
 /**
- * Type guard — whether an opaque `kind` string is one this language knows.
+ * Type guard — whether an opaque `type` string is one this language knows.
  */
-export const isTsEntityKind = (kind: string): kind is TsEntityKind =>
-  Object.hasOwn(tsDeclarationKeywords, kind)
+export const isTsEntityType = (type: string): type is TsEntityType =>
+  Object.hasOwn(tsDeclarationKeywords, type)
 
 /**
- * Narrow the engine's opaque `kind: string` (from `Lang.toIdentifier`'s
- * neutral args) to this language's {@link TsEntityKind} — cast-free, via
- * {@link isTsEntityKind}. Throws on a kind outside the vocabulary, a loud
+ * Narrow the engine's opaque `type: string` (from `Lang.toIdentifier`'s
+ * neutral args) to this language's {@link TsEntityType} — cast-free, via
+ * {@link isTsEntityType}. Throws on a type outside the vocabulary, a loud
  * signal that an identifier built for another language (or with a typo'd
- * kind) reached the TypeScript renderer.
+ * type) reached the TypeScript renderer.
  */
-export const toTsEntityKind = (kind: string): TsEntityKind => {
-  if (!isTsEntityKind(kind)) {
-    throw new Error(`Unknown TypeScript entity kind: ${kind}`)
+export const toTsEntityType = (type: string): TsEntityType => {
+  if (!isTsEntityType(type)) {
+    throw new Error(`Unknown TypeScript entity type: ${type}`)
   }
 
-  return kind
+  return type
 }
 
 /**
- * Maps an identifier's opaque `kind` to its TypeScript declaration keyword
+ * Maps an identifier's opaque `type` to its TypeScript declaration keyword
  * (`'variable'` → `const`, `'namespace'` → `declare namespace`, …) via the
  * single {@link tsDeclarationKeywords} map. Throws (through
- * {@link toTsEntityKind}) on a kind outside this language's vocabulary.
+ * {@link toTsEntityType}) on a type outside this language's vocabulary.
  */
-export const toTsKeyword = (kind: string): string => tsDeclarationKeywords[toTsEntityKind(kind)]
+export const toTsKeyword = (type: string): string => tsDeclarationKeywords[toTsEntityType(type)]
 
 /**
- * Whether a kind renders in *block* form — `export <kw> Name <value>`, where
+ * Whether a type renders in *block* form — `export <kw> Name <value>`, where
  * the value carries any heritage and the braced body, with no `= …` and no
  * trailing `;`. `class` / `interface` / `namespace` are block-form;
  * `variable` / `type` are assignment-form (`export <kw> Name = value;`).
  */
-export const isBlockKind = (kind: TsEntityKind): boolean =>
-  kind === 'class' || kind === 'interface' || kind === 'namespace'
+export const isBlockType = (type: TsEntityType): boolean =>
+  type === 'class' || type === 'interface' || type === 'namespace'
 
 /**
- * Whether a kind imports type-only under `verbatimModuleSyntax` — the
+ * Whether a type imports type-only under `verbatimModuleSyntax` — the
  * type-level kinds `type` and `interface`. (`class` is a value; `namespace`
  * imports as a value for its `.Member` access.)
  */
-export const isTypeOnlyKind = (kind: TsEntityKind): boolean =>
-  kind === 'type' || kind === 'interface'
+export const isTypeOnly = (type: TsEntityType): boolean =>
+  type === 'type' || type === 'interface'

--- a/deno/lang-typescript/src/toTsGqlOperationProjectionBase.ts
+++ b/deno/lang-typescript/src/toTsGqlOperationProjectionBase.ts
@@ -2,7 +2,7 @@ import { toGqlOperationProjectionBase } from '@skmtc/core'
 import type { GqlOperationProjectionBaseConfig } from '@skmtc/core'
 import { TsSnippet } from './TsSnippet.ts'
 import { register, type TsRegisterArgs } from './register.ts'
-import type { TsLang } from './tsLang.ts'
+import type { TsIdentifierType } from './TsIdentifier.ts'
 
 /**
  * Build a TypeScript GraphQL operation projection base class.
@@ -22,11 +22,12 @@ import type { TsLang } from './tsLang.ts'
  * result).
  *
  * The config is core's `GqlOperationProjectionBaseConfig` parameterized over
- * {@link TsLang} (so `toIdentifierType` returns `IdentifierType<TsLang>`). The
- * base is the factory's first argument, not a config field.
+ * {@link TsIdentifierType} (so `toIdentifierType`'s return tightens to the
+ * `type` bound to `TsEntityType`). The base is the factory's first argument,
+ * not a config field.
  */
 export const toTsGqlOperationProjectionBase = <EnrichmentType = undefined>(
-  config: GqlOperationProjectionBaseConfig<EnrichmentType, TsLang>
+  config: GqlOperationProjectionBaseConfig<EnrichmentType, TsIdentifierType>
 ) => {
   return class extends toGqlOperationProjectionBase(TsSnippet, config) {
     /**

--- a/deno/lang-typescript/src/toTsModelProjectionBase.ts
+++ b/deno/lang-typescript/src/toTsModelProjectionBase.ts
@@ -2,7 +2,7 @@ import { toModelProjectionBase } from '@skmtc/core'
 import type { ModelProjectionBaseConfig } from '@skmtc/core'
 import { TsSnippet } from './TsSnippet.ts'
 import { register, type TsRegisterArgs } from './register.ts'
-import type { TsLang } from './tsLang.ts'
+import type { TsIdentifierType } from './TsIdentifier.ts'
 
 /**
  * Build a TypeScript model projection base class.
@@ -22,12 +22,12 @@ import type { TsLang } from './tsLang.ts'
  * result).
  *
  * The config is core's `ModelProjectionBaseConfig` parameterized over
- * {@link TsLang} (so `toIdentifierType` returns `IdentifierType<TsLang>` — the
- * `kind` bound to `TsEntityKind`). The base is the factory's first argument,
+ * {@link TsIdentifierType} (so `toIdentifierType`'s return tightens to the
+ * `type` bound to `TsEntityType`). The base is the factory's first argument,
  * not a config field.
  */
 export const toTsModelProjectionBase = <EnrichmentType = undefined>(
-  config: ModelProjectionBaseConfig<EnrichmentType, TsLang>
+  config: ModelProjectionBaseConfig<EnrichmentType, TsIdentifierType>
 ) => {
   return class extends toModelProjectionBase(TsSnippet, config) {
     /**

--- a/deno/lang-typescript/src/toTsOasOperationProjectionBase.ts
+++ b/deno/lang-typescript/src/toTsOasOperationProjectionBase.ts
@@ -2,7 +2,7 @@ import { toOasOperationProjectionBase } from '@skmtc/core'
 import type { OasOperationProjectionBaseConfig } from '@skmtc/core'
 import { TsSnippet } from './TsSnippet.ts'
 import { register, type TsRegisterArgs } from './register.ts'
-import type { TsLang } from './tsLang.ts'
+import type { TsIdentifierType } from './TsIdentifier.ts'
 
 /**
  * Build a TypeScript OAS operation projection base class.
@@ -22,11 +22,12 @@ import type { TsLang } from './tsLang.ts'
  * result).
  *
  * The config is core's `OasOperationProjectionBaseConfig` parameterized over
- * {@link TsLang} (so `toIdentifierType` returns `IdentifierType<TsLang>`). The
- * base is the factory's first argument, not a config field.
+ * {@link TsIdentifierType} (so `toIdentifierType`'s return tightens to the
+ * `type` bound to `TsEntityType`). The base is the factory's first argument,
+ * not a config field.
  */
 export const toTsOasOperationProjectionBase = <EnrichmentType = undefined>(
-  config: OasOperationProjectionBaseConfig<EnrichmentType, TsLang>
+  config: OasOperationProjectionBaseConfig<EnrichmentType, TsIdentifierType>
 ) => {
   return class extends toOasOperationProjectionBase(TsSnippet, config) {
     /**

--- a/deno/lang-typescript/src/toTsWebhookProjectionBase.ts
+++ b/deno/lang-typescript/src/toTsWebhookProjectionBase.ts
@@ -2,7 +2,7 @@ import { toWebhookProjectionBase } from '@skmtc/core'
 import type { WebhookProjectionBaseConfig } from '@skmtc/core'
 import { TsSnippet } from './TsSnippet.ts'
 import { register, type TsRegisterArgs } from './register.ts'
-import type { TsLang } from './tsLang.ts'
+import type { TsIdentifierType } from './TsIdentifier.ts'
 
 /**
  * Build a TypeScript webhook projection base class.
@@ -23,11 +23,12 @@ import type { TsLang } from './tsLang.ts'
  * result).
  *
  * The config is core's `WebhookProjectionBaseConfig` parameterized over
- * {@link TsLang} (so `toIdentifierType` returns `IdentifierType<TsLang>`).
+ * {@link TsIdentifierType} (so `toIdentifierType`'s return tightens to the
+ * `type` bound to `TsEntityType`).
  * The base is the factory's first argument, not a config field.
  */
 export const toTsWebhookProjectionBase = <EnrichmentType = undefined>(
-  config: WebhookProjectionBaseConfig<EnrichmentType, TsLang>
+  config: WebhookProjectionBaseConfig<EnrichmentType, TsIdentifierType>
 ) => {
   return class extends toWebhookProjectionBase(TsSnippet, config) {
     /**

--- a/deno/lang-typescript/src/tsLang.ts
+++ b/deno/lang-typescript/src/tsLang.ts
@@ -1,9 +1,10 @@
 import type { Lang, GeneratedValue } from '@skmtc/core'
+import invariant from 'npm:tiny-invariant@1.3.3'
 import { TsFile } from './TsFile.ts'
 import { TsDefinition } from './TsDefinition.ts'
 import { TsImport } from './TsImport.ts'
 import { TsIdentifier } from './TsIdentifier.ts'
-import { toTsEntityKind } from './createIdentifier.ts'
+import { toTsEntityType } from './createIdentifier.ts'
 
 /**
  * The JSDoc a definition renders above itself, when the Driver doesn't pass
@@ -17,15 +18,6 @@ const toValueDescription = (value: GeneratedValue): string | undefined =>
     : undefined
 
 /**
- * The TypeScript {@link Lang}, specialized to this language's concrete
- * {@link TsIdentifier}. Threaded as the `L` type argument through the
- * projection-base veneers so core's config tightens `toIdentifierType`'s
- * return to {@link import('./TsIdentifier.ts').TsIdentifierType} (the `kind`
- * bound to `TsEntityKind`) with no recast.
- */
-export type TsLang = Lang<TsIdentifier>
-
-/**
  * The TypeScript {@link Lang} — carried as the static `lang` on
  * {@link import('./TsSnippet.ts').TsSnippet} and inherited by every class
  * built on it. Its only consumers are the engine's Drivers, which read it
@@ -33,24 +25,40 @@ export type TsLang = Lang<TsIdentifier>
  * site. The engine reaches TypeScript only through these neutral
  * factories; it never names `TsFile` / `TsDefinition` / `TsImport` itself.
  */
-export const typescript: TsLang = {
+export const typescript: Lang = {
   createFile: ({ path, settings }) => new TsFile({ path, settings }),
 
-  toDefinition: ({ context, identifier, value, noExport, description }) =>
-    new TsDefinition({
+  toDefinition: ({ context, identifier, value, noExport, description }) => {
+    // The engine holds identifiers as the neutral `IdentifierBase`; this is the
+    // one boundary that narrows back to the concrete `TsIdentifier` before
+    // handing it on (a foreign identifier here is a misconfiguration).
+    invariant(
+      identifier instanceof TsIdentifier,
+      `TsDefinition needs a TsIdentifier to render '${identifier.name}', got a foreign identifier`
+    )
+
+    return new TsDefinition({
       context,
       identifier,
       value,
       noExport,
       description: description ?? toValueDescription(value)
-    }),
+    })
+  },
 
   // The Driver's cross-file import of a peer Definition's identifier.
-  toImport: ({ identifier, module }) => TsImport.fromIdentifier(module, identifier),
+  toImport: ({ identifier, module }) => {
+    invariant(
+      identifier instanceof TsIdentifier,
+      `TsImport needs a TsIdentifier to import '${identifier.name}', got a foreign identifier`
+    )
+
+    return TsImport.fromIdentifier(module, identifier)
+  },
 
   // The engine's identifier-assembly seam: `name` from `toIdentifierName`,
-  // the rest spread from `toIdentifierType`. Narrows the opaque `kind`
-  // string to this language's typed `TsEntityKind`.
-  toIdentifier: ({ name, kind, typeName, exported }) =>
-    new TsIdentifier({ name, typeName, exported, kind: toTsEntityKind(kind) })
+  // the rest spread from `toIdentifierType`. Narrows the opaque `type`
+  // string to this language's typed `TsEntityType`.
+  toIdentifier: ({ name, type, typeName, exported }) =>
+    new TsIdentifier({ name, typeName, exported, type: toTsEntityType(type) })
 }

--- a/deno/openapi-overlays/jsonpath.ts
+++ b/deno/openapi-overlays/jsonpath.ts
@@ -30,10 +30,10 @@ export type PathMatch = {
 }
 
 type Selector =
-  | { kind: 'name'; name: string }
-  | { kind: 'wildcard' }
-  | { kind: 'union'; keys: Array<string | number> }
-  | { kind: 'filter'; predicate: (node: JsonValue) => boolean }
+  | { type: 'name'; name: string }
+  | { type: 'wildcard' }
+  | { type: 'union'; keys: Array<string | number> }
+  | { type: 'filter'; predicate: (node: JsonValue) => boolean }
 
 type Step = { descendant: boolean; selector: Selector }
 
@@ -47,7 +47,7 @@ function isObject(value: JsonValue): value is JsonObject {
 function applySelector(value: JsonValue, selector: Selector): PathMatch[] {
   const matches: PathMatch[] = []
 
-  switch (selector.kind) {
+  switch (selector.type) {
     case 'name': {
       if (isObject(value) && Object.prototype.hasOwnProperty.call(value, selector.name)) {
         matches.push({ value: value[selector.name], parent: value, parentProperty: selector.name })
@@ -163,7 +163,7 @@ function parsePath(expression: string): Step[] {
       steps.push({ descendant, selector: parseBracket(source.slice(i + 1, end)) })
       i = end + 1
     } else if (source[i] === '*') {
-      steps.push({ descendant, selector: { kind: 'wildcard' } })
+      steps.push({ descendant, selector: { type: 'wildcard' } })
       i += 1
     } else {
       const start = i
@@ -172,7 +172,7 @@ function parsePath(expression: string): Step[] {
       if (name === '') throw new Error(`Empty JSONPath segment in: ${expression}`)
       steps.push({
         descendant,
-        selector: name === '*' ? { kind: 'wildcard' } : { kind: 'name', name },
+        selector: name === '*' ? { type: 'wildcard' } : { type: 'name', name },
       })
     }
   }
@@ -203,18 +203,18 @@ function findBracketEnd(source: string, start: number): number {
 function parseBracket(inner: string): Selector {
   const trimmed = inner.trim()
 
-  if (trimmed === '*') return { kind: 'wildcard' }
+  if (trimmed === '*') return { type: 'wildcard' }
 
   if (trimmed.startsWith('?')) {
     const open = trimmed.indexOf('(')
     const close = trimmed.lastIndexOf(')')
     if (open === -1 || close <= open) throw new Error(`Malformed filter: ${inner}`)
-    return { kind: 'filter', predicate: compileFilter(trimmed.slice(open + 1, close)) }
+    return { type: 'filter', predicate: compileFilter(trimmed.slice(open + 1, close)) }
   }
 
   const keys = splitUnion(trimmed).map(parseKey)
   if (keys.length === 0) throw new Error(`Empty bracket selector: ${inner}`)
-  return { kind: 'union', keys }
+  return { type: 'union', keys }
 }
 
 /** Split a union body on commas that sit outside quotes. */

--- a/deno/openapi-overlays/overlay.test.ts
+++ b/deno/openapi-overlays/overlay.test.ts
@@ -12,8 +12,8 @@ import {
 // stderr; silence it so the test run stays readable.
 console.error = () => {}
 
-function fixture(kind: 'openapi' | 'overlays' | 'expected', name: string): JsonValue {
-  const url = new URL(`./fixtures/${kind}/${name}.yaml`, import.meta.url)
+function fixture(type: 'openapi' | 'overlays' | 'expected', name: string): JsonValue {
+  const url = new URL(`./fixtures/${type}/${name}.yaml`, import.meta.url)
   return parseYaml(Deno.readTextFileSync(url)) as JsonValue
 }
 

--- a/deno/server/src/createServer.test.ts
+++ b/deno/server/src/createServer.test.ts
@@ -141,7 +141,7 @@ Deno.test('POST /descriptors - returns one descriptor per generator', async () =
   const body = await res.json()
   assertEquals(body.descriptors.length, 1)
   assertEquals(body.descriptors[0].generator, 'modelGen')
-  assertEquals(body.descriptors[0].subjectKind, 'model')
+  assertEquals(body.descriptors[0].subjectType, 'model')
   // The `coerce` boolean maps to a `toggle` field.
   assertEquals(body.descriptors[0].fields[0].key, 'coerce')
   assertEquals(body.descriptors[0].fields[0].type, 'toggle')

--- a/deno/swagger2openapi/json.ts
+++ b/deno/swagger2openapi/json.ts
@@ -80,11 +80,11 @@ export const toJson = (value: unknown): JsonValue => {
   }
 }
 
-/** Reads a member from either container kind using a string key. */
+/** Reads a member from either container type using a string key. */
 export const getMember = (container: JsonContainer, key: string): JsonValue =>
   isJsonArray(container) ? container[Number(key)] : container[key]
 
-/** Writes a member to either container kind using a string key. */
+/** Writes a member to either container type using a string key. */
 export const setMember = (container: JsonContainer, key: string, value: JsonValue): void => {
   if (isJsonArray(container)) {
     container[Number(key)] = value

--- a/deno/worker/buildAttributionState.test.ts
+++ b/deno/worker/buildAttributionState.test.ts
@@ -37,7 +37,7 @@ Deno.test('buildAttributionState - generatorMeta map becomes a lookup function',
       generatorMeta: {
         '@scope/gen-zod': {
           version: '1.2.3',
-          registry: { host: 'jsr.io', kind: 'jsr' }
+          registry: { host: 'jsr.io', type: 'jsr' }
         }
       }
     }
@@ -48,7 +48,7 @@ Deno.test('buildAttributionState - generatorMeta map becomes a lookup function',
 
   const hit = lookup?.('@scope/gen-zod')
   assertEquals(hit?.version, '1.2.3')
-  assertEquals(hit?.registry, { host: 'jsr.io', kind: 'jsr' })
+  assertEquals(hit?.registry, { host: 'jsr.io', type: 'jsr' })
 })
 
 Deno.test('buildAttributionState - unknown genId falls back to default registry', () => {
@@ -58,7 +58,7 @@ Deno.test('buildAttributionState - unknown genId falls back to default registry'
       generatorMeta: {
         '@scope/gen-zod': {
           version: '1.2.3',
-          registry: { host: 'jsr.skmtc.dev', kind: 'jsr-private' }
+          registry: { host: 'jsr.skmtc.dev', type: 'jsr-private' }
         }
       }
     }
@@ -67,7 +67,7 @@ Deno.test('buildAttributionState - unknown genId falls back to default registry'
   const lookup = result?.postPass?.generatorMeta
   const miss = lookup?.('@unknown/gen-other')
   assertEquals(miss?.version, '')
-  assertEquals(miss?.registry, { host: 'jsr.io', kind: 'jsr' })
+  assertEquals(miss?.registry, { host: 'jsr.io', type: 'jsr' })
 })
 
 Deno.test('buildAttributionState - omitted generatorMeta leaves lookup undefined', () => {
@@ -88,7 +88,7 @@ Deno.test('buildAttributionState - payload round-trips through structured clone'
       generatorMeta: {
         '@scope/gen-zod': {
           version: '0.0.55',
-          registry: { host: 'jsr.io', kind: 'jsr' as const }
+          registry: { host: 'jsr.io', type: 'jsr' as const }
         }
       }
     }

--- a/deno/worker/mod.ts
+++ b/deno/worker/mod.ts
@@ -50,7 +50,7 @@ const buildAttributionState = (
         ? (genId: string) =>
             generatorMeta[genId] ?? {
               version: '',
-              registry: { host: 'jsr.io', kind: 'jsr' as const }
+              registry: { host: 'jsr.io', type: 'jsr' as const }
             }
         : undefined
     }


### PR DESCRIPTION
## Summary

Makes the engine **language-blind** at the type level and renames SKMTC's own `kind` vocabulary to `type` across the deno workspace. Three commits:

1. **`ce0038fe` — language-blind `Lang` + identifier declaration `kind` → `type`.**
   - `Lang` is now **non-generic**; `toIdentifier` returns the neutral `IdentifierBase`. **`LangKind` deleted.**
   - `IdentifierType`, `FindDefinitionsQuery`, `CodeFileBase`, `LangSnippetConstructor` are non-generic (opaque-`string` boundary).
   - Projection-base factories (`toModelProjectionBase`, `toOasOperationProjectionBase`, `toGqlOperationProjectionBase`, `toWebhookProjectionBase`) are generic over the **identifier-type shape** (`IdType extends IdentifierType`), not the `Lang`.
   - Each lang package owns its **fixed** declaration vocabulary concretely: `TsEntityKind` → `TsEntityType` (+ `Kt`/`Cs`/`Go`/`Php`/`Rs`), the `.kind` field on `XxIdentifier` → `.type`, the `createX` factories, `toXxEntityType`/`isXxEntityType`, and `mod.ts` re-exports.

2. **`0810a332` — enrichment-descriptor `kind` → `type`.** `EnrichmentFieldKind` → `EnrichmentFieldType`, `EnrichmentField.kind` → `.type`, `KindShape` → `TypeShape`, `kindFor` → `typeFor`.

3. **`47d44f13` — remaining skmtc `kind` → `type`.** `SubjectKind` → `SubjectType`, the leftover `EntityKind` doc refs, and the bare-`kind` result discriminators / sidecar registry / JSONPath selector across `core` (non-gql), `cli`, `mcp`, `server`, `worker`, `convert`, `openapi-overlays`.

## Boundary

Rename **SKMTC's own** `kind` → `type`. Third-party / language conventions that use `kind` are **kept**:
- **GraphQL** — `rootKind` / `GqlRootKind` / `isGqlRootKind` and graphql-js `Kind` / `node.kind` (GraphQL vocabulary). `rootType` (the GraphQL named-type object) and `rootKind` (the operation label) are distinct and coexist.
- **TypeScript compiler** — `ts.SyntaxKind` / `ts.ModuleKind` in the spike scripts.

## Verification

`core` + all six lang packages type-check; **2086 tests pass**. (Pre-existing, unrelated: `cli/commands/dev.ts` `setTimeout`→`number` and a `fetch`/`Uint8Array` overload — present before this work.)

## Follow-up

- Release the affected `@skmtc/*` packages to local JSR via the cascade.
- Apply the matching `EnrichmentField.kind` → `type` rename in **skmtc-hub** (wire-coupled to the enrichment descriptor) and refactor its consumers against the new packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)