### PR TITLE
fix(ci): pnpm version conflict in Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,10 +63,10 @@ jobs:
         with:
           node-version: 22
 
+      # Version comes from the root package.json `packageManager` field;
+      # setting it here too would conflict (ERR_PNPM_BAD_PM_VERSION).
       - name: Setup pnpm (dnt build)
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Upgrade npm for Trusted Publishing (OIDC)
         run: npm install -g npm@latest


### PR DESCRIPTION
## Problem

The Publish workflow (#25) failed at **Setup pnpm** with `ERR_PNPM_BAD_PM_VERSION`: `pnpm/action-setup` got `version: 10` from the action config **and** `pnpm@10.12.1…` from the root `package.json` `packageManager` field, which conflict.

JSR already shipped core 0.26.0 + cascaded dependents in that run (the release step succeeded); only the npm publish leg was skipped.

## Fix

Drop the explicit `version` from `pnpm/action-setup` so it reads the pinned version from `package.json` `packageManager` (single source of truth).

## On merge

`deno task release` sees everything already on JSR → no-op. The npm guard (`publish:npm-if-needed`) sees npm still lacks 0.26.0 → builds + publishes `@skmtc/core@0.26.0`. This is exactly the idempotent recovery the guard was designed for.