### PR TITLE
fix: resolve JSR registry from JSR_URL, defaulting to public jsr.io

### DIFF
--- a/deno/.scripts/release.ts
+++ b/deno/.scripts/release.ts
@@ -23,8 +23,6 @@
 
 import { dirname, fromFileUrl, join } from '@std/path'
 
-const DEFAULT_JSR_URL = 'https://jsr.skmtc.co.uk/'
-
 /**
  * Scoped runtime permissions for the installed `skmtc` CLI — replaces a
  * blanket `-A`/`--allow-all`. skmtc reads/writes project files, fetches
@@ -378,7 +376,12 @@ const reinstallCliFromJsr = async (jsrUrl: string, version: string): Promise<voi
   }
 }
 
-const printReinstallHint = (mode: ReinstallCliMode, cliDir: string, version: string): void => {
+const printReinstallHint = (
+  mode: ReinstallCliMode,
+  cliDir: string,
+  version: string,
+  jsrUrl: string
+): void => {
   // The "none" mode lands here always; the other modes land here only on
   // error paths so the operator can recover manually.
   console.error('\nTo reinstall the local `skmtc` binary, choose one:')
@@ -390,7 +393,7 @@ const printReinstallHint = (mode: ReinstallCliMode, cliDir: string, version: str
   console.error(`    ${join(cliDir, 'mod.ts')}`)
   console.error('  # From JSR (downstream consumers):')
   console.error(
-    `  JSR_URL=${DEFAULT_JSR_URL} deno install ${SKMTC_PERMS_STR} -g --unstable-worker-options -n skmtc -f jsr:@skmtc/cli@${version}`
+    `  JSR_URL=${jsrUrl} deno install ${SKMTC_PERMS_STR} -g --unstable-worker-options -n skmtc -f jsr:@skmtc/cli@${version}`
   )
   if (mode !== 'none') {
     console.error(
@@ -402,7 +405,7 @@ const printReinstallHint = (mode: ReinstallCliMode, cliDir: string, version: str
 export const release = async (): Promise<void> => {
   const reinstallMode = parseReinstallMode(Deno.args)
   const rootDir = join(dirname(fromFileUrl(import.meta.url)), '..')
-  const jsrUrl = (Deno.env.get('JSR_URL') ?? DEFAULT_JSR_URL).replace(/\/*$/, '/')
+  const jsrUrl = (Deno.env.get('JSR_URL') ?? 'https://jsr.io/').replace(/\/*$/, '/')
 
   console.log(`Registry: ${jsrUrl}\n`)
   const packages = await discoverWorkspace(rootDir)
@@ -466,7 +469,7 @@ export const release = async (): Promise<void> => {
   const cliDir = cliPackage.dir
 
   if (reinstallMode === 'none') {
-    printReinstallHint('none', cliDir, cliVersion)
+    printReinstallHint('none', cliDir, cliVersion, jsrUrl)
     return
   }
 
@@ -479,7 +482,7 @@ export const release = async (): Promise<void> => {
     console.log(`\nLocal \`skmtc\` binary now at ${cliVersion} (${reinstallMode}).`)
   } catch (err) {
     console.error(`\nReinstall failed: ${err instanceof Error ? err.message : String(err)}`)
-    printReinstallHint(reinstallMode, cliDir, cliVersion)
+    printReinstallHint(reinstallMode, cliDir, cliVersion, jsrUrl)
     // Don't exit non-zero — the publish itself succeeded; the reinstall
     // is a convenience.
   }

--- a/deno/cli/CLAUDE.md
+++ b/deno/cli/CLAUDE.md
@@ -58,7 +58,7 @@ interactive login and no stored session.
 ### Generator System
 
 The CLI supports multiple code generators:
-- **Remote Generators** - Fetched from the JSR registry (`JSR_URL`, defaults to `https://jsr.skmtc.dev/`)
+- **Remote Generators** - Fetched from the JSR registry (`JSR_URL`, defaults to `https://jsr.io/`)
 - **Local Projects** - Created and managed locally within the SKMTC root directory
 
 Key generator operations:

--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -48,7 +48,7 @@
   },
   "tasks": {
     "publish": "deno task publish:deno",
-    "publish:deno": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN",
+    "publish:deno": "deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN",
     "test": "deno test --allow-all",
     "test:watch": "deno test --allow-all --watch",
     "test:coverage": "deno test --allow-all --coverage=coverage",

--- a/deno/cli/lib/bundle-deploy.ts
+++ b/deno/cli/lib/bundle-deploy.ts
@@ -47,7 +47,7 @@ const runDenoBundle = async ({
     stderr: 'piped',
     env: {
       ...Deno.env.toObject(),
-      JSR_URL: Deno.env.get('JSR_URL') ?? 'https://jsr.skmtc.dev/'
+      JSR_URL: Deno.env.get('JSR_URL') ?? 'https://jsr.io/'
     }
   })
 

--- a/deno/cli/lib/jsr-registry.test.ts
+++ b/deno/cli/lib/jsr-registry.test.ts
@@ -26,9 +26,9 @@ const withJsrUrl = async <T>(value: string | undefined, fn: () => Promise<T> | T
 
 const originalFetch = globalThis.fetch
 
-Deno.test('getJsrBaseUrl - defaults to local skmtc mirror', async () => {
+Deno.test('getJsrBaseUrl - defaults to upstream jsr.io', async () => {
   await withJsrUrl(undefined, () => {
-    assertEquals(getJsrBaseUrl(), 'https://jsr.skmtc.dev')
+    assertEquals(getJsrBaseUrl(), 'https://jsr.io')
   })
 })
 
@@ -40,14 +40,8 @@ Deno.test('getJsrBaseUrl - honors JSR_URL env override', async () => {
 
 Deno.test('toJsrUrl - composes path against the resolved base, normalizing slashes', async () => {
   await withJsrUrl(undefined, () => {
-    assertEquals(
-      toJsrUrl('@skmtc/gen-zod/meta.json'),
-      'https://jsr.skmtc.dev/@skmtc/gen-zod/meta.json'
-    )
-    assertEquals(
-      toJsrUrl('/@skmtc/gen-zod/meta.json'),
-      'https://jsr.skmtc.dev/@skmtc/gen-zod/meta.json'
-    )
+    assertEquals(toJsrUrl('@skmtc/gen-zod/meta.json'), 'https://jsr.io/@skmtc/gen-zod/meta.json')
+    assertEquals(toJsrUrl('/@skmtc/gen-zod/meta.json'), 'https://jsr.io/@skmtc/gen-zod/meta.json')
   })
 })
 

--- a/deno/cli/lib/jsr-registry.ts
+++ b/deno/cli/lib/jsr-registry.ts
@@ -1,13 +1,11 @@
 /**
  * JSR registry URL resolution + reachability check.
  *
- * The CLI is pinned to a local JSR mirror (`https://jsr.skmtc.dev/` by
- * default) so generator installs and downloads resolve against a known
- * registry rather than upstream `jsr.io`. The `JSR_URL` environment
- * variable overrides the default for local development against a
- * different mirror. The Deno runtime honors the same variable for
- * `jsr:` import resolution, so setting it once keeps both paths in
- * agreement.
+ * The CLI resolves generator installs and downloads against upstream
+ * `jsr.io` by default. The `JSR_URL` environment variable overrides the
+ * default for local development against a mirror. The Deno runtime
+ * honors the same variable for `jsr:` import resolution, so setting it
+ * once keeps both paths in agreement.
  *
  * `assertJsrReachable` runs once at CLI start-up and throws with an
  * actionable error if the registry is unreachable — we'd rather fail
@@ -15,7 +13,7 @@
  * a worker bundle.
  */
 
