### PR TITLE
feat(ci): publish to jsr.io with OIDC; make the registry token optional

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,17 @@
-# Manual-dispatch release via the cascade script, against the
-# jsr.skmtc.co.uk registry (NOT public jsr.io).
+# Manual-dispatch release via the cascade script, publishing to public
+# jsr.io authenticated with GitHub OIDC (no registry token).
 #
 # Releases are deliberate: bump the `version` of the package(s) you
-# changed, merge, then trigger this workflow (or run
-# `cd deno && deno task release` locally — same script, same registry).
-# The cascade publishes any workspace package whose deno.json version
-# isn't yet on the registry and cascades pins + patch bumps to every
-# downstream dependent, so nothing auto-fires on merge to main.
+# changed (`deno task bump`), merge, then trigger this workflow (or run
+# `cd deno && deno task release` locally — same script; locally the
+# ambient JSR_URL / JSR_AUTH_TOKEN from direnv target the local mirror
+# instead). The cascade publishes any workspace package whose deno.json
+# version isn't yet on the registry and cascades pins + patch bumps to
+# every downstream dependent, so nothing auto-fires on merge to main.
 #
-# Requires the `JSR_AUTH_TOKEN` repository secret (a token for
-# jsr.skmtc.co.uk). OIDC is NOT used — that only works against public
-# jsr.io.
+# OIDC requires the `id-token: write` permission below AND each
+# published @skmtc/* package on jsr.io to be linked to this GitHub
+# repository in its package settings.
 
 name: Publish
 
@@ -22,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -31,9 +33,6 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Release via cascade to jsr.skmtc.co.uk
-        env:
-          JSR_URL: https://jsr.skmtc.co.uk/
-          JSR_AUTH_TOKEN: ${{ secrets.JSR_AUTH_TOKEN }}
+      - name: Release via cascade to jsr.io
         working-directory: deno
         run: deno task release