-const DEFAULT_JSR_URL = 'https://jsr.skmtc.dev/'
+const DEFAULT_JSR_URL = 'https://jsr.io/'
 
 const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
 
@@ -39,10 +37,10 @@ export class JsrRegistryUnreachableError extends Error {
       [
         `JSR registry at ${baseUrl} is unreachable (${reason}).`,
         '',
-        'skmtc is pinned to a local JSR mirror. Start the registry or set',
-        'JSR_URL to a reachable mirror before running the CLI:',
+        'Check your network connection, or set JSR_URL to a reachable',
+        'mirror before running the CLI:',
         '',
-        '  JSR_URL=https://jsr.skmtc.dev/ skmtc <command>',
+        '  JSR_URL=https://jsr.io/ skmtc <command>',
         '',
         'If you are intentionally working offline, the only commands that do',
         'not touch JSR are `skmtc generate` (when bundle.js is already built)',

--- a/deno/cli/lib/jsr.test.ts
+++ b/deno/cli/lib/jsr.test.ts
@@ -67,7 +67,7 @@ Deno.test('Jsr.getLatestMeta - fetches and parses metadata successfully', async 
 
   // Mock fetch to return successful response
   globalThis.fetch = async (url: string | URL | Request) => {
-    assertEquals(url, 'https://jsr.skmtc.dev/@skmtc/gen-typescript/meta.json')
+    assertEquals(url, 'https://jsr.io/@skmtc/gen-typescript/meta.json')
 
     return new Response(JSON.stringify(mockMeta), {
       status: 200,

--- a/deno/convert/deno.json
+++ b/deno/convert/deno.json
@@ -12,7 +12,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN",
     "test": "deno test --allow-all --no-check",
     "test:watch": "deno test --allow-all --no-check --watch"
   },

--- a/deno/core/deno.json
+++ b/deno/core/deno.json
@@ -53,7 +53,7 @@
     "publish": "deno task publish:deno",
     "build": "deno run -A .scripts/build-node.ts",
     "publish:npm": "cd ../../packages/core && npm publish",
-    "publish:deno": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish:deno": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
     "docs": "deno doc --html --name=\"My library\" ./mod.ts",
     "docs:json": "deno doc --json --name=\"My library\" ./mod.ts > ../docs/src/docs.json",
     "test": "deno test --allow-all",

--- a/deno/lang-csharp/deno.json
+++ b/deno/lang-csharp/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
     "test": "deno test --allow-all"
   },
   "imports": {

--- a/deno/lang-go/deno.json
+++ b/deno/lang-go/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
   },
   "imports": {
     "@skmtc/core": "jsr:@skmtc/core@0.23.1"

--- a/deno/lang-java/deno.json
+++ b/deno/lang-java/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
   },
   "imports": {}
 }

--- a/deno/lang-kotlin/deno.json
+++ b/deno/lang-kotlin/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
     "test": "deno test --allow-all"
   },
   "imports": {

--- a/deno/lang-php/deno.json
+++ b/deno/lang-php/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
   },
   "imports": {
     "@skmtc/core": "jsr:@skmtc/core@0.23.1"

--- a/deno/lang-python/deno.json
+++ b/deno/lang-python/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
   },
   "imports": {}
 }

--- a/deno/lang-rust/deno.json
+++ b/deno/lang-rust/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
   },
   "imports": {
     "@skmtc/core": "jsr:@skmtc/core@0.23.1"

--- a/deno/lang-typescript/deno.json
+++ b/deno/lang-typescript/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
     "test": "deno test --allow-all"
   },
   "imports": {

--- a/deno/mcp/deno.json
+++ b/deno/mcp/deno.json
@@ -13,6 +13,6 @@
     "@std/path": "jsr:@std/path@^1.0.9"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
   }
 }