--- a/deno/.scripts/release.ts
+++ b/deno/.scripts/release.ts
@@ -438,11 +438,15 @@ export const release = async (): Promise<void> => {
   await applyPlan(order, plan)
 
   console.log('\nPublishing...')
+  // With a JSR_AUTH_TOKEN (e.g. the local mirror's shared secret) the
+  // token is passed explicitly; without one, `deno publish` falls back
+  // to OIDC in GitHub Actions or interactive auth locally.
+  const publishToken = Deno.env.get('JSR_AUTH_TOKEN')
   for (const pkg of order) {
     const planned = plan.get(pkg.name) as PlannedRelease
     console.log(`\n--- ${pkg.name}@${planned.version} ---`)
     const result = await new Deno.Command('deno', {
-      args: ['task', 'publish'],
+      args: ['task', 'publish', ...(publishToken ? [`--token=${publishToken}`] : [])],
       cwd: pkg.dir,
       stdout: 'inherit',
       stderr: 'inherit'

--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -48,7 +48,7 @@
   },
   "tasks": {
     "publish": "deno task publish:deno",
-    "publish:deno": "deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN",
+    "publish:deno": "deno publish --allow-slow-types --allow-dirty --no-check",
     "test": "deno test --allow-all",
     "test:watch": "deno test --allow-all --watch",
     "test:coverage": "deno test --allow-all --coverage=coverage",

--- a/deno/convert/deno.json
+++ b/deno/convert/deno.json
@@ -12,7 +12,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty --no-check",
     "test": "deno test --allow-all --no-check",
     "test:watch": "deno test --allow-all --no-check --watch"
   },

--- a/deno/core/deno.json
+++ b/deno/core/deno.json
@@ -53,7 +53,7 @@
     "publish": "deno task publish:deno",
     "build": "deno run -A .scripts/build-node.ts",
     "publish:npm": "cd ../../packages/core && npm publish",
-    "publish:deno": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish:deno": "deno publish --allow-slow-types --allow-dirty",
     "docs": "deno doc --html --name=\"My library\" ./mod.ts",
     "docs:json": "deno doc --json --name=\"My library\" ./mod.ts > ../docs/src/docs.json",
     "test": "deno test --allow-all",

--- a/deno/lang-csharp/deno.json
+++ b/deno/lang-csharp/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty",
     "test": "deno test --allow-all"
   },
   "imports": {

--- a/deno/lang-go/deno.json
+++ b/deno/lang-go/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {
     "@skmtc/core": "jsr:@skmtc/core@0.23.1"

--- a/deno/lang-java/deno.json
+++ b/deno/lang-java/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {}
 }

--- a/deno/lang-kotlin/deno.json
+++ b/deno/lang-kotlin/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty",
     "test": "deno test --allow-all"
   },
   "imports": {

--- a/deno/lang-php/deno.json
+++ b/deno/lang-php/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {
     "@skmtc/core": "jsr:@skmtc/core@0.23.1"

--- a/deno/lang-python/deno.json
+++ b/deno/lang-python/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {}
 }

--- a/deno/lang-rust/deno.json
+++ b/deno/lang-rust/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {
     "@skmtc/core": "jsr:@skmtc/core@0.23.1"

--- a/deno/lang-typescript/deno.json
+++ b/deno/lang-typescript/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-slow-types --allow-dirty",
     "test": "deno test --allow-all"
   },
   "imports": {

--- a/deno/mcp/deno.json
+++ b/deno/mcp/deno.json
@@ -13,6 +13,6 @@
     "@std/path": "jsr:@std/path@^1.0.9"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty"
   }
 }

--- a/deno/openapi-down-convert/deno.json
+++ b/deno/openapi-down-convert/deno.json
@@ -11,7 +11,7 @@
   "tasks": {
     "test": "deno test --allow-read",
     "test:watch": "deno test --allow-read --watch",
-    "publish": "deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-dirty",
     "publish:dry": "deno publish --dry-run --allow-dirty"
   },
   "publish": {

--- a/deno/openapi-overlays/deno.json
+++ b/deno/openapi-overlays/deno.json
@@ -21,7 +21,7 @@
     "overlay": "deno run --allow-read cli.ts",
     "test": "deno test --allow-read",
     "test:watch": "deno test --allow-read --watch",
-    "publish": "deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-dirty",
     "publish:dry": "deno publish --dry-run --allow-dirty"
   },
   "publish": {

--- a/deno/server/deno.json
+++ b/deno/server/deno.json
@@ -11,6 +11,6 @@
     "@skmtc/convert": "jsr:@skmtc/convert@0.1.16"
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --no-check --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty --no-check"
   }
 }

--- a/deno/swagger2openapi/deno.json
+++ b/deno/swagger2openapi/deno.json
@@ -22,7 +22,7 @@
   "tasks": {
     "test": "deno test --allow-read",
     "test:watch": "deno test --allow-read --watch",
-    "publish": "deno publish --allow-dirty --token=$JSR_AUTH_TOKEN",
+    "publish": "deno publish --allow-dirty",
     "publish:dry": "deno publish --dry-run --allow-dirty"
   },
   "publish": {

--- a/deno/worker/deno.json
+++ b/deno/worker/deno.json
@@ -16,6 +16,6 @@
     ]
   },
   "tasks": {
-    "publish": "deno publish --allow-slow-types --allow-dirty --token=$JSR_AUTH_TOKEN"
+    "publish": "deno publish --allow-slow-types --allow-dirty"
   }
 }


### PR DESCRIPTION
## Summary

Rewires the manual-dispatch **Publish** workflow to release to public jsr.io using GitHub OIDC, and removes the last hardcoded registry-token plumbing so the same cascade works against both jsr.io (CI) and the local mirror (dev).

- **`.github/workflows/publish.yml`**: drops the `JSR_URL` / `JSR_AUTH_TOKEN` env. The cascade now resolves the registry to its default (public jsr.io, since #15) and the job gets `id-token: write`, so `deno publish` authenticates via OIDC.
- **`deno.json` publish tasks** (17 packages): remove the hardcoded `--token=$JSR_AUTH_TOKEN`.
- **`.scripts/release.ts`**: the publish loop appends `--token=$JSR_AUTH_TOKEN` to each spawned `deno task publish` only when the env var is set. Locally (direnv sets `JSR_URL` + `JSR_AUTH_TOKEN`) releases keep targeting the mirror with the shared secret; in CI, with no token, `deno publish` uses OIDC.

## Prerequisite for the first CI run

OIDC publishing requires each `@skmtc/*` package to exist on jsr.io **and** have this GitHub repository linked in its package settings on jsr.io. Unlinked packages will fail their publish step; re-running after linking is safe (already-published packages are skipped).

## Test plan

- `deno check .scripts/release.ts` + `.scripts` tests (13 passed)
- Verified appended-arg forwarding with dry runs: `deno task publish --dry-run` reaches `deno publish` both for direct tasks (openapi-overlays) and the chained `publish` → `publish:deno` form (cli) — the mechanism the conditional `--token` uses
- Full pre-push `deno task check` (doc-sync + workspace test suite) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)