--- a/deno/openapi-down-convert/deno.json
+++ b/deno/openapi-down-convert/deno.json
@@ -11,8 +11,8 @@
   "tasks": {
     "test": "deno test --allow-read",
     "test:watch": "deno test --allow-read --watch",
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
-    "publish:dry": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --dry-run --allow-dirty"
+    "publish": "deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish:dry": "deno publish --dry-run --allow-dirty"
   },
   "publish": {
     "exclude": [

--- a/deno/openapi-overlays/deno.json
+++ b/deno/openapi-overlays/deno.json
@@ -21,8 +21,8 @@
     "overlay": "deno run --allow-read cli.ts",
     "test": "deno test --allow-read",
     "test:watch": "deno test --allow-read --watch",
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
-    "publish:dry": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --dry-run --allow-dirty"
+    "publish": "deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish:dry": "deno publish --dry-run --allow-dirty"
   },
   "publish": {
     "exclude": [

--- a/deno/server/deno.json
+++ b/deno/server/deno.json
@@ -11,6 +11,6 @@
     "@skmtc/convert": "jsr:@skmtc/convert@0.1.16"
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN"
   }
 }

--- a/deno/swagger2openapi/deno.json
+++ b/deno/swagger2openapi/deno.json
@@ -22,8 +22,8 @@
   "tasks": {
     "test": "deno test --allow-read",
     "test:watch": "deno test --allow-read --watch",
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
-    "publish:dry": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --dry-run --allow-dirty"
+    "publish": "deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish:dry": "deno publish --dry-run --allow-dirty"
   },
   "publish": {
     "exclude": [

--- a/deno/worker/deno.json
+++ b/deno/worker/deno.json
@@ -16,6 +16,6 @@
     ]
   },
   "tasks": {
-    "publish": "JSR_URL=https://jsr.skmtc.co.uk/ deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
   }
 }


### PR DESCRIPTION
## Summary

Removes every hardcoded skmtc JSR registry URL so the registry is resolved from the `JSR_URL` env var everywhere, falling back to public `https://jsr.io/`.

- **cli**: `DEFAULT_JSR_URL` in `lib/jsr-registry.ts` flips from `jsr.skmtc.dev` to `jsr.io`; same for the `deno bundle` subprocess env fallback in `lib/bundle-deploy.ts`. The unreachable-registry error recipe and CLAUDE.md updated to match; tests pinning the default updated.
- **deno.json publish tasks** (17 packages): the inline `JSR_URL=https://jsr.skmtc.co.uk/` prefix is removed, so publishes follow the ambient `JSR_URL` instead of silently overriding it.
- **`.scripts/release.ts`**: `DEFAULT_JSR_URL` (`jsr.skmtc.co.uk`) removed; the registry query resolves `JSR_URL ?? https://jsr.io/`, and the manual-reinstall hint now prints the resolved registry instead of a constant.

This closes the divergence where `deno task release` could query one registry to decide what's unpublished while the spawned `deno task publish` targeted another. Local dev is unchanged: direnv sets `JSR_URL=https://jsr.skmtc.co.uk/`, which every step now respects.

## Test plan

- `deno test` on the affected cli test files (18 passed)
- `deno check .scripts/release.ts` + `.scripts` tests (13 passed)
- Full pre-push `deno task check`: 2831 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)