### PR TITLE
docs(skills): docs-writing v0.2.0 + eval harness + verify-docs checks

### DIFF
--- a/deno/docs/concepts/enrichments.md
+++ b/deno/docs/concepts/enrichments.md
@@ -1,97 +1,92 @@
 # Enrichments
 
-> The configuration surface declared by each generator via a Valibot
-> schema and supplied by users in `client.json`. Enrichments are the
-> *configurability* lever of the customization gradient — the narrow
-> tweaks that don't require cloning. An enrichment is a
-> generator-owned opaque leaf at one of three **scopes** — `subject`,
-> `generator`, `stack` — distinguished by key depth in
+> The configuration surface declared by each generator via a Valibot schema and
+> supplied by users in `client.json`. Enrichments are the _configurability_
+> lever of the customization gradient — the narrow tweaks that don't require
+> cloning. An enrichment is a generator-owned opaque leaf at one of three
+> **scopes** — `subject`, `generator`, `stack` — distinguished by key depth in
 > `client.json#settings.enrichments`.
 
-Enrichments are how stock generators expose user-facing options
-without compromising the clone-to-customize philosophy. A generator
-declares what payload it accepts (one composite Valibot schema
-spanning the three scopes). A user supplies values at a key whose
-depth selects the scope (in `client.json`). The engine assembles the
-three scopes into a single `{ subject, generator, stack }` umbrella
-and delivers the validated value to the Projection.
+Enrichments are how stock generators expose user-facing options without
+compromising the clone-to-customize philosophy. A generator declares what
+payload it accepts (one composite Valibot schema spanning the three scopes). A
+user supplies values at a key whose depth selects the scope (in `client.json`).
+The engine assembles the three scopes into a single
+`{ subject, generator, stack }` umbrella and delivers the validated value to the
+Projection.
 
 ## What enrichments are (and aren't)
 
 Enrichments **are**:
 
-- User overrides at one of three scopes — per-item (`subject`),
-  per-generator (`generator`), or per-composition (`stack`)
+- User overrides at one of three scopes — per-item (`subject`), per-generator
+  (`generator`), or per-composition (`stack`)
 - Declared per-generator via a single composite Valibot schema
 - Validated at parse time
 - Supplied by the user in `.settings/client.json`
 - Available at generation time as the
-  `this.settings.enrichments.{subject,generator,stack}` umbrella
-  inside a Projection
+  `this.settings.enrichments.{subject,generator,stack}` umbrella inside a
+  Projection
 
 Enrichments **are not**:
 
-- A general configuration system for *all* customization
+- A general configuration system for _all_ customization
 - A replacement for cloning when you need behavioral changes
-- A way to change identifier naming, export paths, or output template
-  structure (those are clone-time changes)
+- A way to change identifier naming, export paths, or output template structure
+  (those are clone-time changes)
 - A filter for which operations the generator runs against
 
-The mental model: enrichments are the inputs the *author* of a
-generator decided to make user-configurable. Everything else stays
-hardcoded as the clone seam.
+The mental model: enrichments are the inputs the _author_ of a generator decided
+to make user-configurable. Everything else stays hardcoded as the clone seam.
 
 ## The three scopes
 
-An enrichment is a generator-owned opaque leaf at one of three
-scopes. The scope is selected by **how deep its key sits** in
-`client.json#settings.enrichments`:
+An enrichment is a generator-owned opaque leaf at one of three scopes. The scope
+is selected by **how deep its key sits** in `client.json#settings.enrichments`:
 
-| Scope | Key path | Varies | What it's for |
-|---|---|---|---|
-| **subject** | `[id][subject][variant]` | per item | The original per-operation / per-model override — one value per `(refName)` or `(path, method)`, resolved per item. |
-| **generator** | `[id]._generator` | run-constant | A single bag for one generator across the whole run — the generator's own knobs that don't vary per item. |
-| **stack** | `._stack` | run-constant | A single bag shared across *every* generator in the composition — one value the whole stack reads. |
+| Scope         | Key path                 | Varies       | What it's for                                                                                                       |
+| ------------- | ------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **subject**   | `[id][subject][variant]` | per item     | The original per-operation / per-model override — one value per `(refName)` or `(path, method)`, resolved per item. |
+| **generator** | `[id]._generator`        | run-constant | A single bag for one generator across the whole run — the generator's own knobs that don't vary per item.           |
+| **stack**     | `._stack`                | run-constant | A single bag shared across _every_ generator in the composition — one value the whole stack reads.                  |
 
 - `subject` is the enrichment that has always existed: its storage
-  (`[id][subject][variant]`) is **unchanged**. What's new is that it's
-  now one member of a three-scope umbrella.
-- `generator` lives inside a generator's own slot, alongside its
-  subject keys, under the reserved key `_generator`.
-- `stack` lives at the top level of the enrichments record, a sibling
-  of the generator-id keys, under the reserved key `_stack`.
+  (`[id][subject][variant]`) is **unchanged**. What's new is that it's now one
+  member of a three-scope umbrella.
+- `generator` lives inside a generator's own slot, alongside its subject keys,
+  under the reserved key `_generator`.
+- `stack` lives at the top level of the enrichments record, a sibling of the
+  generator-id keys, under the reserved key `_stack`.
 
 ### Reserved keys are `_`-prefixed
 
 The two run-constant scopes use **reserved** keys. The rule:
 
-- `_stack` — the only reserved *top-level* key (sibling of generator
-  ids).
-- `_generator` — the only reserved *per-generator* key (sibling of
-  subject names).
-- Every other key is a **customer** key — a generator id at the top
-  level, a subject name inside a slot — and **must not start with
-  `_`**.
+- `_stack` — the only reserved _top-level_ key (sibling of generator ids).
+- `_generator` — the only reserved _per-generator_ key (sibling of subject
+  names).
+- Every other key is a **customer** key — a generator id at the top level, a
+  subject name inside a slot — and **must not start with `_`**.
 
 Core's single predicate is the source of truth:
 
 ```ts
 // core/types/Enrichments.ts
-export const isReservedEnrichmentKey = (key: string): boolean => key.startsWith('_')
+export const isReservedEnrichmentKey = (key: string): boolean =>
+  key.startsWith("_");
 ```
 
-The reserved-key segregation is a core / migration concern only —
-generators never iterate enrichments themselves. They read each scope
-by known key through the typed umbrella (`ContentSettings`) or the
-helper readers (everywhere else), so they can't trip over the reserved
-keys.
+The reserved-key segregation is a core / migration concern only — generators
+never iterate enrichments themselves. They read each scope by known key through
+the typed umbrella (`ContentSettings`) or the helper readers (everywhere else),
+so they can't trip over the reserved keys.
 
 ### Enrichments aren't a filter — don't gate `isSupported` on them
 
-A common authoring mistake on opt-in generators (forms, tables, page
-shells) is to write `isSupported` so it returns `true` only when the
-operation has the generator's enrichment payload. That makes
-"having an enrichment" the on/off switch.
+A common authoring mistake on opt-in generators (forms, tables, page shells) is
+to write `isSupported` so it returns `true` only when the operation has the
+generator's enrichment payload. That makes "having an enrichment" the on/off
+switch.
 
 ```ts
 // ❌ Wrong — enrichment doubles as the on/off switch
@@ -108,42 +103,41 @@ isSupported({ operation }) {
 
 Two reasons to avoid the wrong form:
 
-1. **`isSupported` declares capability, not user intent.** A
-   generator that *could* produce output for `POST` with a JSON body
-   should say so. Whether the user *wants* it to is a configuration concern.
-2. **Enrichment is for customizing shape, not selecting set.** Once
-   enrichment doubles as the switch, you can't have an enrichment
-   with all-default values — you have to invent a sentinel. Code smell.
+1. **`isSupported` declares capability, not user intent.** A generator that
+   _could_ produce output for `POST` with a JSON body should say so. Whether the
+   user _wants_ it to is a configuration concern.
+2. **Enrichment is for customizing shape, not selecting set.** Once enrichment
+   doubles as the switch, you can't have an enrichment with all-default values —
+   you have to invent a sentinel. Code smell.
 
-The right control for "only run for these operations" is the
-**`include` allow-list** (or `.skip` deny-list) in
-`client.json#settings`, applied *outside* the generator. See
+The right control for "only run for these operations" is the **`include`
+allow-list** (or `.skip` deny-list) in `client.json#settings`, applied _outside_
+the generator. See
 [`using/how-to/skip-or-include-operations.md`](../using/how-to/skip-or-include-operations.md).
 
 ### Extensions vs enrichments: who owns it, and how often does it change?
 
 Two places per-field metadata can live:
 
-- **OpenAPI `x-*` extensions** — written into the schema document
-  itself, exposed on every `Oas*` variant as
-  `extensionFields?: Record<string, unknown>`. Travel with the
-  schema through Parse untouched.
-- **Enrichments** — declared per-generator in `enrichments.ts`,
-  supplied by the consumer in `.settings/client.json`.
+- **OpenAPI `x-*` extensions** — written into the schema document itself,
+  exposed on every `Oas*` variant as
+  `extensionFields?: Record<string, unknown>`. Travel with the schema through
+  Parse untouched.
+- **Enrichments** — declared per-generator in `enrichments.ts`, supplied by the
+  consumer in `.settings/client.json`.
 
 Pick along two axes:
 
-| | Stable data (rarely changes) | Volatile data (changes independently of schema) |
-|---|---|---|
-| **You author the schema** | OpenAPI extension — the data ships with the schema and every consumer gets it for free | Enrichment — keep the volatile bit in `client.json` where it's a local edit, not a schema re-publish |
-| **You only consume the schema** | Enrichment — you can't edit the upstream document anyway | Enrichment |
+|                                 | Stable data (rarely changes)                                                           | Volatile data (changes independently of schema)                                                      |
+| ------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **You author the schema**       | OpenAPI extension — the data ships with the schema and every consumer gets it for free | Enrichment — keep the volatile bit in `client.json` where it's a local edit, not a schema re-publish |
+| **You only consume the schema** | Enrichment — you can't edit the upstream document anyway                               | Enrichment                                                                                           |
 
-Why the asymmetry: editing an extension means changing the schema
-document (and, if it's published, re-shipping it). Editing an
-enrichment is a config change in the consumer's `client.json`. So
-extensions earn their keep when the data is *stable enough* that the
-re-publish cadence is fine, and *universal enough* that every
-consumer wants the same value.
+Why the asymmetry: editing an extension means changing the schema document (and,
+if it's published, re-shipping it). Editing an enrichment is a config change in
+the consumer's `client.json`. So extensions earn their keep when the data is
+_stable enough_ that the re-publish cadence is fine, and _universal enough_ that
+every consumer wants the same value.
 
 ```yaml
 # Schema-author + stable: canonical display label
@@ -159,7 +153,7 @@ components:
 
 ```ts
 // In a generator: read the extension off the parsed schema
-const label = resolved.properties?.['firstName']?.extensionFields?.['x-label']
+const label = resolved.properties?.["firstName"]?.extensionFields?.["x-label"];
 ```
 
 ```ts
@@ -176,62 +170,57 @@ const label = resolved.properties?.['firstName']?.extensionFields?.['x-label']
 
 Cross-generator wiring (the operation-reference protocol — see
 [cross-generator coordination](cross-generator-coordination.md#pattern-operation-reference-consumer-chosen-peer))
-is always volatile by nature, so it always lives in the consumer's
-enrichment.
+is always volatile by nature, so it always lives in the consumer's enrichment.
 
-A common smell when you *do* own the schema: declaring an enrichment
-field that just mirrors a stable schema property — display labels,
-canonical descriptions, formats. Move it to an extension and the
-data stays with the schema, surviving any consumer's `client.json`
-edits.
+A common smell when you _do_ own the schema: declaring an enrichment field that
+just mirrors a stable schema property — display labels, canonical descriptions,
+formats. Move it to an extension and the data stays with the schema, surviving
+any consumer's `client.json` edits.
 
 ## Core owns the hierarchy; the generator owns the leaf
 
-The design fact that explains everything else on this page: core's
-top-level type for enrichments (`core/types/Enrichments.ts`) is
+The design fact that explains everything else on this page: core's top-level
+type for enrichments (`core/types/Enrichments.ts`) is
 
 ```ts
 type GeneratorEnrichments = Record<
   string,
   ModelEnrichments | OasPathEnrichments | GqlRootKindEnrichments
->
+>;
 ```
 
 Each generator-id slot is a subject hierarchy ending in
-`EnrichmentLeaf = unknown` (plus the optional reserved `_generator`
-leaf); the reserved top-level `_stack` key holds the stack leaf. Core's
-Valibot schema types every leaf as `v.unknown()`. **There is no
-canonical enrichment leaf shape in core** — at any of the three scopes.
+`EnrichmentLeaf = unknown` (plus the optional reserved `_generator` leaf); the
+reserved top-level `_stack` key holds the stack leaf. Core's Valibot schema
+types every leaf as `v.unknown()`. **There is no canonical enrichment leaf shape
+in core** — at any of the three scopes.
 
-The leaf shapes live entirely in the generator's
-`toEnrichmentSchema()`. The engine hands a generator the unparsed leaf
-at each scope's key; the generator's own composite Valibot schema
-decides what shape is acceptable for `subject`, `generator`, and
-`stack`.
+The leaf shapes live entirely in the generator's `toEnrichmentSchema()`. The
+engine hands a generator the unparsed leaf at each scope's key; the generator's
+own composite Valibot schema decides what shape is acceptable for `subject`,
+`generator`, and `stack`.
 
 Two consequences worth knowing:
 
 - **Different generators at the same routing key never collide.**
   `enrichments['@skmtc/gen-shadcn-form']['/users']['post']` and
-  `enrichments['@skmtc/gen-msw']['/users']['post']` can have
-  completely different shapes. Each generator reads only its own
-  slice and parses only against its own schema.
-- **Adding a new enrichment field is a purely local change.**
-  Generators can extend their own schemas independently — no
-  coordinated core update, no canonical schema to maintain. This
-  is what makes the clone-and-add-an-enrichment path viable for
-  forks.
+  `enrichments['@skmtc/gen-msw']['/users']['post']` can have completely
+  different shapes. Each generator reads only its own slice and parses only
+  against its own schema.
+- **Adding a new enrichment field is a purely local change.** Generators can
+  extend their own schemas independently — no coordinated core update, no
+  canonical schema to maintain. This is what makes the
+  clone-and-add-an-enrichment path viable for forks.
 
-The split is also what lets enrichments stay an *opaque* lever for
-core while being a *fully-typed* one for the generator's own
-constructor.
+The split is also what lets enrichments stay an _opaque_ lever for core while
+being a _fully-typed_ one for the generator's own constructor.
 
 ## Where enrichments live
 
-User-supplied enrichments go in `client.json`. Key depth selects the
-scope. The subject scope's routing keys under each generator depend on
-the generator's projection-base kind; the payload shape *under* the
-leaf-locating keys is defined by the generator's Valibot schema (see
+User-supplied enrichments go in `client.json`. Key depth selects the scope. The
+subject scope's routing keys under each generator depend on the generator's
+projection-base kind; the payload shape _under_ the leaf-locating keys is
+defined by the generator's Valibot schema (see
 [routing structure](#the-routing-structure) below):
 
 ```json
@@ -267,68 +256,67 @@ leaf-locating keys is defined by the generator's Valibot schema (see
 
 Three scopes are visible here:
 
-- `_stack` — top-level reserved key; one bag shared across every
-  generator in the composition.
-- `["@skmtc/gen-shadcn-form"]._generator` — per-generator reserved
-  key; one bag for this generator.
-- `["@skmtc/gen-shadcn-form"]["/contacts"].post.main` — the subject
-  leaf. `/contacts` and `post` are the **routing** keys (the engine
-  navigates these), `main` is the variant; everything beneath is the
-  **payload** shape declared by the generator's Valibot schema.
+- `_stack` — top-level reserved key; one bag shared across every generator in
+  the composition.
+- `["@skmtc/gen-shadcn-form"]._generator` — per-generator reserved key; one bag
+  for this generator.
+- `["@skmtc/gen-shadcn-form"]["/contacts"].post.main` — the subject leaf.
+  `/contacts` and `post` are the **routing** keys (the engine navigates these),
+  `main` is the variant; everything beneath is the **payload** shape declared by
+  the generator's Valibot schema.
 
 ## The routing structure
 
-Routing applies to the **subject** scope only — the per-item leaf.
-(The `generator` and `stack` scopes are run-constants at fixed reserved
-keys; they aren't routed by item.) Each projection-base factory
-hardcodes its own `get(context.settings, ...)` lookup for the subject
-leaf. There are three shapes:
+Routing applies to the **subject** scope only — the per-item leaf. (The
+`generator` and `stack` scopes are run-constants at fixed reserved keys; they
+aren't routed by item.) Each projection-base factory hardcodes its own
+`get(context.settings, ...)` lookup for the subject leaf. There are three
+shapes:
 
-| Factory | Subject path read |
-|---|---|
-| `toOasOperationProjectionBase` | `enrichments.${generatorId}.${operation.path}.${operation.method}.${variant}` |
-| `toModelProjectionBase` | `enrichments.${generatorId}.${refName}.${variant}` |
+| Factory                        | Subject path read                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------ |
+| `toOasOperationProjectionBase` | `enrichments.${generatorId}.${operation.path}.${operation.method}.${variant}`        |
+| `toModelProjectionBase`        | `enrichments.${generatorId}.${refName}.${variant}`                                   |
 | `toGqlOperationProjectionBase` | `enrichments.${generatorId}.${operation.rootKind}.${operation.fieldName}.${variant}` |
 
-(These are core's own factory names. Generators don't call them
-directly — they wire up through their language package's veneer:
-`toTsModelProjectionBase` / `toTsOasOperationProjectionBase` /
-`toTsGqlOperationProjectionBase` from `@skmtc/lang-typescript`, and the
-`toKt*` / `toCs*` equivalents in the Kotlin and C# lang packages.)
+(These are core's own factory names. Generators don't call them directly — they
+wire up through their language package's veneer: `toTsModelProjectionBase` /
+`toTsOasOperationProjectionBase` / `toTsGqlOperationProjectionBase` from
+`@skmtc/lang-typescript`, and the `toKt*` / `toCs*` equivalents in the Kotlin
+and C# lang packages.)
 
 Specifically:
 
-- **OAS operation generators** route by `(operation.path, operation.method, variant)`
-  — the literal OpenAPI path, lowercase HTTP verb, and variant name.
-- **Model generators** route by `(refName, variant)` — the component
-  name as it appears under `components.schemas`, plus variant name.
-- **GraphQL operation generators** route by `(rootKind, fieldName, variant)`
-  — `"Query" | "Mutation" | "Subscription"`, the operation field,
-  and variant name.
+- **OAS operation generators** route by
+  `(operation.path, operation.method, variant)` — the literal OpenAPI path,
+  lowercase HTTP verb, and variant name.
+- **Model generators** route by `(refName, variant)` — the component name as it
+  appears under `components.schemas`, plus variant name.
+- **GraphQL operation generators** route by `(rootKind, fieldName, variant)` —
+  `"Query" | "Mutation" | "Subscription"`, the operation field, and variant
+  name.
 
-The trailing `variant` level defaults to `'main'` when the consumer
-declares no variants. Whenever any variant is declared, `'main'` MUST
-be present (the engine throws via `toVariantList` otherwise). See
-[`variants.md`](./variants.md).
+The trailing `variant` level defaults to `'main'` when the consumer declares no
+variants. Whenever any variant is declared, `'main'` MUST be present (the engine
+throws via `toVariantList` otherwise). See [`variants.md`](./variants.md).
 
-There is no `operationId`-based routing for OAS, and no separate
-"projection kind" or "projection key" routing level. Beneath the
-engine-routed keys, the leaf value's shape is whatever the
-generator's Valibot schema declares — see
-[enrichments-shape reference](../reference/settings/enrichments-shape.md)
-for the actual routing details and complete examples.
+There is no `operationId`-based routing for OAS, and no separate "projection
+kind" or "projection key" routing level. Beneath the engine-routed keys, the
+leaf value's shape is whatever the generator's Valibot schema declares — see
+[enrichments-shape reference](../reference/settings/enrichments-shape.md) for
+the actual routing details and complete examples.
 
 ## How enrichments are declared
 
-Each generator declares ONE **composite** schema covering all three
-scopes — `v.object({ subject, generator, stack })` — in
-`gen-x/src/enrichments.ts`. Each member describes the leaf at that
-scope; unused scopes are declared `v.undefined()`:
+Each generator declares ONE **composite** schema covering all three scopes —
+`v.object({ subject, generator, stack })` — in `gen-x/src/enrichments.ts`. Each
+member describes the leaf at that scope; unused scopes are declared
+`v.undefined()`:
 
 ```ts
 // gen-shadcn-form/src/enrichments.ts
-import * as v from 'valibot'
-import { moduleExport } from '@skmtc/core'
+import * as v from "valibot";
+import { moduleExport } from "@skmtc/core";
 
 export const formFieldItem = v.object({
   id: v.string(),
@@ -336,8 +324,8 @@ export const formFieldItem = v.object({
   input: v.optional(moduleExport),
   label: v.optional(v.string()),
   placeholder: v.optional(v.string()),
-  references: v.optional(v.string())
-})
+  references: v.optional(v.string()),
+});
 
 // The subject-scoped leaf — the per-operation form override.
 export const formSchema = v.optional(
@@ -345,26 +333,27 @@ export const formSchema = v.optional(
     title: v.optional(v.string()),
     description: v.optional(v.string()),
     submitLabel: v.optional(v.string()),
-    fields: v.optional(v.array(formFieldItem))
-  })
-)
+    fields: v.optional(v.array(formFieldItem)),
+  }),
+);
 
 // The three-scope enrichment umbrella. This generator only consumes the
 // subject scope; `generator` / `stack` are unused (declared `v.undefined()`).
 export const enrichmentSchema = v.object({
   subject: formSchema,
   generator: v.undefined(),
-  stack: v.undefined()
-})
+  stack: v.undefined(),
+});
 
-export type EnrichmentSchema = v.InferOutput<typeof enrichmentSchema>
-export const toEnrichmentSchema = () => enrichmentSchema
+export type EnrichmentSchema = v.InferOutput<typeof enrichmentSchema>;
+export const toEnrichmentSchema = () => enrichmentSchema;
 ```
 
 `toEnrichmentSchema` is **required** on both the entry factory and the
-projection-base config — it's what lets the engine assemble and parse
-the umbrella cast-free (see [how routing works](#how-routing-works-at-generate-time)).
-It's wired in both places:
+projection-base config — it's what lets the engine assemble and parse the
+umbrella cast-free (see
+[how routing works](#how-routing-works-at-generate-time)). It's wired in both
+places:
 
 ```ts
 // gen-shadcn-form/src/mod.ts
@@ -372,7 +361,7 @@ export const ShadcnFormEntry = toOasOperationEntry<EnrichmentSchema>({
   id: denoJson.name,
   toEnrichmentSchema,
   // ...
-})
+});
 ```
 
 ```ts
@@ -381,32 +370,32 @@ export const ShadcnFormBase = toTsOasOperationProjectionBase<EnrichmentSchema>({
   id: denoJson.name,
   toEnrichmentSchema,
   // ...
-})
+});
 ```
 
 A generator with **no enrichments at any scope** declares core's
-`emptyEnrichmentSchema` (every member `v.undefined()`) instead of
-hand-rolling the umbrella:
+`emptyEnrichmentSchema` (every member `v.undefined()`) instead of hand-rolling
+the umbrella:
 
 ```ts
 // gen-typescript/src/enrichments.ts
-import { emptyEnrichmentSchema, type EmptyEnrichments } from '@skmtc/core'
+import { type EmptyEnrichments, emptyEnrichmentSchema } from "@skmtc/core";
 
-export const toEnrichmentSchema = () => emptyEnrichmentSchema
+export const toEnrichmentSchema = () => emptyEnrichmentSchema;
 
-export type EnrichmentSchema = EmptyEnrichments
+export type EnrichmentSchema = EmptyEnrichments;
 ```
 
-This declaration is the canonical source of truth for what
-enrichment fields the generator accepts. **To know what payload a
-generator's enrichments take, read its `enrichments.ts`.**
+This declaration is the canonical source of truth for what enrichment fields the
+generator accepts. **To know what payload a generator's enrichments take, read
+its `enrichments.ts`.**
 
 ## How enrichments are consumed
 
 Inside a Projection, the validated three-scope umbrella is available as
-`this.settings.enrichments`. Read the scope you want —
-`.subject`, `.generator`, or `.stack` — each typed (and `undefined`
-when the generator declares nothing for that scope):
+`this.settings.enrichments`. Read the scope you want — `.subject`, `.generator`,
+or `.stack` — each typed (and `undefined` when the generator declares nothing
+for that scope):
 
 ```ts
 // gen-shadcn-form/src/ShadcnForm.ts
@@ -426,58 +415,55 @@ override toString(): string {
 }
 ```
 
-The enrichments are pre-validated by the engine using the
-generator's declared composite Valibot schema, so the Projection can
-assume the shape is correct. Unknown keys are stripped silently;
-missing optional keys arrive as `undefined`.
+The enrichments are pre-validated by the engine using the generator's declared
+composite Valibot schema, so the Projection can assume the shape is correct.
+Unknown keys are stripped silently; missing optional keys arrive as `undefined`.
 
 ### Reading scopes outside a Projection
 
-`this.settings.enrichments` only exists where there's a
-`ContentSettings` — i.e. inside a Projection. The `generator` and
-`stack` scopes are run-constants, so they're often needed elsewhere:
-in `transform`, in `isSupported`, in an accumulator snippet. From
-those contexts (anywhere holding a `context`), read them with the
-helper readers from `@skmtc/core`:
+`this.settings.enrichments` only exists where there's a `ContentSettings` — i.e.
+inside a Projection. The `generator` and `stack` scopes are run-constants, so
+they're often needed elsewhere: in `transform`, in `isSupported`, in an
+accumulator snippet. From those contexts (anywhere holding a `context`), read
+them with the helper readers from `@skmtc/core`:
 
 ```ts
-import { toGeneratorEnrichment, toStackEnrichment } from '@skmtc/core'
+import { toGeneratorEnrichment, toStackEnrichment } from "@skmtc/core";
 
 // generator-scoped leaf — context.settings.enrichments[id]._generator
-const genConfig = toGeneratorEnrichment(context, id, generatorSchema)
+const genConfig = toGeneratorEnrichment(context, id, generatorSchema);
 
 // stack-scoped leaf — context.settings.enrichments._stack
-const stackConfig = toStackEnrichment(context, stackSchema)
+const stackConfig = toStackEnrichment(context, stackSchema);
 ```
 
-The return type is inferred from the schema you pass — no cast. Each
-reader looks up by a known reserved key and never enumerates, so a
-generator can't trip over the reserved keys. (There is no
-`subject` reader here: the subject scope is per-item and is resolved by
-the engine into `ContentSettings`.)
+The return type is inferred from the schema you pass — no cast. Each reader
+looks up by a known reserved key and never enumerates, so a generator can't trip
+over the reserved keys. (There is no `subject` reader here: the subject scope is
+per-item and is resolved by the engine into `ContentSettings`.)
 
 ## How routing works at generate time
 
 For each Projection the engine builds:
 
-1. The factory's static `toEnrichments({ operation | refName, context, variant })`
-   runs.
+1. The factory's static
+   `toEnrichments({ operation | refName, context, variant })` runs.
 2. It reads the **raw umbrella** from the three storage spots:
-   - `subject` — `get(context.settings, ['enrichments', id, <subject…>, variant])`
-     at the path shown in the routing table for that projection-base kind.
+   - `subject` —
+     `get(context.settings, ['enrichments', id, <subject…>, variant])` at the
+     path shown in the routing table for that projection-base kind.
    - `generator` — `get(context.settings, ['enrichments', id, '_generator'])`.
    - `stack` — `get(context.settings, ['enrichments', '_stack'])`.
-3. The `{ subject, generator, stack }` raw object is parsed **once**
-   through the generator's composite `toEnrichmentSchema()` —
-   `v.parse(config.toEnrichmentSchema(), raw)`. Because the composite
-   schema is required, this parse is cast-free.
-4. The parsed umbrella is delivered as `settings.enrichments` to the
-   Projection.
+3. The `{ subject, generator, stack }` raw object is parsed **once** through the
+   generator's composite `toEnrichmentSchema()` —
+   `v.parse(config.toEnrichmentSchema(), raw)`. Because the composite schema is
+   required, this parse is cast-free.
+4. The parsed umbrella is delivered as `settings.enrichments` to the Projection.
 
-`toEnrichments` is generated by the factory; you don't write it
-manually. The single `EnrichmentType` generic on the projection chain
-now *means* this `{ subject, generator, stack }` umbrella — the chain
-stays single-param; there are no new type parameters per scope.
+`toEnrichments` is generated by the factory; you don't write it manually. The
+single `EnrichmentType` generic on the projection chain now _means_ this
+`{ subject, generator, stack }` umbrella — the chain stays single-param; there
+are no new type parameters per scope.
 
 ## The relationship to clone-vs-install
 
@@ -490,42 +476,44 @@ Enrichments fit in the middle of the customization gradient:
 4. Author new        → write a generator from scratch
 ```
 
-Enrichments are level 2. They let you tweak per-operation behavior
-without bringing source into your project. The price: you can only
-tweak what the generator's author chose to expose.
+Enrichments are level 2. They let you tweak per-operation behavior without
+bringing source into your project. The price: you can only tweak what the
+generator's author chose to expose.
 
 If the generator doesn't expose what you need:
 
-- **Stop and consider**: maybe the answer is to clone (level 3) and
-  add the enrichment field yourself.
-- **Or**: clone and just hardcode the desired behavior — no
-  enrichment needed if it's project-specific anyway.
+- **Stop and consider**: maybe the answer is to clone (level 3) and add the
+  enrichment field yourself.
+- **Or**: clone and just hardcode the desired behavior — no enrichment needed if
+  it's project-specific anyway.
 
-Adding enrichments to a stock generator (to expose what users have
-been hardcoding) is a reasonable upstream contribution. Adding
-enrichments to a clone-then-published fork is fine for project-
-local needs.
+Adding enrichments to a stock generator (to expose what users have been
+hardcoding) is a reasonable upstream contribution. Adding enrichments to a
+clone-then-published fork is fine for project- local needs.
 
 ## AI-driven enrichments — `EnrichmentRequest`
 
-A second enrichment path exists for cases where the *generator*
-wants to *request* an enrichment value rather than wait for the
-user to author one. The shape (`core/types/EnrichmentRequest.ts`):
+A second enrichment path exists for cases where the _generator_ wants to
+_request_ an enrichment value rather than wait for the user to author one. The
+shape (`core/types/EnrichmentRequest.ts`):
 
 ```ts
 type EnrichmentRequest<EnrichmentType> = {
-  prompt: string
-  enrichmentSchema: v.BaseSchema<EnrichmentType, EnrichmentType, v.BaseIssue<unknown>>
-  content: string
-}
+  prompt: string;
+  enrichmentSchema: v.BaseSchema<
+    EnrichmentType,
+    EnrichmentType,
+    v.BaseIssue<unknown>
+  >;
+  content: string;
+};
 ```
 
-A generator can implement `toEnrichmentRequest(refName)` on its
-entry config. The function returns either a request descriptor
-(prompt + schema + content to feed an LLM) or `undefined` to skip.
-Tooling that integrates with an LLM fulfils the request, validates
-the response against the schema, and persists the result into
-`client.json` as if the user had authored it.
+A generator can implement `toEnrichmentRequest(refName)` on its entry config.
+The function returns either a request descriptor (prompt + schema + content to
+feed an LLM) or `undefined` to skip. Tooling that integrates with an LLM fulfils
+the request, validates the response against the schema, and persists the result
+into `client.json` as if the user had authored it.
 
 The flow:
 
@@ -543,25 +531,24 @@ next run consumes the result like a user-authored enrichment
 
 Two ways this fits with the wider model:
 
-- The leaf shape is still owned by the generator (same Valibot
-  schema). The AI path doesn't bypass validation — it just defers
-  the *author* of the leaf from "the user" to "an LLM
-  constrained by the schema."
-- The wire format is the same `client.json` slice. Tooling that
-  doesn't fulfil requests simply ignores them; the project still
-  works with whatever user-authored enrichments are present.
+- The leaf shape is still owned by the generator (same Valibot schema). The AI
+  path doesn't bypass validation — it just defers the _author_ of the leaf from
+  "the user" to "an LLM constrained by the schema."
+- The wire format is the same `client.json` slice. Tooling that doesn't fulfil
+  requests ignores them; the project still works with whatever user-authored
+  enrichments are present.
 
-This is a deferred-fill pattern. It suits enrichments where the
-value is *derivable* from the schema (a sensible default label,
-a sample value, a description) but you'd rather not hand-author
-hundreds of them across a large API.
+This is a deferred-fill pattern. It suits enrichments where the value is
+_derivable_ from the schema (a sensible default label, a sample value, a
+description) but you'd rather not hand-author hundreds of them across a large
+API.
 
 ## Common patterns
 
 ### Per-operation titles and labels
 
-The most common enrichment pattern. The form generator's `title`
-and `submitLabel` enable per-form text without cloning:
+The most common enrichment pattern. The form generator's `title` and
+`submitLabel` enable per-form text without cloning:
 
 ```json
 {
@@ -571,7 +558,7 @@ and `submitLabel` enable per-form text without cloning:
         "post": { "title": "Create User", "submitLabel": "Create" }
       },
       "/users/{id}": {
-        "put":    { "title": "Edit User",   "submitLabel": "Save" },
+        "put": { "title": "Edit User", "submitLabel": "Save" },
         "delete": { "title": "Delete User", "submitLabel": "Delete" }
       }
     }
@@ -581,8 +568,8 @@ and `submitLabel` enable per-form text without cloning:
 
 ### Field-level overrides
 
-When a schema field needs special handling that the generator's
-default routing doesn't cover:
+When a schema field needs special handling that the generator's default routing
+doesn't cover:
 
 ```json
 {
@@ -591,7 +578,11 @@ default routing doesn't cover:
       "/contacts": {
         "post": {
           "fields": [
-            { "id": "officeIds", "references": "GetOffices", "referenceKind": "searchable" }
+            {
+              "id": "officeIds",
+              "references": "GetOffices",
+              "referenceKind": "searchable"
+            }
           ]
         }
       }
@@ -600,45 +591,44 @@ default routing doesn't cover:
 }
 ```
 
-This tells the form generator: when rendering the `officeIds` field
-of `POST /contacts`, route it to the `GetOffices` operation
-(searchable dropdown), not the default string-array renderer.
+This tells the form generator: when rendering the `officeIds` field of
+`POST /contacts`, route it to the `GetOffices` operation (searchable dropdown),
+not the default string-array renderer.
 
 ### Operation-reference patterns
 
-A common enrichment shape across generators: pointing one operation
-at another. The `references` field in form fields above is an
-example — the form's `officeIds` field references the `GetOffices`
-operation as the source of selectable values.
+A common enrichment shape across generators: pointing one operation at another.
+The `references` field in form fields above is an example — the form's
+`officeIds` field references the `GetOffices` operation as the source of
+selectable values.
 
-This is how generators compose across the operation graph without
-hardcoded knowledge of specific operations.
+This is how generators compose across the operation graph without hardcoded
+knowledge of specific operations.
 
 ## Common questions
 
 ### Are enrichments validated?
 
-Yes. Each generator's `toEnrichmentSchema()` returns a Valibot
-schema that the engine uses to validate the user's input. Unknown
-fields are stripped silently; missing optional fields are
-`undefined`; type mismatches surface as parse errors.
+Yes. Each generator's `toEnrichmentSchema()` returns a Valibot schema that the
+engine uses to validate the user's input. Unknown fields are stripped silently;
+missing optional fields are `undefined`; type mismatches surface as parse
+errors.
 
 ### Can I extend a stock generator's enrichments without cloning?
 
-No. The enrichment schema is part of the generator's source. To add
-new keys, you clone the generator and edit `enrichments.ts`.
+No. The enrichment schema is part of the generator's source. To add new keys,
+you clone the generator and edit `enrichments.ts`.
 
 ### Are enrichments hot-reloadable?
 
-Yes — they're runtime config, not bundle code. Edit `client.json`,
-re-run `skmtc generate`, the new values apply. No rebundle needed.
-This is part of why enrichments are the right lever for narrow
-per-operation tweaks.
+Yes — they're runtime config, not bundle code. Edit `client.json`, re-run
+`skmtc generate`, the new values apply. No rebundle needed. This is part of why
+enrichments are the right lever for narrow per-operation tweaks.
 
 ### What about per-model enrichments (vs per-operation)?
 
-Model generators (like `gen-zod` or `gen-typescript`) route the
-subject scope by `refName` (then `variant`):
+Model generators (like `gen-zod` or `gen-typescript`) route the subject scope by
+`refName` (then `variant`):
 
 ```json
 {
@@ -650,37 +640,39 @@ subject scope by `refName` (then `variant`):
 }
 ```
 
-`refName` → `variant` locates the subject leaf; the value beneath the
-variant **is** the validated subject payload. (`variant` defaults to
-`'main'`.)
+`refName` → `variant` locates the subject leaf; the value beneath the variant
+**is** the validated subject payload. (`variant` defaults to `'main'`.)
 
 ### Can I share enrichment values across generators?
 
-Yes — that's exactly what the **stack** scope is for. The reserved
-top-level `_stack` key holds one leaf every generator in the
-composition can read (via `toStackEnrichment(context, schema)`). Each
-consuming generator passes a *partial* schema describing only the
-fields it reads — Valibot ignores unknown keys, so fields other
-generators consume don't interfere.
+Yes — that's exactly what the **stack** scope is for. The reserved top-level
+`_stack` key holds one leaf every generator in the composition can read (via
+`toStackEnrichment(context, schema)`). Each consuming generator passes a
+_partial_ schema describing only the fields it reads — Valibot ignores unknown
+keys, so fields other generators consume don't interfere.
 
-What you *can't* share is a **subject** or **generator** scope leaf —
-each generator declares its own shape independently there. If you want
-the same per-item value across generators without using `_stack`, you
-replicate the relevant portion to each generator's section.
+What you _can't_ share is a **subject** or **generator** scope leaf — each
+generator declares its own shape independently there. If you want the same
+per-item value across generators without using `_stack`, you replicate the
+relevant portion to each generator's section.
 
 ### Do enrichments survive when I clone the generator?
 
-User data in `client.json` is unaffected by cloning. But if the
-clone keeps the same routing shape (same projection-base factory)
-**and** the same generator `id`, the existing enrichments still
-land. If you change the `id` (which you typically do when you
-republish), update the `client.json` keys to match the new id.
+User data in `client.json` is unaffected by cloning. But if the clone keeps the
+same routing shape (same projection-base factory) **and** the same generator
+`id`, the existing enrichments still land. If you change the `id` (which you
+typically do when you republish), update the `client.json` keys to match the new
+id.
 
 ## Further reading
 
-- [Clone vs install](clone-vs-install.md) — where enrichments fit on the customization gradient
-- [Projects and workspaces](projects-and-workspaces.md) — where `client.json` lives
+- [Clone vs install](clone-vs-install.md) — where enrichments fit on the
+  customization gradient
+- [Projects and workspaces](projects-and-workspaces.md) — where `client.json`
+  lives
 - [Settings reference: client.json schema](../reference/settings/client-json-schema.md)
 - [Settings reference: enrichments shape](../reference/settings/enrichments-shape.md)
-- [`skmtc-cli` skill §6](../skills/skmtc-cli/SKILL.md) — operational guidance for configuring enrichments
-- [`skmtc-generator` skill](../skills/skmtc-generator/SKILL.md) — how to declare a new enrichment in your generator
+- [`skmtc-cli` skill §6](../skills/skmtc-cli/SKILL.md) — operational guidance
+  for configuring enrichments
+- [`skmtc-generator` skill](../skills/skmtc-generator/SKILL.md) — how to declare
+  a new enrichment in your generator

--- a/deno/docs/concepts/error-handling-philosophy.md
+++ b/deno/docs/concepts/error-handling-philosophy.md
@@ -1,33 +1,32 @@
 # Error handling philosophy
 
-> Why parse fails open and the manifest is the canonical run record:
-> SKMTC treats partial output with full diagnostics as more valuable
-> than zero output with a single root-cause error. One bad schema
-> shouldn't kill the run.
+> Why parse fails open and the manifest is the canonical run record: SKMTC
+> treats partial output with full diagnostics as more valuable than zero output
+> with a single root-cause error. One bad schema shouldn't kill the run.
 
 The philosophy in one sentence: **lenient input, strict diagnostics**.
 
-Many codegen tools fail closed — one parse error halts everything,
-forcing the user to fix the schema before getting any output. SKMTC
-fails open: it parses what it can, prunes what it can't, logs every
-decision, and produces output for the surviving items. The manifest
-is the structured record of what worked and what didn't.
+Many codegen tools fail closed — one parse error halts everything, forcing the
+user to fix the schema before getting any output. SKMTC fails open: it parses
+what it can, prunes what it can't, logs every decision, and produces output for
+the surviving items. The manifest is the structured record of what worked and
+what didn't.
 
-This isn't anything-goes leniency. Diagnostics are exhaustive; every
-dropped item, every cascading failure, every type-inference fallback
-is logged with location and reason. The user gets both the output
-they could have *and* full visibility into what was sacrificed.
+This isn't anything-goes leniency. Diagnostics are exhaustive; every dropped
+item, every cascading failure, every type-inference fallback is logged with
+location and reason. The user gets both the output they could have _and_ full
+visibility into what was sacrificed.
 
 ## The one-line definition
 
-Parse never throws to its caller. Generator transforms catch errors
-per item. The manifest records every outcome. Exit codes are derived
-from the manifest, not from process throws.
+Parse never throws to its caller. Generator transforms catch errors per item.
+The manifest records every outcome. Exit codes are derived from the manifest,
+not from process throws.
 
 ## Two-tier error isolation in Parse
 
-Parse uses two complementary mechanisms to ensure one bad item
-doesn't kill the run.
+Parse uses two complementary mechanisms to ensure one bad item doesn't kill the
+run.
 
 ### Tier 1: per-item isolation via `tryParseAt`
 
@@ -37,44 +36,41 @@ Every per-item parser is wrapped in `tryParseAt`:
 // core/oas/schema/toSchemasV3.ts
 for (const [key, schema] of entries) {
   const value = tryParseAt({
-    stackTrail, key, context,
-    type: 'INVALID_SCHEMA',
+    stackTrail,
+    key,
+    context,
+    type: "INVALID_SCHEMA",
     parent: schema,
-    fn: st => toSchemaV3({ schema, stackTrail: st, context })
-  })
+    fn: (st) => toSchemaV3({ schema, stackTrail: st, context }),
+  });
   if (value !== undefined) {
-    output[key] = value
+    output[key] = value;
   }
   // ← if value is undefined, the entry is silently omitted from output
 }
 ```
 
-A throw inside `toSchemaV3` becomes a `level: 'error'` `ParseIssue`,
-and the key is simply skipped in the output map. The siblings
-continue parsing. The error stays in the issue log with full
-stack-trail location.
+A throw inside `toSchemaV3` becomes a `level: 'error'` `ParseIssue`, and the key
+is skipped in the output map. The siblings continue parsing. The error stays in
+the issue log with full stack-trail location.
 
-This is **per-item** isolation. The unit can be one schema, one
-operation, one parameter — whatever the level the `tryParseAt` wraps.
+This is **per-item** isolation. The unit can be one schema, one operation, one
+parameter — whatever the level the `tryParseAt` wraps.
 
 ### Tier 2: cross-ref via `removeErroredItems`
 
-What happens when a parsed item references a *failed* item via
-`$ref`?
+What happens when a parsed item references a _failed_ item via `$ref`?
 
 During the parse walk, every `$ref` encounter calls
 `context.registerRef(stackTrail.clone(), $ref)`. This builds a map:
-`#refConsumers: Map<refKey, StackTrail[]>` — "who pointed at this
-ref?"
+`#refConsumers: Map<refKey, StackTrail[]>` — "who pointed at this ref?"
 
 When a parse error happens at a component position, `logIssueNoKey`
 auto-registers the error against the ref by calling
-`context.registerRefError(issue.cause, stackTrail.toStackRef())`.
-This builds: `#refErrors: Map<refKey, unknown[]>` — "what went wrong
-with this ref?"
+`context.registerRefError(issue.cause, stackTrail.toStackRef())`. This builds:
+`#refErrors: Map<refKey, unknown[]>` — "what went wrong with this ref?"
 
-After the main walk finishes, `removeErroredItems` walks both maps
-together:
+After the main walk finishes, `removeErroredItems` walks both maps together:
 
 ```ts
 for (const [refKey, errors] of this.#refErrors) {
@@ -95,63 +91,57 @@ for (const [refKey, errors] of this.#refErrors) {
 }
 ```
 
-So if `User` fails to parse and `CreateUserRequest.parameters[0]`
-referenced `User`, that operation gets pruned from
-`oasDocument.operations`, with an `INVALID_DEPENDENCY_REF` issue at
-the operation's location explaining why.
+So if `User` fails to parse and `CreateUserRequest.parameters[0]` referenced
+`User`, that operation gets pruned from `oasDocument.operations`, with an
+`INVALID_DEPENDENCY_REF` issue at the operation's location explaining why.
 
-The cascade is **one hop deep** by current design. If `Post`
-references `User` and `Comment` references `Post`, breaking `User`
-prunes `Post` (one hop). `Comment` would then fail later when it
-tries to resolve a now-missing `Post` — but that failure happens at
-generate time, not in `removeErroredItems`.
+The cascade is **one hop deep** by current design. If `Post` references `User`
+and `Comment` references `Post`, breaking `User` prunes `Post` (one hop).
+`Comment` would then fail later when it tries to resolve a now-missing `Post` —
+but that failure happens at generate time, not in `removeErroredItems`.
 
 ## How the mechanism is engineered
 
-The high-level model (parse fails open, refs are cloned, cascade
-prunes consumers one hop) rests on four small implementation
-choices, each easy to overlook on a casual read. None of them are
-load-bearing in isolation; together they are what makes the model
-true rather than aspirational.
+The high-level model (parse fails open, refs are cloned, cascade prunes
+consumers one hop) rests on four small implementation choices, each easy to
+overlook on a casual read. None of them are load-bearing in isolation; together
+they are what makes the model true rather than aspirational.
 
 ### 1. Empty parsed document issued at construction, mutated in place
 
-`ParseContext` constructs an empty `OasDocument` *before* the walk
-starts (`core/context/ParseContext.ts:120`). Every `OasRef`
-constructed during the walk holds a reference to
-`context.parsedDocument`, which wraps that same instance:
+`ParseContext` constructs an empty `OasDocument` _before_ the walk starts
+(`core/context/ParseContext.ts:120`). Every `OasRef` constructed during the walk
+holds a reference to `context.parsedDocument`, which wraps that same instance:
 
 ```ts
 // core/oas/ref/toRefV31.ts:26-34
-context.registerRef(stackTrail.clone(), $ref)
-return new OasRef({ refType, $ref }, context.parsedDocument)
+context.registerRef(stackTrail.clone(), $ref);
+return new OasRef({ refType, $ref }, context.parsedDocument);
 ```
 
-`OasDocument.#fields` is `undefined` at this point — every getter
-throws (`Document.ts:248`: `Accessing 'openapi' before fields are
-set`). At the end of parse, `parse()` mutates the same instance
-via `oasState.oasDocument.fields = toDocumentFieldsV3(...)`. All
-the refs that captured the empty wrapper now resolve through the
-now-populated fields.
+`OasDocument.#fields` is `undefined` at this point — every getter throws
+(`Document.ts:248`: `Accessing 'openapi' before fields are
+set`). At the end of
+parse, `parse()` mutates the same instance via
+`oasState.oasDocument.fields = toDocumentFieldsV3(...)`. All the refs that
+captured the empty wrapper now resolve through the now-populated fields.
 
-The same pattern is applied to `GqlDocument` (`ParseContext.ts:134-136`).
-Issued empty at construction, populated by `parseGqlDocument` at
-the end of the walk. The symmetry is deliberate.
+The same pattern is applied to `GqlDocument` (`ParseContext.ts:134-136`). Issued
+empty at construction, populated by `parseGqlDocument` at the end of the walk.
+The symmetry is deliberate.
 
-Without this pattern, lazy ref resolution would require either two
-passes (parse all schemas first, then resolve refs) or strict
-topological ordering of components in the source document. The
-issued-empty-then-mutated trick avoids both.
+Without this pattern, lazy ref resolution would require either two passes (parse
+all schemas first, then resolve refs) or strict topological ordering of
+components in the source document. The issued-empty-then-mutated trick avoids
+both.
 
 ### 2. The `toStackRef` + `registerRefError` no-op composition
 
-`StackTrail.toStackRef()` returns a `$ref` string *only* when the
-trail points at a recognized component position
-(`['components', <bucket>, <name>]`) — and returns `undefined`
-otherwise (`StackTrail.ts:138-154`).
+`StackTrail.toStackRef()` returns a `$ref` string _only_ when the trail points
+at a recognized component position (`['components', <bucket>, <name>]`) — and
+returns `undefined` otherwise (`StackTrail.ts:138-154`).
 
-`ParseContext.registerRefError` is a deliberate no-op on
-`undefined`:
+`ParseContext.registerRefError` is a deliberate no-op on `undefined`:
 
 ```ts
 // core/context/ParseContext.ts:334-342
@@ -161,31 +151,29 @@ registerRefError(error: unknown, refKey: string | undefined): void {
 }
 ```
 
-The two compose. Inside `logIssueNoKey`, every error-level issue
-runs:
+The two compose. Inside `logIssueNoKey`, every error-level issue runs:
 
 ```ts
 // core/context/ParseContext.ts:399
-this.registerRefError(issue.cause ?? issue.message, stackTrail.toStackRef())
+this.registerRefError(issue.cause ?? issue.message, stackTrail.toStackRef());
 ```
 
-Parser code never has to know whether it's at a component
-position. The trail shape decides; non-component errors fall
-through silently. This is the bridge between two different
-addressing schemes — tree positions (held by trails) and `$ref`
-strings (used by consumers). Every component-position error
-automatically becomes eligible for cascade pruning; every other
-error stays in the issue log but doesn't fan out.
+Parser code never has to know whether it's at a component position. The trail
+shape decides; non-component errors fall through silently. This is the bridge
+between two different addressing schemes — tree positions (held by trails) and
+`$ref` strings (used by consumers). Every component-position error automatically
+becomes eligible for cascade pruning; every other error stays in the issue log
+but doesn't fan out.
 
-See [the-stack-trail.md](the-stack-trail.md#tostackref-the-address-bridge)
-for the full address-bridge story.
+See [the-stack-trail.md](the-stack-trail.md#tostackref-the-address-bridge) for
+the full address-bridge story.
 
 ### 3. `removeItem` reads only the first three trail segments
 
 When cascade pruning runs, each stored consumer trail is passed to
-`OasDocument.removeItem`. The trail can be arbitrarily deep —
-wherever the parser was when it hit the `$ref` — but `removeItem`
-only looks at `[first, second, third]`:
+`OasDocument.removeItem`. The trail can be arbitrarily deep — wherever the
+parser was when it hit the `$ref` — but `removeItem` only looks at
+`[first, second, third]`:
 
 ```ts
 // core/oas/document/Document.ts:190-219
@@ -201,103 +189,92 @@ case 'components': {
 ```
 
 So a deeply-nested consumer trail like
-`paths./users.post.requestBody.content.application/json.schema`
-prunes the whole `POST /users` operation. The deeper segments are
-discarded.
+`paths./users.post.requestBody.content.application/json.schema` prunes the whole
+`POST /users` operation. The deeper segments are discarded.
 
-The granularity is by design: OAS operations and components are
-atomic at the pruning level. There is no useful "remove the
-request body schema but keep the rest of the operation" — either
-the operation parses or it gets pruned. The same is true for
-components.
+The granularity is by design: OAS operations and components are atomic at the
+pruning level. There is no useful "remove the request body schema but keep the
+rest of the operation" — either the operation parses or it gets pruned. The same
+is true for components.
 
 ### 4. `tryParseAt` re-enters `stackTrail.trace` on the error path
 
-`tryParseAt` runs its callback inside `stackTrail.trace(key, ...)`.
-By the time a thrown error reaches the surrounding `catch`, the
-trace has already popped `key` from the trail (that's `trace`'s
-pop-on-both-paths guarantee). To log the error at the *child*
-position, `tryParseAt` opens a fresh trace:
+`tryParseAt` runs its callback inside `stackTrail.trace(key, ...)`. By the time
+a thrown error reaches the surrounding `catch`, the trace has already popped
+`key` from the trail (that's `trace`'s pop-on-both-paths guarantee). To log the
+error at the _child_ position, `tryParseAt` opens a fresh trace:
 
 ```ts
 // core/context/tryParseAt.ts:81-99
 try {
-  return stackTrail.trace(key, childStack => fn(childStack))
+  return stackTrail.trace(key, (childStack) => fn(childStack));
 } catch (error) {
   // ...
-  stackTrail.trace(key, childStack => {
+  stackTrail.trace(key, (childStack) => {
     context.logIssueNoKey({
-      level: 'error',
+      level: "error",
       stackTrail: childStack,
       // ...
-    })
-  })
-  return undefined
+    });
+  });
+  return undefined;
 }
 ```
 
-Without the re-trace, the error would log at the *parent*
-location, and every per-item failure would point at its container
-instead of the offending item. With the re-trace,
-`INVALID_SCHEMA` issues land at `components:schemas:User` instead
-of `components:schemas`.
+Without the re-trace, the error would log at the _parent_ location, and every
+per-item failure would point at its container instead of the offending item.
+With the re-trace, `INVALID_SCHEMA` issues land at `components:schemas:User`
+instead of `components:schemas`.
 
-This is also why issues stay accurately located even though the
-trail itself is mutable and shared across the walker.
+This is also why issues stay accurately located even though the trail itself is
+mutable and shared across the walker.
 
 ## Why one-hop cascade pruning?
 
-The honest answer: depth-2+ pruning was deferred. Implementing it
-robustly requires walking the ref graph transitively, which is
-non-trivial because:
+The honest answer: depth-2+ pruning was deferred. Implementing it robustly
+requires walking the ref graph transitively, which is non-trivial because:
 
-- The ref graph can have cycles (handled by `MAX_LOOKUPS` at
-  resolution time, but graph walking needs its own cycle protection)
+- The ref graph can have cycles (handled by `MAX_LOOKUPS` at resolution time,
+  but graph walking needs its own cycle protection)
 - A single ref can be referenced by many consumers; ordering matters
-- Removing items can trigger their own cascades — the algorithm
-  becomes iterative-to-fixpoint
+- Removing items can trigger their own cascades — the algorithm becomes
+  iterative-to-fixpoint
 
-In practice, depth-2 failures show up at generate time as
-`Ref "Post" not found` exceptions in generator code. The generator's
-own `try/catch` handles these gracefully (the operation is marked
-`'error'` in the manifest results). The user sees the chain in the
-manifest: `User` is `INVALID_SCHEMA`, `Post` is
-`INVALID_DEPENDENCY_REF`, `Comment` operations are individually
-marked `'error'` with `Ref "Post" not found` as the message.
+In practice, depth-2 failures show up at generate time as `Ref "Post" not found`
+exceptions in generator code. The generator's own `try/catch` handles these
+gracefully (the operation is marked `'error'` in the manifest results). The user
+sees the chain in the manifest: `User` is `INVALID_SCHEMA`, `Post` is
+`INVALID_DEPENDENCY_REF`, `Comment` operations are individually marked `'error'`
+with `Ref "Post" not found` as the message.
 
 Imperfect but acceptable. The manifest still records everything.
 
 ## Type-inference fallbacks (the other lenient lever)
 
-OAS documents in the wild often omit `type` on schemas — the JSON
-Schema spec made it optional. SKMTC infers when it can rather than
-failing:
+OAS documents in the wild often omit `type` on schemas — the JSON Schema spec
+made it optional. SKMTC infers when it can rather than failing:
 
 - Schema has `properties` → assume `type: 'object'`. Logs a
   `MISSING_OBJECT_TYPE` warning.
-- Schema has `items` → assume `type: 'array'`. Logs
-  `MISSING_ARRAY_TYPE`.
-- Schema has `default` or `example` that's a string → assume
+- Schema has `items` → assume `type: 'array'`. Logs `MISSING_ARRAY_TYPE`.
+- Schema has `default` or `example` that's a string → assume `type: 'string'`.
+  Logs `MISSING_STRING_TYPE`.
+- Schema has a recognized string `format` (`date`, `date-time`, etc.) → assume
   `type: 'string'`. Logs `MISSING_STRING_TYPE`.
-- Schema has a recognized string `format` (`date`, `date-time`,
-  etc.) → assume `type: 'string'`. Logs `MISSING_STRING_TYPE`.
 
-These are **warnings**, not errors. The output is produced; the
-warning is logged. A consumer reviewing the manifest sees both: "I
-got my types" and "by the way, three of your schemas were missing
-`type` fields and I inferred them — you might want to fix the
-source."
+These are **warnings**, not errors. The output is produced; the warning is
+logged. A consumer reviewing the manifest sees both: "I got my types" and "by
+the way, three of your schemas were missing `type` fields and I inferred them —
+you might want to fix the source."
 
-This is the leniency-strictness pairing in action. Lenient on
-input (we don't refuse to parse), strict on diagnostics (we log
-every inference).
+This is the leniency-strictness pairing in action. Lenient on input (we don't
+refuse to parse), strict on diagnostics (we log every inference).
 
 ## The manifest as canonical run record
 
-The manifest at `<root>/.skmtc/<project>/.settings/manifest.json` is
-the **source of truth** for what happened in the last run. The
-on-screen output reports a summary; the manifest reports every
-decision.
+The manifest at `<root>/.skmtc/<project>/.settings/manifest.json` is the
+**source of truth** for what happened in the last run. The on-screen output
+reports a summary; the manifest reports every decision.
 
 ### Top-level structure
 
@@ -344,21 +321,20 @@ Each leaf is one of:
 - `success` — generator ran, produced output for this item
 - `warning` — produced output with a recoverable issue logged
 - `error` — generator threw or returned failure; output missing or partial
-- `skipped` — item matched but deliberately skipped (e.g., by
-  `client.json` filters)
-- `notSupported` — generator's `isSupported` returned false — *expected*
-  for items outside the generator's scope
+- `skipped` — item matched but deliberately skipped (e.g., by `client.json`
+  filters)
+- `notSupported` — generator's `isSupported` returned false — _expected_ for
+  items outside the generator's scope
 
 ### Per-operation results
 
-The result granularity is `(generator × item)`. If you have 100
-operations and 5 generators, the manifest contains up to 500 results.
-You can ask "which operations did this generator process, and how?"
+The result granularity is `(generator × item)`. If you have 100 operations and 5
+generators, the manifest contains up to 500 results. You can ask "which
+operations did this generator process, and how?"
 
 ## Exit code derivation
 
-The CLI exits non-zero when any `parseIssue.level === 'error'` is
-present:
+The CLI exits non-zero when any `parseIssue.level === 'error'` is present:
 
 ```
 1. parseIssues is empty or has only level: 'warning' entries
@@ -381,90 +357,91 @@ or
    → Exit 2 with recipe error
 ```
 
-This is the agent contract: a CI run that exits 0 is success; a run
-that exits 1 has captured failures in the manifest's parseIssues
-array (which agents can parse and present).
+This is the agent contract: a CI run that exits 0 is success; a run that exits 1
+has captured failures in the manifest's parseIssues array (which agents can
+parse and present).
 
-The manifest persists regardless of exit code. Even a failed run
-writes the manifest — the diagnostic record survives.
+The manifest persists regardless of exit code. Even a failed run writes the
+manifest — the diagnostic record survives.
 
 ## Why no thrown exceptions to the caller?
 
 A throw-based error model is wrong for SKMTC's use case:
 
-1. **Partial output is valuable.** A schema with 100 operations and
-   one broken schema can still produce 99 useful files. Throwing on
-   the first error kills the other 99.
+1. **Partial output is valuable.** A schema with 100 operations and one broken
+   schema can still produce 99 useful files. Throwing on the first error kills
+   the other 99.
 
-2. **The manifest is structured.** Errors as exception messages lose
-   structure — they're strings. The manifest is JSON, which agents
-   can grep, transform, and route.
+2. **The manifest is structured.** Errors as exception messages lose structure —
+   they're strings. The manifest is JSON, which agents can grep, transform, and
+   route.
 
-3. **Cascading failures need representation.** A single broken `User`
-   schema produces many `INVALID_DEPENDENCY_REF` issues. A throw
-   model would surface only the first; the manifest surfaces all of
-   them as separate entries.
+3. **Cascading failures need representation.** A single broken `User` schema
+   produces many `INVALID_DEPENDENCY_REF` issues. A throw model would surface
+   only the first; the manifest surfaces all of them as separate entries.
 
-4. **Recoverable warnings exist.** Missing `type` fields, unexpected
-   properties — these aren't errors but deserve recording. Throws
-   can't carry warnings; the manifest can.
+4. **Recoverable warnings exist.** Missing `type` fields, unexpected properties
+   — these aren't errors but deserve recording. Throws can't carry warnings; the
+   manifest can.
 
 ## Common questions
 
 ### What if my generator wants to fail loudly?
 
-Generators *can* throw — and the catch in `#runOasOperationGenerator`
-will convert the throw into a `result: 'error'` for that operation.
-That's the right path for "this operation is malformed and I can't
-produce sensible output."
+Generators _can_ throw — and the catch in `#runOasOperationGenerator` will
+convert the throw into a `result: 'error'` for that operation. That's the right
+path for "this operation is malformed and I can't produce sensible output."
 
-Whole-run failure (exit 1) is achieved by logging an `INVALID_SCHEMA`
-issue at parse time (which already happens for top-level parse
-errors). User-level "stop the world" controls aren't first-class —
-the model assumes partial output is always preferable to no output.
+Whole-run failure (exit 1) is achieved by logging an `INVALID_SCHEMA` issue at
+parse time (which already happens for top-level parse errors). User-level "stop
+the world" controls aren't first-class — the model assumes partial output is
+always preferable to no output.
 
 ### Why are warnings still mirrored to stderr instead of just the manifest?
 
-For developer ergonomics. Looking at the manifest after every run is
-overhead; seeing warnings flow past on stderr surfaces issues
-in-the-moment. The manifest is the canonical record; stderr is the
-human-readable preview.
+For developer ergonomics. Looking at the manifest after every run is overhead;
+seeing warnings flow past on stderr surfaces issues in-the-moment. The manifest
+is the canonical record; stderr is the human-readable preview.
 
 ### Can I filter out specific warnings?
 
-Not at the engine level. The leniency-strictness pairing is intentional
-— we want users to see what was inferred. If a warning is genuinely
-noise (e.g., your schema legitimately doesn't declare `type` for
-historical reasons), the right answer is to fix the source schema,
-not silence the warning.
+Not at the engine level. The leniency-strictness pairing is intentional — we
+want users to see what was inferred. If a warning is genuinely noise (e.g., your
+schema legitimately doesn't declare `type` for historical reasons), the right
+answer is to fix the source schema, not silence the warning.
 
 ### What if I want to abort generation on the first error?
 
-There's no `--strict-parse` flag. You can post-process the manifest:
-if `parseIssues.some(i => i.level === 'error')`, treat the run as
-failed and discard the partial output. CI flows often do this with a
-follow-up `jq` check after `skmtc generate`.
+There's no `--strict-parse` flag. You can post-process the manifest: if
+`parseIssues.some(i => i.level === 'error')`, treat the run as failed and
+discard the partial output. CI flows often do this with a follow-up `jq` check
+after `skmtc generate`.
 
 ### Does this philosophy apply to Generate phase errors too?
 
 Yes. Each `(generator, operation)` pair runs inside a try/catch in
-`#runOasOperationGenerator`. A generator throwing for one operation
-doesn't affect siblings. The manifest records the per-operation
-result.
+`#runOasOperationGenerator`. A generator throwing for one operation doesn't
+affect siblings. The manifest records the per-operation result.
 
-The Render phase is intentionally simpler — it's pure serialization
-of the file map produced by Generate. Errors at Render time
-typically indicate a structural bug (something is in `#files` that
-can't be stringified), which is a bug to fix rather than a
-recoverable diagnostic.
+The Render phase is intentionally simpler — it's pure serialization of the file
+map produced by Generate. Errors at Render time typically indicate a structural
+bug (something is in `#files` that can't be stringified), which is a bug to fix
+rather than a recoverable diagnostic.
 
 ## Further reading
 
 - [The three phases](the-three-phases.md) — where Parse-time errors get isolated
-- [Refs and resolution](refs-and-resolution.md) — how the ref-error cascade works
-- [The StackTrail](the-stack-trail.md) — the mutable position-stack that addresses, locates, and bridges to `$ref` strings
-- [The manifest](the-manifest.md) — the structured run record `parseIssues` lives in, plus the `results` tree and `previews` / `mappings`
-- [Manifest format reference](../reference/manifest-format.md) — the full Valibot schema
-- [Error codes reference](../reference/error-codes.md) — the full list of issue types
-- [`skmtc-debug` skill](../skills/skmtc-debug/SKILL.md) — operational diagnosis using the manifest
-- [Design philosophy: lenient input, strict diagnostics](../explanation/design-philosophy.md) — the broader rationale
+- [Refs and resolution](refs-and-resolution.md) — how the ref-error cascade
+  works
+- [The StackTrail](the-stack-trail.md) — the mutable position-stack that
+  addresses, locates, and bridges to `$ref` strings
+- [The manifest](the-manifest.md) — the structured run record `parseIssues`
+  lives in, plus the `results` tree and `previews` / `mappings`
+- [Manifest format reference](../reference/manifest-format.md) — the full
+  Valibot schema
+- [Error codes reference](../reference/error-codes.md) — the full list of issue
+  types
+- [`skmtc-debug` skill](../skills/skmtc-debug/SKILL.md) — operational diagnosis
+  using the manifest
+- [Design philosophy: lenient input, strict diagnostics](../explanation/design-philosophy.md)
+  — the broader rationale

--- a/deno/docs/concepts/multi-package-output.md
+++ b/deno/docs/concepts/multi-package-output.md
@@ -1,34 +1,33 @@
 # Multi-package output
 
 By default SKMTC writes every generated file under a single root —
-`client.json#settings.basePath` — and every cross-file import renders
-through one `@/…` alias. **Multi-package output** lets a project route
-generated files into *separate packages* of a monorepo (generated
-models in one package, generated server or UI code in others) with
-cross-package imports that resolve correctly.
+`client.json#settings.basePath` — and every cross-file import renders through
+one `@/…` alias. **Multi-package output** lets a project route generated files
+into _separate packages_ of a monorepo (generated models in one package,
+generated server or UI code in others) with cross-package imports that resolve
+correctly.
 
 The feature is `client.json#settings.packages`. It is first-class in
-`@skmtc/core` but easy to miss — without it an agent emits raw
-relative imports or assumes cross-package output isn't supported.
+`@skmtc/core` but easy to miss — without it an agent emits raw relative imports
+or assumes cross-package output isn't supported.
 
 ## `basePath` has two meanings
 
-`basePath` is the on-disk anchor for generated output. Its precise
-role depends on whether `packages` is set:
+`basePath` is the on-disk anchor for generated output. Its precise role depends
+on whether `packages` is set:
 
-- **Single-package** (no `packages`): `basePath` is the consumer
-  app's bundler `@` alias root — `@/foo` lands at `<basePath>/foo`,
-  and the app's bundler is configured so `@` resolves there.
-- **Multi-package** (`packages` set): `basePath` is purely *a common
-  on-disk ancestor of every package* — typically the monorepo root.
-  It is **not** a bundler alias; `@` is per-package (see below).
+- **Single-package** (no `packages`): `basePath` is the consumer app's bundler
+  `@` alias root — `@/foo` lands at `<basePath>/foo`, and the app's bundler is
+  configured so `@` resolves there.
+- **Multi-package** (`packages` set): `basePath` is purely _a common on-disk
+  ancestor of every package_ — typically the monorepo root. It is **not** a
+  bundler alias; `@` is per-package (see below).
 
 ## The `packages` setting
 
-Every package is a `{ rootPath, moduleName? }` entry. **`rootPath` is
-a forward path** — relative to `basePath`, with no `..` segments.
-Because `basePath` is a common ancestor, every package sits forward
-from it:
+Every package is a `{ rootPath, moduleName? }` entry. **`rootPath` is a forward
+path** — relative to `basePath`, with no `..` segments. Because `basePath` is a
+common ancestor, every package sits forward from it:
 
 ```jsonc
 {
@@ -37,71 +36,69 @@ from it:
     "basePath": "skmtc-hub",
     "packages": [
       { "rootPath": "packages/models/src", "moduleName": "@skmtc/models" },
-      { "rootPath": "apps/mock-server",     "moduleName": "@skmtc/mock-server" }
+      { "rootPath": "apps/mock-server", "moduleName": "@skmtc/mock-server" }
     ]
   }
 }
 ```
 
 `rootPath` is where that package's generated files live — on disk,
-`join(basePath, rootPath)`. `moduleName` is its npm/JSR package name,
-used when *other* packages import from it.
+`join(basePath, rootPath)`. `moduleName` is its npm/JSR package name, used when
+_other_ packages import from it.
 
-> **Forward paths only.** A `rootPath` (or `basePath`) containing a
-> `..` segment is **rejected at config load**. A `..` means `basePath`
-> was placed below some output location — lift `basePath` to a common
-> ancestor instead. Hand-counting `../` segments, and keeping that
-> count in lockstep across config fields, is exactly the
-> silent-misplacement footgun the forward-path rule removes.
+> **Forward paths only.** A `rootPath` (or `basePath`) containing a `..` segment
+> is **rejected at config load**. A `..` means `basePath` was placed below some
+> output location — lift `basePath` to a common ancestor instead. Hand-counting
+> `../` segments, and keeping that count in lockstep across config fields, is
+> exactly the silent-misplacement footgun the forward-path rule removes.
 
 ## How a file is routed
 
-Two resolutions — **where the file lands on disk** and **how an
-import to it renders**.
+Two resolutions — **where the file lands on disk** and **how an import to it
+renders**.
 
-**On disk.** `toResolvedArtifactPath` is `join(basePath, exportPath)`.
-A generator targeting a package returns a `toExportPath` that is a
-forward path under that package's `rootPath` (e.g.
-`packages/models/src/User.ts`); joined onto `basePath` it lands in
-the right place. No `..`.
+**On disk.** `toResolvedArtifactPath` is `join(basePath, exportPath)`. A
+generator targeting a package returns a `toExportPath` that is a forward path
+under that package's `rootPath` (e.g. `packages/models/src/User.ts`); joined
+onto `basePath` it lands in the right place. No `..`.
 
-**In imports.** `normalizeModuleName` (`dsl/File.ts`) resolves a
-cross-file import three ways:
+**In imports.** `normalizeModuleName` (`dsl/File.ts`) resolves a cross-file
+import three ways:
 
-- importer and target in the **same package** → intra-package
-  `@/…` (the target's `exportPath` with the package `rootPath`
-  replaced by `@`);
-- importer and target in **different packages** → the target
-  package's `moduleName`;
+- importer and target in the **same package** → intra-package `@/…` (the
+  target's `exportPath` with the package `rootPath` replaced by `@`);
+- importer and target in **different packages** → the target package's
+  `moduleName`;
 - **no package match** → the raw `exportPath`.
 
 So `@` is **per-package**, not a single global alias: a file under
-`packages/models/src` sees `@/` rooted at that package; a file in
-another package importing it gets `@skmtc/models`.
+`packages/models/src` sees `@/` rooted at that package; a file in another
+package importing it gets `@skmtc/models`.
 
 ## Barrels: a re-export-only file
 
-A package usually wants one entry point that re-exports everything it
-generated. A barrel does **not** need an accumulator class — it is
-simply a `File` populated only with re-exports:
+A package usually wants one entry point that re-exports everything it generated.
+A barrel does **not** need an accumulator class — it is a `File` populated only
+with re-exports:
 
 ```ts
 context.register({
   reExports: { [modelExportPath]: [settings.identifier] },
-  destinationPath: barrelPath
-})
+  destinationPath: barrelPath,
+});
 ```
 
-`reExports` is `Record<string, Identifier[]>` (module → identifiers);
-each identifier's entity type selects `export { x }` vs
-`export type { x }`. Multiple generators may `register` re-exports
-into the same `destinationPath` — the `File.reExports` map merges
-them. A `File` with only `reExports` (no `Definition`s) is a valid
-emitted artifact: there is no shared *value*, just a shared file
-accumulating re-export entries.
+`reExports` is `Record<string, Identifier[]>` (module → identifiers); each
+identifier's entity type selects `export { x }` vs `export type { x }`. Multiple
+generators may `register` re-exports into the same `destinationPath` — the
+`File.reExports` map merges them. A `File` with only `reExports` (no
+`Definition`s) is a valid emitted artifact: there is no shared _value_, just a
+shared file accumulating re-export entries.
 
 ## See also
 
-- [`projects-and-workspaces.md`](./projects-and-workspaces.md) — the single-`basePath` model
-- [`files-and-dedup.md`](./files-and-dedup.md) — the `File` model and import normalisation
+- [`projects-and-workspaces.md`](./projects-and-workspaces.md) — the
+  single-`basePath` model
+- [`files-and-dedup.md`](./files-and-dedup.md) — the `File` model and import
+  normalisation
 - `skmtc-cli` skill §6 — the `client.json` shape

--- a/deno/docs/concepts/projections-and-snippets.md
+++ b/deno/docs/concepts/projections-and-snippets.md
@@ -1,85 +1,83 @@
 # Projections and Snippets
 
-> The DSL's two-level model: named exportable artifacts (Projections)
-> and anonymous embedded fragments (Snippets). Both descend from
-> `SnippetBase`. The distinguishing question is whether the unit of
-> output needs a name at file scope.
+> The DSL's two-level model: named exportable artifacts (Projections) and
+> anonymous embedded fragments (Snippets). Both descend from `SnippetBase`. The
+> distinguishing question is whether the unit of output needs a name at file
+> scope.
 
-A Projection produces an `export const X = …` declaration. A Snippet
-produces a fragment that gets spliced into a Projection's body via
-template-literal interpolation. The split makes file-scope identity a
-deliberate choice, not a default.
+A Projection produces an `export const X = …` declaration. A Snippet produces a
+fragment that gets spliced into a Projection's body via template-literal
+interpolation. The split makes file-scope identity a deliberate choice, not a
+default.
 
 ## The one-line distinction
 
 A Projection has a name and a file. A Snippet has neither.
 
-Projections produce `export const NAME = VALUE;` (or
-`export type NAME = …;`) declarations. They're addressable, importable,
-and participate in cross-generator coordination through the
-`(name, exportPath)` cache. Snippets produce JSX elements, function
-bodies, type fragments, or any other stringifiable value that gets
-*embedded into* a Projection.
+Projections produce `export const NAME = VALUE;` (or `export type NAME = …;`)
+declarations. They're addressable, importable, and participate in
+cross-generator coordination through the `(name, exportPath)` cache. Snippets
+produce JSX elements, function bodies, type fragments, or any other
+stringifiable value that gets _embedded into_ a Projection.
 
 ## Why two levels?
 
-The split maps onto JSX components vs JSX expressions. Top-level
-React components have names, get imported by other modules, and exist
-in their own files. JSX expressions (`<Button onClick={...} />`) are
-anonymous and embedded in their parent's rendering. SKMTC's DSL makes
-the same cut.
+The split maps onto JSX components vs JSX expressions. Top-level React
+components have names, get imported by other modules, and exist in their own
+files. JSX expressions (`<Button onClick={...} />`) are anonymous and embedded
+in their parent's rendering. SKMTC's DSL makes the same cut.
 
-The alternative — a single "unit" abstraction — would force every
-snippet to have a name and a path, even ones that exist only as an
-inline `<StringField />` JSX element. That's overhead with no benefit
-to the cross-generator coordination story (which only needs file-scope
-items in its cache). The two-level split keeps the cache small and the
-authoring ergonomics natural.
+The alternative — a single "unit" abstraction — would force every snippet to
+have a name and a path, even ones that exist only as an inline `<StringField />`
+JSX element. That's overhead with no benefit to the cross-generator coordination
+story (which only needs file-scope items in its cache). The two-level split
+keeps the cache small and the authoring ergonomics natural.
 
 ## Projections
 
 The full-citizen class for unit-of-output:
 
-- Subclasses one of three projection bases:
-  `ModelProjectionBase`, `OasOperationProjectionBase`, or
-  `GqlOperationProjectionBase`
+- Subclasses one of three projection bases: `ModelProjectionBase`,
+  `OasOperationProjectionBase`, or `GqlOperationProjectionBase`
 - Has a class-level `id` (the generator package name)
 - Has static methods on the class: `toIdentifier`, `toExportPath`,
   `toEnrichments`, `toEnrichmentSchema`
-- Has instance properties: `settings: ContentSettings` (=
-  identifier + exportPath + enrichments), plus `context` and
-  `generatorKey`
+- Has instance properties: `settings: ContentSettings` (= identifier +
+  exportPath + enrichments), plus `context` and `generatorKey`
 - Has instance methods inherited from the base: `insertOperation`,
-  `insertModel`, `insertNormalizedModel` (these auto-fill
-  `destinationPath` from `this.settings.exportPath`)
+  `insertModel`, `insertNormalizedModel` (these auto-fill `destinationPath` from
+  `this.settings.exportPath`)
 
-Drivers wrap a Projection's output value in a `Definition`, which
-produces the `export const NAME = VALUE;` statement. The Projection's
-`toString()` produces just the VALUE; the wrapping is automatic.
+Drivers wrap a Projection's output value in a `Definition`, which produces the
+`export const NAME = VALUE;` statement. The Projection's `toString()` produces
+just the VALUE; the wrapping is automatic.
 
 ### Examples in stock generators
 
-- `ZodProjection` (`gen-zod`) — produces `export const userBody = z.object({...})`
+- `ZodProjection` (`gen-zod`) — produces
+  `export const userBody = z.object({...})`
 - `TsProjection` (`gen-typescript`) — produces `export type UserBody = { ... }`
-- `ShadcnForm` (`gen-shadcn-form`) — produces `export const CreateUserForm = (props) => ...`
-- `TanstackQuery` (`gen-tanstack-query-fetch-zod`) — produces `export const useCreateUser = (args) => ...`
+- `ShadcnForm` (`gen-shadcn-form`) — produces
+  `export const CreateUserForm = (props) => ...`
+- `TanstackQuery` (`gen-tanstack-query-fetch-zod`) — produces
+  `export const useCreateUser = (args) => ...`
 
-Each is a class that extends an operation or model projection base.
-Each has the static `toIdentifier` / `toExportPath` pair that makes
-it addressable in the cache.
+Each is a class that extends an operation or model projection base. Each has the
+static `toIdentifier` / `toExportPath` pair that makes it addressable in the
+cache.
 
 ### The three projection bases
 
-| Base | Source unit | When |
-|---|---|---|
-| `ModelProjectionBase` | An OAS schema component (a `refName`) | Generators that produce one file per type/schema |
-| `OasOperationProjectionBase` | An OAS operation (path + method) | Generators that produce one file per endpoint |
-| `GqlOperationProjectionBase` | A GraphQL operation | GraphQL-side generators |
+| Base                         | Source unit                           | When                                             |
+| ---------------------------- | ------------------------------------- | ------------------------------------------------ |
+| `ModelProjectionBase`        | An OAS schema component (a `refName`) | Generators that produce one file per type/schema |
+| `OasOperationProjectionBase` | An OAS operation (path + method)      | Generators that produce one file per endpoint    |
+| `GqlOperationProjectionBase` | A GraphQL operation                   | GraphQL-side generators                          |
 
 Each base provides the `insertOperation` / `insertModel` /
-`insertNormalizedModel` methods with `destinationPath` auto-filled
-from `this.settings.exportPath` — a convenience over calling the
-underlying methods on `context` directly.
+`insertNormalizedModel` methods with `destinationPath` auto-filled from
+`this.settings.exportPath` — a convenience over calling the underlying methods
+on `context` directly.
 
 ## Snippets
 
@@ -89,28 +87,27 @@ The anonymous fragment class:
   projection mechanics)
 - No required static methods
 - No `settings` property
-- Receives constructor arguments like `destinationPath` from the
-  parent that will embed it
-- Embedded into a parent via `${this.snippet}` template-literal
-  interpolation
-- The parent calls `toString()` on the snippet implicitly via the
-  template literal
+- Receives constructor arguments like `destinationPath` from the parent that
+  will embed it
+- Embedded into a parent via `${this.snippet}` template-literal interpolation
+- The parent calls `toString()` on the snippet implicitly via the template
+  literal
 
 ### Examples in stock generators
 
 - `FormFields` (`gen-shadcn-form`) — a list of field renderings inside a form
-- `StringInput`, `SelectInput`, `CheckboxInput`, etc. — individual JSX field elements
-- `CustomValue` — escape hatch wrapping arbitrary TS fragments that
-  don't fit the OAS-derived schema model
-- `Identifier` — a name with entity-type tracking (technically a
-  Snippet, though rarely thought of that way)
-- `Definition` — yes, even Definition is technically a Snippet (see
-  below)
+- `StringInput`, `SelectInput`, `CheckboxInput`, etc. — individual JSX field
+  elements
+- `CustomValue` — escape hatch wrapping arbitrary TS fragments that don't fit
+  the OAS-derived schema model
+- `Identifier` — a name with entity-type tracking (technically a Snippet, though
+  rarely thought of that way)
+- `Definition` — yes, even Definition is technically a Snippet (see below)
 
 ## How Definition bridges them
 
-`Definition` extends `SnippetBase` but plays a special bridging role:
-it's the wrapper that makes a Projection's value exportable.
+`Definition` extends `SnippetBase` but plays a special bridging role: it's the
+wrapper that makes a Projection's value exportable.
 
 ```
 Projection.toString()
@@ -121,26 +118,27 @@ File.toString()
        ↓ produces the complete file with imports + definitions
 ```
 
-So `Definition` is the bridge between "unit of output" (Projection)
-and "rendered TypeScript declaration." It's a Snippet in the sense
-that it extends `SnippetBase`, but its role is specifically
-projection-wrapping. You rarely construct one directly — Drivers do.
+So `Definition` is the bridge between "unit of output" (Projection) and
+"rendered TypeScript declaration." It's a Snippet in the sense that it extends
+`SnippetBase`, but its role is specifically projection-wrapping. You rarely
+construct one directly — Drivers do.
 
 ## The composition model
 
-JavaScript template literals call `String()` on interpolated values,
-which falls back to `.toString()`. Every `SnippetBase` descendant
-implements `toString()`, so they compose naturally:
+JavaScript template literals call `String()` on interpolated values, which falls
+back to `.toString()`. Every `SnippetBase` descendant implements `toString()`,
+so they compose naturally:
 
 ```ts
 class CreateUserForm extends ShadcnFormBase {
-  fields: FormFields              // ← a Snippet
-  clientName: string
+  fields: FormFields; // ← a Snippet
+  clientName: string;
 
   constructor(args) {
-    super(args)
-    this.fields = new FormFields(args)
-    this.clientName = this.insertOperation(TanstackQuery, args.operation).toName()
+    super(args);
+    this.fields = new FormFields(args);
+    this.clientName = this.insertOperation(TanstackQuery, args.operation)
+      .toName();
   }
 
   override toString() {
@@ -155,34 +153,33 @@ class CreateUserForm extends ShadcnFormBase {
           </form>
         </Form>
       )
-    }`
+    }`;
   }
 }
 ```
 
-The interpolation pattern is the entire composition mechanism. No
-registry, no slot system, no callback API. Anything that has a
-`toString()` (which is everything that extends `SnippetBase`) can be
-embedded.
+The interpolation pattern is the entire composition mechanism. No registry, no
+slot system, no callback API. Anything that has a `toString()` (which is
+everything that extends `SnippetBase`) can be embedded.
 
 ## When to use which
 
 - **Other generators might reference it by name** → Projection
 - **It needs a file-scope export (`export const X = ...`)** → Projection
 - **It's a fragment inside another generator's output** → Snippet
-- **Unsure** → Probably Snippet. Promote to Projection only when
-  cross-file identity is needed.
+- **Unsure** → Probably Snippet. Promote to Projection only when cross-file
+  identity is needed.
 
-The cost asymmetry: turning a Snippet into a Projection later is
-simple (subclass a base, add static methods). Turning a Projection
-into a Snippet is also simple but removes it from the cross-generator
-coordination cache. Default to Snippet unless you have a reason.
+The cost asymmetry: turning a Snippet into a Projection later is simple
+(subclass a base, add static methods). Turning a Projection into a Snippet is
+also simple but removes it from the cross-generator coordination cache. Default
+to Snippet unless you have a reason.
 
 ## Choosing the right primitive — mechanical traps to avoid
 
-Three shapes that look reasonable but break the framework's invariants
-in specific ways. Each has the same root: reaching for an ad-hoc
-construction when a Projection or `SnippetBase` descendant fits.
+Three shapes that look reasonable but break the framework's invariants in
+specific ways. Each has the same root: reaching for an ad-hoc construction when
+a Projection or `SnippetBase` descendant fits.
 
 ### File-scope export via a Snippet + `defineAndRegister`
 
@@ -190,29 +187,33 @@ construction when a Projection or `SnippetBase` descendant fits.
 // ❌ A supplemental file-scope type, registered as a sibling Definition
 // in the parent's exportPath, wrapping a Snippet instead of a Projection
 class FormValuesSnippet extends SnippetBase {
-  override toString() { return `{ firstName: string; email: string }` }
+  override toString() {
+    return `{ firstName: string; email: string }`;
+  }
 }
 
 context.defineAndRegister({
   identifier: createType(`${name}Values`),
   value: new FormValuesSnippet({ context }),
-  destinationPath: settings.exportPath
-})
+  destinationPath: settings.exportPath,
+});
 ```
 
-This *does* land an `export type CreateCustomerFormValues = {...}` line
-in the File. It also fails on three framework guarantees:
+This _does_ land an `export type CreateCustomerFormValues = {...}` line in the
+File. It also fails on three framework guarantees:
 
-| Guarantee | Why it fails |
-|---|---|
+| Guarantee                                                                          | Why it fails                                                                                                                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Cache-key identity is `(Producer.toIdentifier(op), Producer.toExportPath(op))`** | A Snippet has no static `toIdentifier` / `toExportPath`. The Definition is keyed by whatever name string the caller built. `context.findDefinition({ name, exportPath })` works only for callers who know the exact name string — there's no Producer class to drive the lookup. |
-| **`insertOperation(Producer, op)` requires a Projection class as the first arg** | There is no class to pass. The Definition is unreachable through the operation-reference protocol; future generators that want this same type must re-derive the name string at their own call site. |
-| **Rename safety** | The identifier name lives at the caller (`${name}Values`). Renaming the convention means editing every caller plus every consumer reading by that name. A Projection's `toIdentifier` is one site. |
+| **`insertOperation(Producer, op)` requires a Projection class as the first arg**   | There is no class to pass. The Definition is unreachable through the operation-reference protocol; future generators that want this same type must re-derive the name string at their own call site.                                                                             |
+| **Rename safety**                                                                  | The identifier name lives at the caller (`${name}Values`). Renaming the convention means editing every caller plus every consumer reading by that name. A Projection's `toIdentifier` is one site.                                                                               |
 
-Fix: extend the appropriate projection base. `class FormValuesType
+Fix: extend the appropriate projection base.
+`class FormValuesType
 extends MyFormBase { static override toIdentifier(...) {...} override
-toString() {...} }`, then `insertOperation(FormValuesType, op)`. The
-mechanics now match the rest of cross-generator composition.
+toString() {...} }`,
+then `insertOperation(FormValuesType, op)`. The mechanics now match the rest of
+cross-generator composition.
 
 ### Ad-hoc `{ toString: () => '…' }` returned from a helper function
 
@@ -220,19 +221,18 @@ mechanics now match the rest of cross-generator composition.
 // ❌ A helper that returns a duck-typed Stringable
 const renderRow = (cols: number, inner: string) => ({
   toString: () =>
-    `<div className="grid gap-4 sm:grid-cols-${cols}">${inner}</div>`
-})
+    `<div className="grid gap-4 sm:grid-cols-${cols}">${inner}</div>`,
+});
 ```
 
 This satisfies `Stringable` structurally and renders correctly when
-interpolated. It also lacks every framework affordance a real Snippet
-provides:
+interpolated. It also lacks every framework affordance a real Snippet provides:
 
-| Affordance | Why it fails |
-|---|---|
-| **`context` access (and therefore `register({ imports, destinationPath })`)** | The object has no `context`. If the markup ever needs to import a peer component (a UI library `<Row>`, a hand-written helper), the import has to bubble up to whichever caller has `context` — coupling the caller to the helper's internals. |
-| **`generatorKey`** | The integrity machinery (`affirmDefinition`, `findDefinition`'s mismatch detection) operates on values carrying a `generatorKey`. The duck-typed object has none, so it's invisible to the integrity layer if it ever ends up wrapped in a Definition. |
-| **`instanceof SnippetBase`** | Generic code that operates on "SnippetBase or its descendants" can't treat the duck-typed object as a member of the family. |
+| Affordance                                                                    | Why it fails                                                                                                                                                                                                                                           |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`context` access (and therefore `register({ imports, destinationPath })`)** | The object has no `context`. If the markup ever needs to import a peer component (a UI library `<Row>`, a hand-written helper), the import has to bubble up to whichever caller has `context` — coupling the caller to the helper's internals.         |
+| **`generatorKey`**                                                            | The integrity machinery (`affirmDefinition`, `findDefinition`'s mismatch detection) operates on values carrying a `generatorKey`. The duck-typed object has none, so it's invisible to the integrity layer if it ever ends up wrapped in a Definition. |
+| **`instanceof SnippetBase`**                                                  | Generic code that operates on "SnippetBase or its descendants" can't treat the duck-typed object as a member of the family.                                                                                                                            |
 
 Fix: a real `SnippetBase` descendant with its `register` calls in the
 constructor.
@@ -240,25 +240,23 @@ constructor.
 ```ts
 class FormRow extends SnippetBase {
   constructor({ context, cols, inner, destinationPath }) {
-    super({ context })
-    this.cols = cols
-    this.inner = inner
+    super({ context });
+    this.cols = cols;
+    this.inner = inner;
     // any imports the markup needs go here
   }
   override toString() {
-    return `<div className="grid gap-4 sm:grid-cols-${this.cols}">${this.inner}</div>`
+    return `<div className="grid gap-4 sm:grid-cols-${this.cols}">${this.inner}</div>`;
   }
 }
 ```
 
-Same line count once the class is written; every framework guarantee
-restored.
+Same line count once the class is written; every framework guarantee restored.
 
 ### Snippet over-parameterized with sole-caller hardcoded values
 
-This one is *not* about the Projection-vs-Snippet choice — the Snippet
-is the right primitive, but its constructor signature is wider than
-necessary:
+This one is _not_ about the Projection-vs-Snippet choice — the Snippet is the
+right primitive, but its constructor signature is wider than necessary:
 
 ```ts
 // ❌ Five constructor args; four are hardcoded by the sole caller
@@ -273,123 +271,123 @@ class FormFooter extends SnippetBase {
 }
 ```
 
-Mechanically: every parameter that all callers pass identically still
-gets typed in the signature, passed at every call site, closed over by
-the constructor, and read by `toString()`. The cost is in the type
-surface and the call-site verbosity — not in framework invariants.
+Mechanically: every parameter that all callers pass identically still gets typed
+in the signature, passed at every call site, closed over by the constructor, and
+read by `toString()`. The cost is in the type surface and the call-site
+verbosity — not in framework invariants.
 
-Diagnostic question per parameter: *would a hypothetical second caller
-pass a different value here?* If no → inline the value in the Snippet,
-remove the parameter.
+Diagnostic question per parameter: _would a hypothetical second caller pass a
+different value here?_ If no → inline the value in the Snippet, remove the
+parameter.
 
-This is adjacent to the two anti-patterns above (each is about
-reaching for the wrong shape) but the failure mode is API-design
-debt, not framework breakage. Listed here because the same triage
-question — "is this the right shape?" — catches all three.
+This is adjacent to the two anti-patterns above (each is about reaching for the
+wrong shape) but the failure mode is API-design debt, not framework breakage.
+Listed here because the same triage question — "is this the right shape?" —
+catches all three.
 
 ## Snippets need destinationPath passed in
 
-Because Snippets don't have their own `exportPath`, they can't
-register imports against their own file — they need to know where
-their parent is going to land. The convention: the parent passes
-`destinationPath` as a constructor argument.
+Because Snippets don't have their own `exportPath`, they can't register imports
+against their own file — they need to know where their parent is going to land.
+The convention: the parent passes `destinationPath` as a constructor argument.
 
 ```ts
 class StringInput extends SnippetBase {
   constructor({ context, name, destinationPath }) {
-    super({ context })
-    this.name = name
+    super({ context });
+    this.name = name;
 
     // Register against the parent's destination file
     this.register({
-      imports: { '@/components/fields/string-field': ['StringField'] },
-      destinationPath
-    })
+      imports: { "@/components/fields/string-field": ["StringField"] },
+      destinationPath,
+    });
   }
 
   override toString() {
-    return `<StringField name="${this.name}" />`
+    return `<StringField name="${this.name}" />`;
   }
 }
 ```
 
-The parent Projection has its own `exportPath` from
-`this.settings.exportPath`, so it doesn't need this dance. Snippets
-nested inside a Projection (or another Snippet) follow the chain —
-each parent passes `destinationPath` down to its children.
+The parent Projection has its own `exportPath` from `this.settings.exportPath`,
+so it doesn't need this dance. Snippets nested inside a Projection (or another
+Snippet) follow the chain — each parent passes `destinationPath` down to its
+children.
 
-This is the "side-effect on context with explicit destination"
-pattern: Snippets register their imports immediately during
-construction, before the parent's `toString()` even runs. By the time
-`File.toString()` assembles the final output, all imports across all
-nested Snippets have already accumulated in the file's import map.
+This is the "side-effect on context with explicit destination" pattern: Snippets
+register their imports immediately during construction, before the parent's
+`toString()` even runs. By the time `File.toString()` assembles the final
+output, all imports across all nested Snippets have already accumulated in the
+file's import map.
 
 ## Common questions
 
 ### Can a Snippet reach other generators?
 
 Indirectly. A Snippet inside a Projection can call
-`this.context.insertOperation(...)` or
-`this.context.insertNormalizedModel(...)` directly (Snippets don't
-have the projection-base wrappers, so they use the methods on
-`context`). The returned `Inserted<V, E>` gives access to the peer's
+`this.context.insertOperation(...)` or `this.context.insertNormalizedModel(...)`
+directly (Snippets don't have the projection-base wrappers, so they use the
+methods on `context`). The returned `Inserted<V, E>` gives access to the peer's
 identifier name just like in a Projection.
 
-That said: most cross-generator coordination *happens* in Projection
-constructors, where the projection-base wrappers auto-fill
-`destinationPath`. Snippets that compose generators are unusual but
-not forbidden.
+That said: most cross-generator coordination _happens_ in Projection
+constructors, where the projection-base wrappers auto-fill `destinationPath`.
+Snippets that compose generators are unusual but not forbidden.
 
 ### Why isn't `register` on Projections only?
 
-`register` is defined on `SnippetBase` because both layers need it.
-Snippets register imports for themselves (against the parent's
-file). Projections register imports and definitions for their target
-file. The same primitive serves both — only `destinationPath` differs.
+`register` is defined on `SnippetBase` because both layers need it. Snippets
+register imports for themselves (against the parent's file). Projections
+register imports and definitions for their target file. The same primitive
+serves both — only `destinationPath` differs.
 
 ### Is `Definition` really a Snippet?
 
-By inheritance, yes. By role, no — it's a bridging wrapper that
-Drivers create automatically. The fact that `Definition extends
-SnippetBase` is more of a technical detail than a conceptual claim.
-In practice, you compose Projections (which become Definitions via
-Drivers) with anonymous Snippets, and you never touch `Definition`
-directly.
+By inheritance, yes. By role, no — it's a bridging wrapper that Drivers create
+automatically. The fact that `Definition extends
+SnippetBase` is more of a
+technical detail than a conceptual claim. In practice, you compose Projections
+(which become Definitions via Drivers) with anonymous Snippets, and you never
+touch `Definition` directly.
 
 ### Can I have multiple Projections in one file?
 
 Yes. Each Projection has its own `Definition`; the `File` holds a
-`Map<name, Definition>`. Multiple Projections targeting the same
-`exportPath` simply add their entries to the same File's
-`definitions` map. The file's `toString()` joins them with blank
-lines.
+`Map<name, Definition>`. Multiple Projections targeting the same `exportPath`
+add their entries to the same File's `definitions` map. The file's `toString()`
+joins them with blank lines.
 
 ### What if I want a named export but not a full Projection?
 
-Use `register({ definitions: [new TsDefinition({...})] })` directly.
-This is the escape hatch — you produce a Definition without going
-through a Projection base. The trade-off: no cross-generator
-coordination (no cache, no integrity check) for that definition.
+Use `register({ definitions: [new TsDefinition({...})] })` directly. This is the
+escape hatch — you produce a Definition without going through a Projection base.
+The trade-off: no cross-generator coordination (no cache, no integrity check)
+for that definition.
 
-Useful when producing boilerplate that doesn't need to be addressable
-from other generators (e.g., a constants table, a default-values
-object).
+Useful when producing boilerplate that doesn't need to be addressable from other
+generators (e.g., a constants table, a default-values object).
 
 ### Can a Snippet contain another Snippet?
 
-Yes — composition is unlimited depth. A `FormFields` snippet contains
-multiple `StringInput` / `SelectInput` snippets. Each child Snippet
-embeds itself via `${this.fields}` in the parent's `toString()`.
-Imports propagate up via shared `destinationPath`; the file's import
-map accumulates contributions from every nested snippet.
+Yes — composition is unlimited depth. A `FormFields` snippet contains multiple
+`StringInput` / `SelectInput` snippets. Each child Snippet embeds itself via
+`${this.fields}` in the parent's `toString()`. Imports propagate up via shared
+`destinationPath`; the file's import map accumulates contributions from every
+nested snippet.
 
 ## Further reading
 
-- [How generators produce output](how-generators-produce-output.md) — who instantiates Projections and when; the pull-based model
-- [Composing output with Stringable](stringable-composition.md) — how Projection and Snippet `toString()` methods compose into rendered output
-- [Cross-generator coordination](cross-generator-coordination.md) — how Projections find each other
-- [The three phases](the-three-phases.md) — where Projections and Snippets fit in Parse / Generate / Render
+- [How generators produce output](how-generators-produce-output.md) — who
+  instantiates Projections and when; the pull-based model
+- [Composing output with Stringable](stringable-composition.md) — how Projection
+  and Snippet `toString()` methods compose into rendered output
+- [Cross-generator coordination](cross-generator-coordination.md) — how
+  Projections find each other
+- [The three phases](the-three-phases.md) — where Projections and Snippets fit
+  in Parse / Generate / Render
 - [API reference: projection-bases](../reference/api/projection-bases.md)
 - [API reference: dsl-snippet-base](../reference/api/dsl-snippet-base.md)
 - [API reference: dsl-definition](../reference/api/dsl-definition.md)
-- [`skmtc-generator` skill](../skills/skmtc-generator/SKILL.md) — operational guidance for authoring
+- [`skmtc-generator` skill](../skills/skmtc-generator/SKILL.md) — operational
+  guidance for authoring

--- a/deno/docs/concepts/the-three-phases.md
+++ b/deno/docs/concepts/the-three-phases.md
@@ -1,8 +1,13 @@
 # The three phases
 
-A SKMTC generation run is a pipeline. The interesting work happens in three sequential phases — **Parse**, **Generate**, and **Render** — each producing an immutable artifact that the next consumes.
+A SKMTC generation run is a pipeline. The interesting work happens in three
+sequential phases — **Parse**, **Generate**, and **Render** — each producing an
+immutable artifact that the next consumes.
 
-This document explains what each phase does, why the boundaries are drawn where they are, and what invariants depend on the separation. It's organized for understanding, not lookup; for the API surface of each phase see [the reference docs](../reference/api/).
+This document explains what each phase does, why the boundaries are drawn where
+they are, and what invariants depend on the separation. It's organized for
+understanding, not lookup; for the API surface of each phase see
+[the reference docs](../reference/api/).
 
 ## The shape of the pipeline
 
@@ -14,7 +19,11 @@ Schema input ──▶  PARSE  ──▶  GENERATE  ──▶  RENDER  ──▶
               + issues      (in-memory) strings
 ```
 
-Each arrow is a one-way data hand-off. By the time a phase finishes, its output is locked in — the next phase reads it but can't change it. This is structural: each phase has its own context class (`ParseContext`, `GenerateContext`, `RenderContext`) that holds the in-progress state, and the hand-off to the next phase is a method call that produces an output value.
+Each arrow is a one-way data hand-off. By the time a phase finishes, its output
+is locked in — the next phase reads it but can't change it. This is structural:
+each phase has its own context class (`ParseContext`, `GenerateContext`,
+`RenderContext`) that holds the in-progress state, and the hand-off to the next
+phase is a method call that produces an output value.
 
 ```ts
 // core/run/toArtifacts.ts (sketch)
@@ -28,64 +37,106 @@ const renderContext = new RenderContext({ files, ... })
 const { artifacts } = renderContext.render(stackTrail)
 ```
 
-The phases share a `StackTrail` (for location tracking in diagnostics) and a `Logger`. Everything else flows phase-to-phase as an explicit return value.
+The phases share a `StackTrail` (for location tracking in diagnostics) and a
+`Logger`. Everything else flows phase-to-phase as an explicit return value.
 
 ## Why three phases?
 
-You could imagine fewer or more. Single-phase ("everything in one pass") is what most simple codegen tools do. Two-phase ("parse and render") is the next step up. Three-phase is where SKMTC settles, and the reasons are concrete:
+You could imagine fewer or more. Single-phase ("everything in one pass") is what
+most simple codegen tools do. Two-phase ("parse and render") is the next step
+up. Three-phase is where SKMTC settles, and the reasons are concrete:
 
-**Parse is separate because** the parse-time error model is fundamentally different from generate-time. Parsing tolerates partial failure (one bad schema doesn't kill the run; it produces a `ParseIssue` and prunes downstream consumers). Generate is permitted to assume everything in `parsedDocument` is valid. Combining the two would force every generator to defensively handle malformed schemas.
+**Parse is separate because** the parse-time error model is fundamentally
+different from generate-time. Parsing tolerates partial failure (one bad schema
+doesn't kill the run; it produces a `ParseIssue` and prunes downstream
+consumers). Generate is permitted to assume everything in `parsedDocument` is
+valid. Combining the two would force every generator to defensively handle
+malformed schemas.
 
-**Generate is separate from Render because** cross-generator coordination needs a settled model of "what files exist and what's in them" before serialization. Two generators may both contribute imports to the same file; the order of contributions doesn't affect output, but only because Render runs after both are done. If Render were interleaved with Generate, generator A's output would already be a string by the time generator B tried to add an import to the same file.
+**Generate is separate from Render because** cross-generator coordination needs
+a settled model of "what files exist and what's in them" before serialization.
+Two generators may both contribute imports to the same file; the order of
+contributions doesn't affect output, but only because Render runs after both are
+done. If Render were interleaved with Generate, generator A's output would
+already be a string by the time generator B tried to add an import to the same
+file.
 
-**Render is separate from Persist because** the in-memory artifact map is the boundary with the host process. Inside the Worker, Render produces `Record<path, content>`. The Worker then `postMessage`s this back to the host, which writes to disk. The host doesn't have a notion of `File` or `Definition`; it sees only `{ path, content }`. That clean boundary is what lets the host be permission-unconstrained while the Worker is sandboxed.
+**Render is separate from Persist because** the in-memory artifact map is the
+boundary with the host process. Inside the Worker, Render produces
+`Record<path, content>`. The Worker then `postMessage`s this back to the host,
+which writes to disk. The host doesn't have a notion of `File` or `Definition`;
+it sees only `{ path, content }`. That clean boundary is what lets the host be
+permission-unconstrained while the Worker is sandboxed.
 
 ## Phase 1: Parse
 
-**Purpose:** Convert raw schema input into a typed, navigable internal model that downstream phases can rely on.
+**Purpose:** Convert raw schema input into a typed, navigable internal model
+that downstream phases can rely on.
 
-**Input:** `SkmtcDocumentInput` — a discriminated union, either `{ type: 'oas', value: OpenAPIV3.Document }` or `{ type: 'gql', value: GraphQLSchema | string }`.
+**Input:** `SkmtcDocumentInput` — a discriminated union, either
+`{ type: 'oas', value: OpenAPIV3.Document }` or
+`{ type: 'gql', value: GraphQLSchema | string }`.
 
-**Output:** `SkmtcParsedDocument` (`{ type: 'oas', value: OasDocument }` or `{ type: 'gql', value: GqlDocument }`), plus a populated `ParseContext.issues` array.
+**Output:** `SkmtcParsedDocument` (`{ type: 'oas', value: OasDocument }` or
+`{ type: 'gql', value: GqlDocument }`), plus a populated `ParseContext.issues`
+array.
 
-**Where it runs:** Inside the Worker. (The host *does* run a pre-parse step for OAS — see [the worker runtime concept](the-worker-runtime.md) for why — but the protocol-specific parse always happens worker-side.)
+**Where it runs:** Inside the Worker. (The host _does_ run a pre-parse step for
+OAS — see [the worker runtime concept](the-worker-runtime.md) for why — but the
+protocol-specific parse always happens worker-side.)
 
 ### Mechanism
 
-The walk is recursive descent. `core/oas/document/toDocumentFieldsV3.ts` destructures the OAS document and traces each top-level field (`info`, `paths`, `components`, …) into a child parser. Each child parser does the same for its sub-fields. The accumulated location is carried in a `StackTrail`:
+The walk is recursive descent. `core/oas/document/toDocumentFieldsV3.ts`
+destructures the OAS document and traces each top-level field (`info`, `paths`,
+`components`, …) into a child parser. Each child parser does the same for its
+sub-fields. The accumulated location is carried in a `StackTrail`:
 
 ```ts
-operations: stackTrail.trace('paths', st =>
-  toOperationsV3({ paths, stackTrail: st, context })
-)
+operations: stackTrail.trace(
+  "paths",
+  (st) => toOperationsV3({ paths, stackTrail: st, context }),
+);
 ```
 
-Every `trace(key, fn)` pushes `key` onto the trail before calling `fn`, and pops it after. So an error at `paths['/users']['post'].requestBody.content['application/json'].schema.properties.email` has a precise location string in its `ParseIssue` without any individual parser explicitly threading path information.
+Every `trace(key, fn)` pushes `key` onto the trail before calling `fn`, and pops
+it after. So an error at
+`paths['/users']['post'].requestBody.content['application/json'].schema.properties.email`
+has a precise location string in its `ParseIssue` without any individual parser
+explicitly threading path information.
 
 ### Two-tier error isolation
 
-Parse uses two complementary mechanisms to ensure one bad item doesn't kill the run.
+Parse uses two complementary mechanisms to ensure one bad item doesn't kill the
+run.
 
-**Tier 1 — per-item isolation via `tryParseAt`.** Every per-item parser is wrapped:
+**Tier 1 — per-item isolation via `tryParseAt`.** Every per-item parser is
+wrapped:
 
 ```ts
 // core/oas/schema/toSchemasV3.ts
 for (const [key, schema] of entries) {
   const value = tryParseAt({
-    stackTrail, key, context,
-    type: 'INVALID_SCHEMA',
+    stackTrail,
+    key,
+    context,
+    type: "INVALID_SCHEMA",
     parent: schema,
-    fn: st => toSchemaV3({ schema, stackTrail: st, context })
-  })
+    fn: (st) => toSchemaV3({ schema, stackTrail: st, context }),
+  });
   if (value !== undefined) {
-    output[key] = value     // bad entries silently omitted
+    output[key] = value; // bad entries silently omitted
   }
 }
 ```
 
-A throw inside `toSchemaV3` becomes a `level: 'error'` `ParseIssue`, and the key is simply skipped in the output map.
+A throw inside `toSchemaV3` becomes a `level: 'error'` `ParseIssue`, and the key
+is skipped in the output map.
 
-**Tier 2 — cascade pruning via `removeErroredItems`.** During the walk, every `$ref` consumer is recorded in `ParseContext.#refConsumers`. When a parse error happens at a component position, the error is recorded in `ParseContext.#refErrors` keyed by the same ref. After the walk finishes:
+**Tier 2 — cascade pruning via `removeErroredItems`.** During the walk, every
+`$ref` consumer is recorded in `ParseContext.#refConsumers`. When a parse error
+happens at a component position, the error is recorded in
+`ParseContext.#refErrors` keyed by the same ref. After the walk finishes:
 
 ```ts
 for (const [refKey, errors] of this.#refErrors) {
@@ -107,48 +158,72 @@ for (const [refKey, errors] of this.#refErrors) {
 }
 ```
 
-So if `User` fails to parse and `Operation X` referenced `User`, `Operation X` is removed from `oasDocument.operations` with an `INVALID_DEPENDENCY_REF` issue. The downstream Generate phase sees a smaller document with all surviving items guaranteed valid.
+So if `User` fails to parse and `Operation X` referenced `User`, `Operation X`
+is removed from `oasDocument.operations` with an `INVALID_DEPENDENCY_REF` issue.
+The downstream Generate phase sees a smaller document with all surviving items
+guaranteed valid.
 
-The cascade is one hop deep by current design — transitive pruning of consumers-of-pruned-consumers is a known limitation, partially mitigated by the fact that `resolve()` on a now-missing ref will throw at generate time, which `#runOasOperationGenerator` catches as a per-operation error.
+The cascade is one hop deep by current design — transitive pruning of
+consumers-of-pruned-consumers is a known limitation, partially mitigated by the
+fact that `resolve()` on a now-missing ref will throw at generate time, which
+`#runOasOperationGenerator` catches as a per-operation error.
 
 ### Type-inference fallbacks
 
-`toSchemaV3` (`core/oas/schema/toSchemasV3.ts:75-252`) dispatches on `schema.type`. But OAS documents in the wild often omit `type` for object-shaped schemas. Rather than failing, SKMTC infers:
+`toSchemaV3` (`core/oas/schema/toSchemasV3.ts:75-252`) dispatches on
+`schema.type`. But OAS documents in the wild often omit `type` for object-shaped
+schemas. Rather than failing, SKMTC infers:
 
-- Has `properties` → assume `type: 'object'`, log a `MISSING_OBJECT_TYPE` warning.
+- Has `properties` → assume `type: 'object'`, log a `MISSING_OBJECT_TYPE`
+  warning.
 - Has `items` → assume `type: 'array'`, log a `MISSING_ARRAY_TYPE` warning.
-- Has a string-shaped `enum` or recognized string `format` → assume `type: 'string'`, log a `MISSING_STRING_TYPE` warning.
-- Otherwise → fall through to `toUnknown`, which produces an `OasUnknown` schema.
+- Has a string-shaped `enum` or recognized string `format` → assume
+  `type: 'string'`, log a `MISSING_STRING_TYPE` warning.
+- Otherwise → fall through to `toUnknown`, which produces an `OasUnknown`
+  schema.
 
-"Be lenient on input, strict on diagnostics" — incorrect schemas produce code anyway, but every assumption shows up in the issue log.
+"Be lenient on input, strict on diagnostics" — incorrect schemas produce code
+anyway, but every assumption shows up in the issue log.
 
 ### Forward-reference handling
 
-A `$ref` may point at a definition that hasn't been parsed yet. SKMTC handles this without a two-pass scheme by giving each `OasRef` a live reference to the in-progress document:
+A `$ref` may point at a definition that hasn't been parsed yet. SKMTC handles
+this without a two-pass scheme by giving each `OasRef` a live reference to the
+in-progress document:
 
 ```ts
 // core/oas/ref/toRefV31.ts
-context.registerRef(stackTrail.clone(), $ref)
-return new OasRef({ refType, $ref }, context.parsedDocument)
+context.registerRef(stackTrail.clone(), $ref);
+return new OasRef({ refType, $ref }, context.parsedDocument);
 ```
 
-`context.parsedDocument` returns a `SkmtcParsedDocument` wrapping the *same mutable* `OasDocument` instance that the rest of the parse is filling in. The `OasRef`'s `.resolve()` looks up its target at call time. Resolution succeeds as long as the target has been populated by the time anyone resolves — which is always true after parse completes.
+`context.parsedDocument` returns a `SkmtcParsedDocument` wrapping the _same
+mutable_ `OasDocument` instance that the rest of the parse is filling in. The
+`OasRef`'s `.resolve()` looks up its target at call time. Resolution succeeds as
+long as the target has been populated by the time anyone resolves — which is
+always true after parse completes.
 
 ### Output guarantees
 
 By the time `parse()` returns:
 
-- Every item in the output `OasDocument` (or `GqlDocument`) parsed without throwing.
-- Every item that depended on a failed schema has been pruned, with an issue logged.
+- Every item in the output `OasDocument` (or `GqlDocument`) parsed without
+  throwing.
+- Every item that depended on a failed schema has been pruned, with an issue
+  logged.
 - `ParseContext.issues` contains the full diagnostic record.
 
-The Generate phase can iterate `oasDocument.operations` and trust every operation; it doesn't need defensive checks for "what if the request body schema is malformed."
+The Generate phase can iterate `oasDocument.operations` and trust every
+operation; it doesn't need defensive checks for "what if the request body schema
+is malformed."
 
 ## Phase 2: Generate
 
-**Purpose:** Walk the parsed document with the configured generators, producing an in-memory map of files-to-render.
+**Purpose:** Walk the parsed document with the configured generators, producing
+an in-memory map of files-to-render.
 
-**Input:** `SkmtcParsedDocument`, `ClientSettings`, `toGeneratorConfigMap()` (provides the registered generators).
+**Input:** `SkmtcParsedDocument`, `ClientSettings`, `toGeneratorConfigMap()`
+(provides the registered generators).
 
 **Output:** `{ files: Map<path, File | JsonFile>, previews, mappings }`.
 
@@ -156,7 +231,9 @@ The Generate phase can iterate `oasDocument.operations` and trust every operatio
 
 ### The outer loop
 
-`GenerateContext.toArtifacts` (`core/context/GenerateContext.ts:275`) iterates the configured generators. For each generator, it applies filter checks, then dispatches by generator type:
+`GenerateContext.toArtifacts` (`core/context/GenerateContext.ts:275`) iterates
+the configured generators. For each generator, it applies filter checks, then
+dispatches by generator type:
 
 ```ts
 generators.forEach(generatorConfig => {
@@ -173,107 +250,158 @@ generators.forEach(generatorConfig => {
 })
 ```
 
-Inside each `#run*Generator`, the per-item loop iterates operations or refNames, applies item-level filters, calls the generator's `isSupported({ operation })` capability gate, then calls `generatorConfig.transform({ context, operation, acc })`. The transform is where the generator produces its output — but not by returning strings (its return value is discarded). Instead, the transform calls `context.insertOperation(MyProjection, op)` or `context.insertNormalizedModel(MyProjection, args)`, which delegate to Drivers.
+Inside each `#run*Generator`, the per-item loop iterates operations or refNames,
+applies item-level filters, calls the generator's `isSupported({ operation })`
+capability gate, then calls
+`generatorConfig.transform({ context, operation, acc })`. The transform is where
+the generator produces its output — but not by returning strings (its return
+value is discarded). Instead, the transform calls
+`context.insertOperation(MyProjection, op)` or
+`context.insertNormalizedModel(MyProjection, args)`, which delegate to Drivers.
 
 ### The Driver lifecycle
 
 When `transform` calls `context.insertOperation(TanstackQuery, operation)`:
 
-1. `new OasOperationDriver(...)` runs (`core/dsl/operation/oas/OasOperationDriver.ts`).
-2. Driver computes `settings = context.toOperationContentSettings({ projection, operation })`, which calls the Projection's static `toIdentifier`, `toExportPath`, and `toEnrichments`.
-3. Driver looks up `context.findDefinition({ name: settings.identifier.name, exportPath: settings.exportPath })`.
-4. **Cache hit + `affirmDefinition` passes:** Driver returns the cached `Definition`. No work done.
-5. **Cache hit + `generatorKey` mismatch:** Driver throws `Registered definition mismatch`. Loud failure.
-6. **Cache miss:** Driver instantiates `new projection({ context, operation, settings })`. The Projection's *constructor* runs — which may call `register({ imports, ... })`, `insertNormalizedModel(...)`, or even `insertOperation(...)` recursively for further dependencies. After the constructor returns, Driver wraps the value in a `Definition` and registers it via `context.register({ definitions: [definition], destinationPath: settings.exportPath })`.
-7. If the calling file differs from `settings.exportPath` (e.g., a form file is asking for a hook in a services file), Driver also registers an import stitch into the calling file via `context.register({ imports, destinationPath })`.
+1. `new OasOperationDriver(...)` runs
+   (`core/dsl/operation/oas/OasOperationDriver.ts`).
+2. Driver computes
+   `settings = context.toOperationContentSettings({ projection, operation })`,
+   which calls the Projection's static `toIdentifier`, `toExportPath`, and
+   `toEnrichments`.
+3. Driver looks up
+   `context.findDefinition({ name: settings.identifier.name, exportPath: settings.exportPath })`.
+4. **Cache hit + `affirmDefinition` passes:** Driver returns the cached
+   `Definition`. No work done.
+5. **Cache hit + `generatorKey` mismatch:** Driver throws
+   `Registered definition mismatch`. Loud failure.
+6. **Cache miss:** Driver instantiates
+   `new projection({ context, operation, settings })`. The Projection's
+   _constructor_ runs — which may call `register({ imports, ... })`,
+   `insertNormalizedModel(...)`, or even `insertOperation(...)` recursively for
+   further dependencies. After the constructor returns, Driver wraps the value
+   in a `Definition` and registers it via
+   `context.register({ definitions: [definition], destinationPath: settings.exportPath })`.
+7. If the calling file differs from `settings.exportPath` (e.g., a form file is
+   asking for a hook in a services file), Driver also registers an import stitch
+   into the calling file via `context.register({ imports, destinationPath })`.
 
 ### Why order doesn't matter
 
-This is the single most important property of the Generate phase. Two facts combine to make it work:
+This is the single most important property of the Generate phase. Two facts
+combine to make it work:
 
-1. `toIdentifier` and `toExportPath` are *pure functions* of `(operation, enrichments)`. Same inputs → same outputs.
+1. `toIdentifier` and `toExportPath` are _pure functions_ of
+   `(operation, enrichments)`. Same inputs → same outputs.
 2. The cache key is `(identifier.name, exportPath)`.
 
-So whichever generator's `transform` runs first for a given `(projection, operation)` pair triggers the construction. Later generators that depend on the same projection (e.g., a form depending on a mutation hook) get a cache hit. The output `#files` map is identical regardless of which order the outer loop happens to visit generators in.
+So whichever generator's `transform` runs first for a given
+`(projection, operation)` pair triggers the construction. Later generators that
+depend on the same projection (e.g., a form depending on a mutation hook) get a
+cache hit. The output `#files` map is identical regardless of which order the
+outer loop happens to visit generators in.
 
-This is what underlies "generators run in any order" — it's a structural property, not a feature you have to maintain.
+This is what underlies "generators run in any order" — it's a structural
+property, not a feature you have to maintain.
 
 ### Output structure
 
 `context.#files: Map<string, File | JsonFile>`. Each `File` contains:
 
-- `imports: Map<module, Set<importName>>` — populated by `register({ imports })`. The `Set` is what dedupes.
-- `reExports: Map<module, { [entityType]: Set<name> }>` — populated by `register({ reExports })`.
-- `definitions: Map<name, Definition>` — populated by `register({ definitions })`. First-write-wins.
+- `imports: Map<module, Set<importName>>` — populated by
+  `register({ imports })`. The `Set` is what dedupes.
+- `reExports: Map<module, { [entityType]: Set<name> }>` — populated by
+  `register({ reExports })`.
+- `definitions: Map<name, Definition>` — populated by
+  `register({ definitions })`. First-write-wins.
 
-The `JsonFile` variant is used when the path ends in `.json`; instead of definitions, it holds a JSON value.
+The `JsonFile` variant is used when the path ends in `.json`; instead of
+definitions, it holds a JSON value.
 
-By the time Generate finishes, every file's contents are fully determined. The map is what's handed to Render.
+By the time Generate finishes, every file's contents are fully determined. The
+map is what's handed to Render.
 
 ## Phase 3: Render
 
-**Purpose:** Serialize the files map to a `Record<path, content>` artifacts payload.
+**Purpose:** Serialize the files map to a `Record<path, content>` artifacts
+payload.
 
 **Input:** `Map<string, File | JsonFile>` from Generate.
 
-**Output:** `{ artifacts: Record<path, string>, files: Record<path, metadata> }`.
+**Output:**
+`{ artifacts: Record<path, string>, files: Record<path, metadata> }`.
 
 **Where it runs:** Inside the Worker.
 
 ### Mechanism
 
-`RenderContext.collate` (`core/context/RenderContext.ts:185`) iterates the files map and calls `file.toString()` on each:
+`RenderContext.collate` (`core/context/RenderContext.ts:185`) iterates the files
+map and calls `file.toString()` on each:
 
 ```ts
 const fileObjects: FileObject[] = fileEntries.map(([destinationPath, file]) => {
-  return stackTrail.trace(destinationPath, st => {
+  return stackTrail.trace(destinationPath, (st) => {
     return renderFile({
       content: file.toString(),
       destinationPath,
-      basePath: this.basePath
-    })
-  })
-})
+      basePath: this.basePath,
+    });
+  });
+});
 ```
 
 `File.toString()` (`core/dsl/File.ts:181`) joins three sections:
 
 ```ts
 return [reExports, imports, definitions]
-  .filter(section => Boolean(section.length))
-  .map(section => section.join('\n'))
-  .join('\n\n')
+  .filter((section) => Boolean(section.length))
+  .map((section) => section.join("\n"))
+  .join("\n\n");
 ```
 
-That's the entire transformation. Imports get assembled from the `Map<module, Set<name>>`. Definitions get stringified via their own `toString()` (which produces `export const X = VALUE;` via the `Definition` wrapper). The sections are joined with blank lines. No formatting, no analysis, no transformation.
+That's the entire transformation. Imports get assembled from the
+`Map<module, Set<name>>`. Definitions get stringified via their own `toString()`
+(which produces `export const X = VALUE;` via the `Definition` wrapper). The
+sections are joined with blank lines. No formatting, no analysis, no
+transformation.
 
-### What Render does *not* do
+### What Render does _not_ do
 
-Render does not format. `renderFile` takes the `content` produced by `file.toString()` and returns it unmodified:
+Render does not format. `renderFile` takes the `content` produced by
+`file.toString()` and returns it unmodified:
 
 ```ts
-const renderFile = ({ content, destinationPath, basePath }: RenderFileArgs): FileObject => {
-  const path = toResolvedArtifactPath({ basePath, destinationPath })
+const renderFile = (
+  { content, destinationPath, basePath }: RenderFileArgs,
+): FileObject => {
+  const path = toResolvedArtifactPath({ basePath, destinationPath });
   return {
-    content: content,        // ← raw, no formatting
+    content: content, // ← raw, no formatting
     path,
     destinationPath,
-    lines: content.split('\n').length,
-    characters: content.length
-  }
-}
+    lines: content.split("\n").length,
+    characters: content.length,
+  };
+};
 ```
 
-A `grep` for `prettier.format` across `@skmtc/core` returns zero hits. No formatter — Prettier, Biome, `deno fmt`, or otherwise — runs inside the pipeline. **Generated output is unformatted.** Consumers run their own formatter as a separate step (typically a pre-commit hook or build script).
+A `grep` for `prettier.format` across `@skmtc/core` returns zero hits. No
+formatter — Prettier, Biome, `deno fmt`, or otherwise — runs inside the
+pipeline. **Generated output is unformatted.** Consumers run their own formatter
+as a separate step (typically a pre-commit hook or build script).
 
-This is a deliberate architectural choice, not an omission: formatting is the consumer's concern. Generators produce syntactically valid TypeScript and trust the consumer's toolchain to handle aesthetics.
+This is a deliberate architectural choice, not an omission: formatting is the
+consumer's concern. Generators produce syntactically valid TypeScript and trust
+the consumer's toolchain to handle aesthetics.
 
 ### Output structure
 
 `{ artifacts, files }` where:
 
-- `artifacts: Record<resolvedPath, content>` — the actual file contents keyed by their resolved disk path (with `basePath` applied).
-- `files: Record<resolvedPath, { destinationPath, lines, characters }>` — metadata used by the manifest.
+- `artifacts: Record<resolvedPath, content>` — the actual file contents keyed by
+  their resolved disk path (with `basePath` applied).
+- `files: Record<resolvedPath, { destinationPath, lines, characters }>` —
+  metadata used by the manifest.
 
 This is what the Worker `postMessage`s back to the host.
 
@@ -281,51 +409,96 @@ This is what the Worker `postMessage`s back to the host.
 
 The three-phase model encodes several invariants that other code relies on:
 
-1. **Parse output is immutable to Generate.** Generate doesn't add or remove items from `oasDocument`; it only reads. If you needed to add a synthetic operation, you'd have to do it during parse, not generate.
+1. **Parse output is immutable to Generate.** Generate doesn't add or remove
+   items from `oasDocument`; it only reads. If you needed to add a synthetic
+   operation, you'd have to do it during parse, not generate.
 
-2. **Generate output is fully determined before Render.** Render is pure serialization; if a definition isn't in `#files` by the end of Generate, it won't appear in output. There's no "Render-time hook" for adding content.
+2. **Generate output is fully determined before Render.** Render is pure
+   serialization; if a definition isn't in `#files` by the end of Generate, it
+   won't appear in output. There's no "Render-time hook" for adding content.
 
-3. **The Worker boundary aligns with the parse-safety boundary.** OAS gets converted to v3 host-side (so the clone-safe JSON crosses cleanly), then parsed worker-side. GraphQL SDL stays a string until inside the worker. The asymmetry is forced by `structuredClone`'s inability to handle class instances with cyclic back-references.
+3. **The Worker boundary aligns with the parse-safety boundary.** OAS gets
+   converted to v3 host-side (so the clone-safe JSON crosses cleanly), then
+   parsed worker-side. GraphQL SDL stays a string until inside the worker. The
+   asymmetry is forced by `structuredClone`'s inability to handle class
+   instances with cyclic back-references.
 
-4. **The Worker boundary is also the security boundary.** Generators run sandboxed (no network, no subprocess). The host handles disk I/O outside the sandbox. The three-phase model maps cleanly onto this: parse and generate (in the worker) trust nothing from the host; persist (on the host) trusts only the artifact paths and contents that the worker returned.
+4. **The Worker boundary is also the security boundary.** Generators run
+   sandboxed (no network, no subprocess). The host handles disk I/O outside the
+   sandbox. The three-phase model maps cleanly onto this: parse and generate (in
+   the worker) trust nothing from the host; persist (on the host) trusts only
+   the artifact paths and contents that the worker returned.
 
 ## Common questions
 
 **Can a generator run before Parse finishes?**
 
-No. Generate operates on `SkmtcParsedDocument`, which only exists after Parse completes. The two phases are strictly sequential.
+No. Generate operates on `SkmtcParsedDocument`, which only exists after Parse
+completes. The two phases are strictly sequential.
 
 **Can generators see each other's output during Generate?**
 
-Yes — through the cache. When Generator A calls `insertOperation(BProjection, op)`, the Driver instantiates `B` (if not cached) and returns an `Inserted<...>` carrying the identifier name. A can use that name in its own template. A cannot read B's *body* (`toString()` output), but it doesn't need to — coordination is by name, not by content.
+Yes — through the cache. When Generator A calls
+`insertOperation(BProjection, op)`, the Driver instantiates `B` (if not cached)
+and returns an `Inserted<...>` carrying the identifier name. A can use that name
+in its own template. A cannot read B's _body_ (`toString()` output), but it
+doesn't need to — coordination is by name, not by content.
 
 **Can Render call back into Generate?**
 
-No. Render is a one-way serialization. If your generator needs to know something about other generators' output, it must happen during Generate via the cross-generator coordination mechanism, not in Render.
+No. Render is a one-way serialization. If your generator needs to know something
+about other generators' output, it must happen during Generate via the
+cross-generator coordination mechanism, not in Render.
 
 **Why is OAS converted before the worker but GraphQL isn't?**
 
-`structuredClone` (which the Worker `postMessage` uses) can serialize plain JSON but not class instances with cyclic references. A converted `OpenAPIV3.Document` is plain JSON — clone-safe. A parsed `GqlDocument` has class instances with back-references — clone-unsafe. So OAS gets converted (a JSON-preserving step) host-side, but GraphQL parsing happens worker-side. See [the GraphQL asymmetry](../explanation/the-graphql-asymmetry.md).
+`structuredClone` (which the Worker `postMessage` uses) can serialize plain JSON
+but not class instances with cyclic references. A converted `OpenAPIV3.Document`
+is plain JSON — clone-safe. A parsed `GqlDocument` has class instances with
+back-references — clone-unsafe. So OAS gets converted (a JSON-preserving step)
+host-side, but GraphQL parsing happens worker-side. See
+[the GraphQL asymmetry](../explanation/the-graphql-asymmetry.md).
 
 **What happens if I throw in a generator's `transform`?**
 
-`#runOasOperationGenerator` (`core/context/GenerateContext.ts:417-432`) catches it, logs an error, and marks the operation as `'error'` in the manifest. The rest of the run continues. Errors are scoped to one (generator × operation) pair.
+`#runOasOperationGenerator` (`core/context/GenerateContext.ts:417-432`) catches
+it, logs an error, and marks the operation as `'error'` in the manifest. The
+rest of the run continues. Errors are scoped to one (generator × operation)
+pair.
 
-**What happens if I throw in a Projection's *constructor*?**
+**What happens if I throw in a Projection's _constructor_?**
 
-The throw propagates up through the Driver, then up through `insertOperation` in the calling generator's `transform`. The catch in `#runOasOperationGenerator` handles it. So a constructor failure becomes an operation-level error in the same way a transform-level failure does.
+The throw propagates up through the Driver, then up through `insertOperation` in
+the calling generator's `transform`. The catch in `#runOasOperationGenerator`
+handles it. So a constructor failure becomes an operation-level error in the
+same way a transform-level failure does.
 
 **Can two generators write to the same file?**
 
-Yes — this is the common case. The form generator and the Tanstack Query generator both write definitions into different files, but they also both write imports into each other's files (when forms reference hooks). The `Set`-based deduplication in `register({ imports })` handles same-module collisions; the `Map.has` gate in `register({ definitions })` enforces first-write-wins. Same-name collisions from different generators throw via `affirmDefinition` on the Driver path.
+Yes — this is the common case. The form generator and the Tanstack Query
+generator both write definitions into different files, but they also both write
+imports into each other's files (when forms reference hooks). The `Set`-based
+deduplication in `register({ imports })` handles same-module collisions; the
+`Map.has` gate in `register({ definitions })` enforces first-write-wins.
+Same-name collisions from different generators throw via `affirmDefinition` on
+the Driver path.
 
 ## Further reading
 
-- [How generators produce output](how-generators-produce-output.md) — `GenerateContext.toArtifacts`'s iteration loop and the pull-based Projection model.
-- [Files, deduplication, and integrity](files-and-dedup.md) — what Drivers register into, and the `generatorKey` integrity check on top.
-- [The Worker runtime](the-worker-runtime.md) — what happens at the worker boundary.
-- [Cross-generator coordination](cross-generator-coordination.md) — the cache mechanism in depth.
-- [Error handling philosophy](error-handling-philosophy.md) — the manifest as canonical run record.
-- [`reference/api/parse-context.md`](../reference/api/parse-context.md) — Parse API surface.
-- [`reference/api/generate-context.md`](../reference/api/generate-context.md) — Generate API surface.
-- [`reference/api/render-context.md`](../reference/api/render-context.md) — Render API surface.
+- [How generators produce output](how-generators-produce-output.md) —
+  `GenerateContext.toArtifacts`'s iteration loop and the pull-based Projection
+  model.
+- [Files, deduplication, and integrity](files-and-dedup.md) — what Drivers
+  register into, and the `generatorKey` integrity check on top.
+- [The Worker runtime](the-worker-runtime.md) — what happens at the worker
+  boundary.
+- [Cross-generator coordination](cross-generator-coordination.md) — the cache
+  mechanism in depth.
+- [Error handling philosophy](error-handling-philosophy.md) — the manifest as
+  canonical run record.
+- [`reference/api/parse-context.md`](../reference/api/parse-context.md) — Parse
+  API surface.
+- [`reference/api/generate-context.md`](../reference/api/generate-context.md) —
+  Generate API surface.
+- [`reference/api/render-context.md`](../reference/api/render-context.md) —
+  Render API surface.

--- a/deno/docs/evals/.gitignore
+++ b/deno/docs/evals/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/deno/docs/evals/calibrate.ts
+++ b/deno/docs/evals/calibrate.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env -S deno run -A
+/**
+ * Grader calibration — every grader kind must produce the correct
+ * verdict on one known-good and one known-bad case before its task's
+ * numbers are trusted (plan decision 5).
+ *
+ * Mechanical kinds are exercised against a synthetic sandbox; the
+ * llm-judge kind makes two live judge calls (haiku, ~$0.01).
+ *
+ * Usage: deno run -A calibrate.ts [--skip-judge]
+ * Exit 0 = all verdicts correct.
+ */
+
+import { parseArgs } from 'jsr:@std/cli@^1/parse-args'
+import { join } from 'jsr:@std/path@^1'
+import { runGraders, type GraderSpec } from './graders.ts'
+
+const flags = parseArgs(Deno.args, { boolean: ['skip-judge'] })
+
+const sandbox = await Deno.makeTempDir({ prefix: 'skmtc-eval-calibration-' })
+await Deno.writeTextFile(join(sandbox, 'present.txt'), 'the codeword is ZEPHYR-42\n')
+
+type Case = {
+  name: string
+  spec: GraderSpec
+  finalMessage: string
+  expectPass: boolean
+}
+
+const mechanicalCases: Case[] = [
+  {
+    name: 'file-exists / present',
+    spec: { kind: 'file-exists', path: 'present.txt' },
+    finalMessage: '',
+    expectPass: true
+  },
+  {
+    name: 'file-exists / absent',
+    spec: { kind: 'file-exists', path: 'absent.txt' },
+    finalMessage: '',
+    expectPass: false
+  },
+  {
+    name: 'file-contains / matching',
+    spec: { kind: 'file-contains', path: 'present.txt', pattern: 'ZEPHYR-42' },
+    finalMessage: '',
+    expectPass: true
+  },
+  {
+    name: 'file-contains / non-matching',
+    spec: { kind: 'file-contains', path: 'present.txt', pattern: 'WRONG-99' },
+    finalMessage: '',
+    expectPass: false
+  },
+  {
+    name: 'run-command / exit 0',
+    spec: { kind: 'run-command', cmd: 'true' },
+    finalMessage: '',
+    expectPass: true
+  },
+  {
+    name: 'run-command / exit 1',
+    spec: { kind: 'run-command', cmd: 'false' },
+    finalMessage: '',
+    expectPass: false
+  }
+]
+
+const judgeRubric =
+  'Pass only if the answer states that the root cause is a stale bundle ' +
+  '(bundle.js not rebuilt after the generator source changed).'
+
+const judgeCases: Case[] = [
+  {
+    name: 'llm-judge / correct diagnosis',
+    spec: { kind: 'llm-judge', rubric: judgeRubric },
+    finalMessage:
+      'The generator output was stale because bundle.js was not rebuilt after ' +
+      'the source edit — the stale bundle kept serving the old generator. ' +
+      'Running `skmtc bundle` fixed it.',
+    expectPass: true
+  },
+  {
+    name: 'llm-judge / wrong diagnosis',
+    spec: { kind: 'llm-judge', rubric: judgeRubric },
+    finalMessage:
+      'The output was missing because the OpenAPI schema had a broken $ref, ' +
+      'so the parser dropped the model.',
+    expectPass: false
+  }
+]
+
+const cases = flags['skip-judge'] ? mechanicalCases : [...mechanicalCases, ...judgeCases]
+
+let failures = 0
+
+for (const testCase of cases) {
+  const [result] = await runGraders({
+    specs: [testCase.spec],
+    sandbox,
+    finalMessage: testCase.finalMessage,
+    judgeModel: 'haiku'
+  })
+
+  const correct = result.pass === testCase.expectPass
+  console.log(
+    `${correct ? 'ok  ' : 'FAIL'}  ${testCase.name} → ${result.pass ? 'pass' : 'fail'} (${result.detail})`
+  )
+  if (!correct) failures++
+}
+
+await Deno.remove(sandbox, { recursive: true })
+
+if (failures > 0) {
+  console.error(`\n${failures} calibration case(s) wrong`)
+  Deno.exit(1)
+}
+console.log('\nall grader verdicts correct')

--- a/deno/docs/evals/fixtures/author-model-generator/setup.ts
+++ b/deno/docs/evals/fixtures/author-model-generator/setup.ts
@@ -1,0 +1,98 @@
+/** Fixture: an initialized, empty SKMTC project + a small OpenAPI
+ * schema. The eval agent must author a local model generator from
+ * scratch (the docs under test describe the wiring and the DSL).
+ *
+ * The environment facts the agent cannot derive from docs — which
+ * registry versions are mutually consistent — are stated in the task
+ * prompt (core 0.23.2 / lang-typescript 0.12.8; see the plan's
+ * "Environment discoveries" for why).
+ *
+ * Requires: skmtc on PATH (the harness provides the sandbox shim).
+ */
+
+import { join } from 'jsr:@std/path@^1'
+
+const sandbox = Deno.args[0]
+if (!sandbox) {
+  console.error('usage: deno run -A setup.ts <sandboxDir>')
+  Deno.exit(2)
+}
+
+const run = async (cmd: string, args: string[]): Promise<string> => {
+  const output = await new Deno.Command(cmd, {
+    args,
+    cwd: sandbox,
+    stdout: 'piped',
+    stderr: 'piped'
+  }).output()
+  const stdout = new TextDecoder().decode(output.stdout)
+  if (!output.success) {
+    throw new Error(
+      `${cmd} ${args.join(' ')} exited ${output.code}: ${new TextDecoder().decode(output.stderr)} ${stdout}`
+    )
+  }
+  return stdout
+}
+
+const schema = {
+  openapi: '3.0.3',
+  info: { title: 'Petstore Lite', version: '1.0.0' },
+  paths: {
+    '/pets': {
+      get: {
+        operationId: 'listPets',
+        responses: {
+          '200': {
+            description: 'A list of pets',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      Pet: {
+        type: 'object',
+        required: ['id', 'name'],
+        properties: {
+          id: { type: 'integer', format: 'int64' },
+          name: { type: 'string' },
+          tag: { type: 'string' }
+        }
+      },
+      Order: {
+        type: 'object',
+        required: ['id', 'petId', 'quantity'],
+        properties: {
+          id: { type: 'integer', format: 'int64' },
+          petId: { type: 'integer', format: 'int64' },
+          quantity: { type: 'integer' }
+        }
+      }
+    }
+  }
+}
+
+await Deno.writeTextFile(join(sandbox, 'schema.json'), JSON.stringify(schema, null, 2))
+
+await run('skmtc', ['init', 'lab', 'app/src', '--json'])
+
+// Pin the schema source so `skmtc generate lab` needs no positional.
+const clientJsonPath = join(sandbox, '.skmtc', 'lab', '.settings', 'client.json')
+const clientJson: unknown = JSON.parse(await Deno.readTextFile(clientJsonPath))
+if (typeof clientJson !== 'object' || clientJson === null || Array.isArray(clientJson)) {
+  throw new Error('client.json did not parse to an object')
+}
+const clientRecord: Record<string, unknown> = { ...clientJson }
+clientRecord.source = join(sandbox, 'schema.json')
+await Deno.writeTextFile(clientJsonPath, JSON.stringify(clientRecord, null, 2))
+
+console.log('fixture ready: empty project initialized, schema pinned')

--- a/deno/docs/evals/fixtures/diagnose-skipped-output/setup.ts
+++ b/deno/docs/evals/fixtures/diagnose-skipped-output/setup.ts
@@ -1,0 +1,217 @@
+/** Fixture: a working SKMTC project where `client.json#settings.skip`
+ * silences @skmtc/gen-typescript — `generate` succeeds but emits no
+ * type files.
+ *
+ * The generator is VENDORED from the workspace source
+ * (skmtc-generators/gen-typescript) as a local generator rather than
+ * installed from a registry: as of 2026-07-05 no registry serves a
+ * version-consistent gen-typescript install (jsr.io's is ancient,
+ * the mirror's pins a stale core → dual-core-copy → silently empty
+ * artifacts; see the plan's "Environment discoveries"). The vendored
+ * source pins core 0.24.0 + lang-typescript 0.12.9, which unify with
+ * the jsr.io worker 0.3.44 pin — a single core copy.
+ *
+ * Self-verification: proves the HEALTHY state first (generate emits
+ * non-empty types), then plants the fault and proves the BROKEN
+ * state (generate exits 0, no output). A fixture that only plants
+ * the fault could hand the agent an unsolvable environment.
+ *
+ * Requires: skmtc on PATH resolving against jsr.io (run with JSR_URL
+ * unset — the harness strips it), deno, and the skmtc-generators
+ * checkout as a sibling of the skmtc repo.
+ */
+
+import { dirname, fromFileUrl, join } from 'jsr:@std/path@^1'
+import { copy } from 'jsr:@std/fs@^1'
+
+const sandbox = Deno.args[0]
+if (!sandbox) {
+  console.error('usage: deno run -A setup.ts <sandboxDir>')
+  Deno.exit(2)
+}
+
+const fixtureDir = dirname(fromFileUrl(import.meta.url))
+const workspaceRoot = join(fixtureDir, '..', '..', '..', '..', '..', '..')
+const genTypescriptSource = join(workspaceRoot, 'skmtc-generators', 'gen-typescript')
+
+try {
+  await Deno.stat(join(genTypescriptSource, 'deno.json'))
+} catch {
+  console.error(`gen-typescript source not found at ${genTypescriptSource}`)
+  Deno.exit(2)
+}
+
+const run = async (cmd: string, args: string[]): Promise<string> => {
+  const output = await new Deno.Command(cmd, {
+    args,
+    cwd: sandbox,
+    stdout: 'piped',
+    stderr: 'piped'
+  }).output()
+  const stdout = new TextDecoder().decode(output.stdout)
+  if (!output.success) {
+    throw new Error(
+      `${cmd} ${args.join(' ')} exited ${output.code}: ${new TextDecoder().decode(output.stderr)} ${stdout}`
+    )
+  }
+  return stdout
+}
+
+const schema = {
+  openapi: '3.0.3',
+  info: { title: 'Petstore Lite', version: '1.0.0' },
+  paths: {
+    '/pets': {
+      get: {
+        operationId: 'listPets',
+        responses: {
+          '200': {
+            description: 'A list of pets',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      Pet: {
+        type: 'object',
+        required: ['id', 'name'],
+        properties: {
+          id: { type: 'integer', format: 'int64' },
+          name: { type: 'string' },
+          tag: { type: 'string' },
+          status: { type: 'string', enum: ['available', 'pending', 'sold'] }
+        }
+      },
+      Order: {
+        type: 'object',
+        required: ['id', 'petId', 'quantity'],
+        properties: {
+          id: { type: 'integer', format: 'int64' },
+          petId: { type: 'integer', format: 'int64' },
+          quantity: { type: 'integer' },
+          shipDate: { type: 'string', format: 'date-time' }
+        }
+      }
+    }
+  }
+}
+
+await Deno.writeTextFile(join(sandbox, 'schema.json'), JSON.stringify(schema, null, 2))
+
+await run('skmtc', ['init', 'lab', 'app/src', '--json'])
+
+// Vendor the generator as a local workspace member (the CLI discovers
+// it via the gen-* import key in the project deno.json).
+const projectDir = join(sandbox, '.skmtc', 'lab')
+await copy(genTypescriptSource, join(projectDir, 'gen-typescript'), { overwrite: true })
+
+// Rewrite the member's imports for the sandbox world:
+// 1. Pin the bare specifiers its source imports (@std/path,
+//    ts-pattern) — in skmtc-generators the ROOT deno.json supplies
+//    them; standalone, the member must.
+// 2. Re-pin core + lang-typescript to the mirror-consistent line
+//    (core 0.23.2 — what the sandbox CLI's worker pin and
+//    lang-typescript 0.12.8 both resolve to), so the runtime holds a
+//    SINGLE core copy. The source's own pins (core 0.24.0) belong to
+//    the jsr.io line, which deno bundle currently can't load from.
+const genDenoJsonPath = join(projectDir, 'gen-typescript', 'deno.json')
+const genDenoJson: unknown = JSON.parse(await Deno.readTextFile(genDenoJsonPath))
+if (typeof genDenoJson !== 'object' || genDenoJson === null || Array.isArray(genDenoJson)) {
+  throw new Error('gen-typescript deno.json did not parse to an object')
+}
+const genRecord: Record<string, unknown> = { ...genDenoJson }
+const genImports = genRecord.imports
+genRecord.imports = {
+  ...(typeof genImports === 'object' && genImports !== null ? genImports : {}),
+  '@skmtc/core': 'jsr:@skmtc/core@0.23.2',
+  '@skmtc/lang-typescript': 'jsr:@skmtc/lang-typescript@0.12.8',
+  '@std/path': 'jsr:@std/path@^1.1.2',
+  'ts-pattern': 'npm:ts-pattern@^5.8.0'
+}
+await Deno.writeTextFile(genDenoJsonPath, JSON.stringify(genRecord, null, 2))
+
+const projectDenoJsonPath = join(projectDir, 'deno.json')
+const projectDenoJson: unknown = JSON.parse(await Deno.readTextFile(projectDenoJsonPath))
+if (
+  typeof projectDenoJson !== 'object' ||
+  projectDenoJson === null ||
+  Array.isArray(projectDenoJson)
+) {
+  throw new Error('project deno.json did not parse to an object')
+}
+const projectRecord: Record<string, unknown> = { ...projectDenoJson }
+const existingImports = projectRecord.imports
+projectRecord.imports = {
+  ...(typeof existingImports === 'object' && existingImports !== null ? existingImports : {}),
+  '@skmtc/gen-typescript': './gen-typescript/mod.ts'
+}
+projectRecord.workspace = ['./gen-typescript']
+await Deno.writeTextFile(projectDenoJsonPath, JSON.stringify(projectRecord, null, 2))
+
+// bundle regenerates worker.ts from the imports and adds the
+// @skmtc/core + @skmtc/worker pins at the CLI's own versions.
+await run('skmtc', ['bundle', 'lab', '--json'])
+
+// Pin the schema source.
+const clientJsonPath = join(projectDir, '.settings', 'client.json')
+const readClientJson = async (): Promise<Record<string, unknown>> => {
+  const parsed: unknown = JSON.parse(await Deno.readTextFile(clientJsonPath))
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('client.json did not parse to an object')
+  }
+  return { ...parsed }
+}
+const readSettings = (clientRecord: Record<string, unknown>): Record<string, unknown> => {
+  const settings = clientRecord.settings
+  if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) {
+    throw new Error('client.json#settings is not an object')
+  }
+  return { ...settings }
+}
+
+const healthyClient = await readClientJson()
+healthyClient.source = join(sandbox, 'schema.json')
+await Deno.writeTextFile(clientJsonPath, JSON.stringify(healthyClient, null, 2))
+
+// Prove the HEALTHY state: generate emits a non-empty Pet type.
+await run('skmtc', ['generate', 'lab', '--json'])
+const petPath = join(sandbox, 'app', 'src', 'types', 'pet.generated.ts')
+const petContent = await Deno.readTextFile(petPath)
+if (!petContent.includes('Pet')) {
+  throw new Error(`fixture invalid: healthy generate produced unusable output: '${petContent.slice(0, 120)}'`)
+}
+
+// Plant the fault and reset the output tree.
+// NOTE: a subtler include-allow-list fault (refName that matches
+// nothing) was tried and does NOT take on this stack — core 0.23.2
+// predates per-model include enforcement, so the entry is ignored
+// and output still generates. Until the registries converge on a
+// current core, the fault is a bare whole-generator `skip`, which
+// the no-docs control also solves — this task currently validates
+// harness plumbing more than docs quality (see checklist).
+const brokenClient = await readClientJson()
+brokenClient.settings = { ...readSettings(brokenClient), skip: ['@skmtc/gen-typescript'] }
+await Deno.writeTextFile(clientJsonPath, JSON.stringify(brokenClient, null, 2))
+
+await run('skmtc', ['clean', 'lab', '--json'])
+await run('skmtc', ['generate', 'lab', '--json'])
+
+// Prove the BROKEN state: generate succeeded, no output.
+try {
+  await Deno.stat(join(sandbox, 'app', 'src', 'types'))
+  throw new Error('fixture invalid: app/src/types exists — the skip filter did not take')
+} catch (error) {
+  if (!(error instanceof Deno.errors.NotFound)) throw error
+}
+
+console.log('fixture ready: healthy state proven, fault planted, broken state proven')

--- a/deno/docs/evals/fixtures/rewrite-flawed-page/setup.ts
+++ b/deno/docs/evals/fixtures/rewrite-flawed-page/setup.ts
@@ -1,0 +1,216 @@
+/** Fixture: a small working Deno CLI (tool/export.ts) plus a
+ * deliberately flawed how-to page (guides/export-data.md) documenting
+ * it. Exercises the docs-writing skill — especially §1.1 verify-first:
+ * the page's central fault is FACTUAL drift only visible by checking
+ * the source or running the tool.
+ *
+ * Planted faults, keyed to the docs-writing checklist (§14):
+ *   - documents a `--force` flag that doesn't exist (real: --overwrite)
+ *   - wrong defaults (claims out/ + csv; real: dist/ + json)      §1.1
+ *   - opens with project history instead of the task; no prereqs  §1.3
+ *   - design-rationale digression mid-guide (type mixing)         §3
+ *   - filler (simply/just/easily), "please", anthropomorphism,
+ *     time-bound words (currently/new/will)                       §4
+ *   - multi-action steps, no expected results, no completing
+ *     action                                                      §5
+ *   - "click here" link, "as mentioned above", skipped heading
+ *     level (H2 → H4)                                             §6
+ *   - three names for one thing (export file / output bundle /
+ *     artifact)                                                   §4
+ *
+ * Self-verification: proves the tool's REAL behavior first (help
+ * text, default dist/export.json, --overwrite gating), resets the
+ * output, then asserts the faults are planted (page mentions --force
+ * and out/). A fixture that only plants faults could drift from the
+ * tool it lies about.
+ *
+ * Requires: deno on PATH. No skmtc / network dependency.
+ */
+
+import { join } from "jsr:@std/path@^1";
+
+const sandbox = Deno.args[0];
+if (!sandbox) {
+  console.error("usage: deno run -A setup.ts <sandboxDir>");
+  Deno.exit(2);
+}
+
+const cliSource = `const usage = \`expo — export table data
+
+Usage: deno run --allow-read --allow-write tool/export.ts [options]
+
+Options:
+  --out <dir>     Output directory (default: dist)
+  --format <fmt>  Output format: json or csv (default: json)
+  --overwrite     Replace an existing output directory
+  --help          Show this help
+\`
+
+type Options = { out: string; format: 'json' | 'csv'; overwrite: boolean }
+
+const parseArgs = (args: string[]): Options => {
+  const options: Options = { out: 'dist', format: 'json', overwrite: false }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === '--help') {
+      console.log(usage)
+      Deno.exit(0)
+    } else if (arg === '--overwrite') {
+      options.overwrite = true
+    } else if (arg === '--out') {
+      const value = args[++index]
+      if (!value) throw new Error('--out requires a directory')
+      options.out = value
+    } else if (arg === '--format') {
+      const value = args[++index]
+      if (value !== 'json' && value !== 'csv') {
+        throw new Error(\`--format must be json or csv, got '\${value}'\`)
+      }
+      options.format = value
+    } else {
+      throw new Error(\`unknown option '\${arg}' — see --help\`)
+    }
+  }
+  return options
+}
+
+const rows = [
+  { id: 1, name: 'Aster', status: 'active' },
+  { id: 2, name: 'Briar', status: 'archived' }
+]
+
+const render = (format: Options['format']): string =>
+  format === 'json'
+    ? JSON.stringify(rows, null, 2)
+    : ['id,name,status', ...rows.map(row => \`\${row.id},\${row.name},\${row.status}\`)].join('\\n')
+
+const main = async (): Promise<void> => {
+  const options = parseArgs(Deno.args)
+  let outExists = false
+  try {
+    await Deno.stat(options.out)
+    outExists = true
+  } catch {
+    // fresh output directory
+  }
+  if (outExists && !options.overwrite) {
+    console.error(\`refusing to overwrite '\${options.out}' — pass --overwrite to replace it\`)
+    Deno.exit(1)
+  }
+  await Deno.mkdir(options.out, { recursive: true })
+  const outPath = \`\${options.out}/export.\${options.format}\`
+  await Deno.writeTextFile(outPath, render(options.format))
+  console.log(\`wrote \${outPath} (\${rows.length} rows)\`)
+}
+
+await main()
+`;
+
+const flawedPage = `# Exporting
+
+## Background
+
+The expo tool grew out of our internal reporting pipeline, which
+originally wrote everything to a shared network drive. After the
+2024 migration we rewrote it in Deno, and it currently lives in
+tool/export.ts. The new exporter is much faster and will keep
+getting faster as we tune it.
+
+As mentioned above, the tool wants to write your data somewhere, so
+it helps to understand its history before running it.
+
+#### Why we picked flat files
+
+We debated a database sink for a long time. Flat files won because
+they are easy to diff and easy to ship. A database sink may return
+some day.
+
+## Doing an export
+
+It's really easy — you can simply run the tool and it will figure
+out the rest.
+
+1. Open a terminal, cd into the project, and run
+   \`deno run --allow-read --allow-write tool/export.ts\` to produce
+   the export file.
+2. The output bundle lands in \`out/\` by default, in CSV format.
+3. If the folder already exists, please just pass \`--force\` and the
+   tool will happily clobber it for you.
+4. You can also change where the artifact goes with \`--out\`.
+
+For more details [click here](https://example.com/expo).
+`;
+
+await Deno.mkdir(join(sandbox, "tool"), { recursive: true });
+await Deno.mkdir(join(sandbox, "guides"), { recursive: true });
+await Deno.writeTextFile(join(sandbox, "tool", "export.ts"), cliSource);
+await Deno.writeTextFile(join(sandbox, "guides", "export-data.md"), flawedPage);
+
+const run = async (
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> => {
+  const output = await new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", "tool/export.ts", ...args],
+    cwd: sandbox,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code: output.code,
+    stdout: new TextDecoder().decode(output.stdout),
+    stderr: new TextDecoder().decode(output.stderr),
+  };
+};
+
+// Prove the REAL behavior the rubric depends on.
+const help = await run(["--help"]);
+if (
+  help.code !== 0 || !help.stdout.includes("--overwrite") ||
+  !help.stdout.includes("default: dist")
+) {
+  throw new Error(
+    `fixture invalid: help text drifted: ${help.stdout} ${help.stderr}`,
+  );
+}
+
+const firstRun = await run([]);
+if (firstRun.code !== 0) {
+  throw new Error(`fixture invalid: default export failed: ${firstRun.stderr}`);
+}
+const exported = await Deno.readTextFile(join(sandbox, "dist", "export.json"));
+if (!exported.includes("Aster")) {
+  throw new Error("fixture invalid: dist/export.json missing expected rows");
+}
+
+const blockedRun = await run([]);
+if (blockedRun.code === 0 || !blockedRun.stderr.includes("--overwrite")) {
+  throw new Error(
+    "fixture invalid: second run should refuse without --overwrite",
+  );
+}
+
+const overwriteRun = await run(["--overwrite", "--format", "csv"]);
+if (overwriteRun.code !== 0) {
+  throw new Error(
+    `fixture invalid: --overwrite run failed: ${overwriteRun.stderr}`,
+  );
+}
+
+// Reset the output tree so the agent starts from a clean sandbox.
+await Deno.remove(join(sandbox, "dist"), { recursive: true });
+
+// Prove the faults are planted.
+const plantedPage = await Deno.readTextFile(
+  join(sandbox, "guides", "export-data.md"),
+);
+for (
+  const fault of ["--force", "`out/`", "simply", "currently", "click here"]
+) {
+  if (!plantedPage.includes(fault)) {
+    throw new Error(
+      `fixture invalid: planted fault '${fault}' missing from the flawed page`,
+    );
+  }
+}
+
+console.log("fixture ready: real tool behavior proven, flawed page planted");

--- a/deno/docs/evals/fixtures/smoke/setup.ts
+++ b/deno/docs/evals/fixtures/smoke/setup.ts
@@ -1,0 +1,35 @@
+/** Smoke fixture: a tiny workspace whose only challenge is reading a
+ * file. Proves the harness plumbing (sandbox, spawn, grading), not the
+ * docs. */
+
+import { join } from 'jsr:@std/path@^1'
+
+const sandbox = Deno.args[0]
+if (!sandbox) {
+  console.error('usage: deno run -A setup.ts <sandboxDir>')
+  Deno.exit(2)
+}
+
+await Deno.writeTextFile(
+  join(sandbox, 'README.md'),
+  [
+    '# Orchard service',
+    '',
+    'Internal tooling for the orchard batch pipeline. Operational',
+    'details live in ops-notes.md.',
+    ''
+  ].join('\n')
+)
+
+await Deno.writeTextFile(
+  join(sandbox, 'ops-notes.md'),
+  [
+    '# Ops notes',
+    '',
+    '- Batch window: 02:00-04:00 UTC',
+    '- On-call rotation is in the shared calendar',
+    '- Deploy codeword: ZEPHYR-42',
+    '- Rollbacks require two approvals',
+    ''
+  ].join('\n')
+)

--- a/deno/docs/evals/graders.ts
+++ b/deno/docs/evals/graders.ts
@@ -1,0 +1,239 @@
+/**
+ * Graders for the docs eval harness. Mechanical kinds first
+ * (`file-exists`, `file-contains`, `run-command`); `llm-judge` is
+ * reserved for qualitative outcomes a mechanical check can't reach.
+ *
+ * Every grader returns a `GraderResult` — the harness ANDs them: a
+ * trial passes only when every grader passes.
+ */
+
+import { join } from 'jsr:@std/path@^1'
+
+export type GraderSpec =
+  | { kind: 'file-exists'; path: string }
+  | { kind: 'file-contains'; path: string; pattern: string }
+  | { kind: 'run-command'; cmd: string; args?: string[]; expectExit?: number }
+  | { kind: 'llm-judge'; rubric: string }
+
+export type GraderResult = {
+  kind: string
+  pass: boolean
+  detail: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every(item => typeof item === 'string')
+
+export const parseGraderSpec = (value: unknown, context: string): GraderSpec => {
+  if (!isRecord(value)) {
+    throw new Error(`${context}: grader spec must be an object`)
+  }
+
+  switch (value.kind) {
+    case 'file-exists': {
+      if (typeof value.path !== 'string') {
+        throw new Error(`${context}: file-exists grader needs a string 'path'`)
+      }
+      return { kind: 'file-exists', path: value.path }
+    }
+    case 'file-contains': {
+      if (typeof value.path !== 'string' || typeof value.pattern !== 'string') {
+        throw new Error(`${context}: file-contains grader needs string 'path' and 'pattern'`)
+      }
+      return { kind: 'file-contains', path: value.path, pattern: value.pattern }
+    }
+    case 'run-command': {
+      if (typeof value.cmd !== 'string') {
+        throw new Error(`${context}: run-command grader needs a string 'cmd'`)
+      }
+      if (value.args !== undefined && !isStringArray(value.args)) {
+        throw new Error(`${context}: run-command 'args' must be a string array`)
+      }
+      if (value.expectExit !== undefined && typeof value.expectExit !== 'number') {
+        throw new Error(`${context}: run-command 'expectExit' must be a number`)
+      }
+      return {
+        kind: 'run-command',
+        cmd: value.cmd,
+        args: isStringArray(value.args) ? value.args : undefined,
+        expectExit: typeof value.expectExit === 'number' ? value.expectExit : undefined
+      }
+    }
+    case 'llm-judge': {
+      if (typeof value.rubric !== 'string') {
+        throw new Error(`${context}: llm-judge grader needs a string 'rubric'`)
+      }
+      return { kind: 'llm-judge', rubric: value.rubric }
+    }
+    default: {
+      throw new Error(`${context}: unknown grader kind '${String(value.kind)}'`)
+    }
+  }
+}
+
+const truncate = (text: string, max: number): string =>
+  text.length <= max ? text : `${text.slice(0, max)}…`
+
+const gradeFileExists = async (sandbox: string, path: string): Promise<GraderResult> => {
+  try {
+    const stat = await Deno.stat(join(sandbox, path))
+    return {
+      kind: 'file-exists',
+      pass: stat.isFile,
+      detail: stat.isFile ? `${path} exists` : `${path} exists but is not a file`
+    }
+  } catch {
+    return { kind: 'file-exists', pass: false, detail: `${path} not found` }
+  }
+}
+
+const gradeFileContains = async (
+  sandbox: string,
+  path: string,
+  pattern: string
+): Promise<GraderResult> => {
+  try {
+    const content = await Deno.readTextFile(join(sandbox, path))
+    const matched = new RegExp(pattern, 'm').test(content)
+    return {
+      kind: 'file-contains',
+      pass: matched,
+      detail: matched
+        ? `${path} matches /${pattern}/`
+        : `${path} does not match /${pattern}/ (content: ${truncate(content.trim(), 200)})`
+    }
+  } catch {
+    return { kind: 'file-contains', pass: false, detail: `${path} not readable` }
+  }
+}
+
+const gradeRunCommand = async (
+  sandbox: string,
+  cmd: string,
+  args: string[],
+  expectExit: number
+): Promise<GraderResult> => {
+  try {
+    const output = await new Deno.Command(cmd, {
+      args,
+      cwd: sandbox,
+      stdout: 'piped',
+      stderr: 'piped'
+    }).output()
+
+    const stderr = new TextDecoder().decode(output.stderr)
+    const stdout = new TextDecoder().decode(output.stdout)
+    const pass = output.code === expectExit
+
+    return {
+      kind: 'run-command',
+      pass,
+      detail: pass
+        ? `${cmd} ${args.join(' ')} exited ${output.code}`
+        : `${cmd} ${args.join(' ')} exited ${output.code} (expected ${expectExit}): ${truncate(
+            `${stdout} ${stderr}`.trim(),
+            400
+          )}`
+    }
+  } catch (error) {
+    return {
+      kind: 'run-command',
+      pass: false,
+      detail: `failed to spawn ${cmd}: ${error instanceof Error ? error.message : String(error)}`
+    }
+  }
+}
+
+const extractJsonObject = (text: string): unknown => {
+  const match = text.match(/\{[\s\S]*\}/)
+  if (!match) throw new Error('no JSON object in judge reply')
+  return JSON.parse(match[0])
+}
+
+const gradeLlmJudge = async (
+  rubric: string,
+  finalMessage: string,
+  judgeModel: string
+): Promise<GraderResult> => {
+  const prompt = [
+    'You are grading the final answer an AI agent gave at the end of a task.',
+    'Apply the rubric below strictly. Do not give credit for effort or partial work.',
+    '',
+    `<rubric>${rubric}</rubric>`,
+    '',
+    `<agent-final-answer>${finalMessage}</agent-final-answer>`,
+    '',
+    'Reply with ONLY a JSON object of the shape {"pass": boolean, "reason": string}.'
+  ].join('\n')
+
+  try {
+    const output = await new Deno.Command('claude', {
+      args: ['-p', prompt, '--output-format', 'json', '--model', judgeModel, '--max-turns', '1'],
+      stdout: 'piped',
+      stderr: 'piped'
+    }).output()
+
+    const envelope = JSON.parse(new TextDecoder().decode(output.stdout))
+    if (!isRecord(envelope) || typeof envelope.result !== 'string') {
+      throw new Error('unexpected judge envelope shape')
+    }
+
+    const verdict = extractJsonObject(envelope.result)
+    if (!isRecord(verdict) || typeof verdict.pass !== 'boolean') {
+      throw new Error(`unexpected judge verdict: ${truncate(envelope.result, 200)}`)
+    }
+
+    return {
+      kind: 'llm-judge',
+      pass: verdict.pass,
+      detail: typeof verdict.reason === 'string' ? verdict.reason : '(no reason given)'
+    }
+  } catch (error) {
+    return {
+      kind: 'llm-judge',
+      pass: false,
+      detail: `judge failed: ${error instanceof Error ? error.message : String(error)}`
+    }
+  }
+}
+
+export const runGraders = async (args: {
+  specs: GraderSpec[]
+  sandbox: string
+  finalMessage: string
+  judgeModel: string
+}): Promise<GraderResult[]> => {
+  const results: GraderResult[] = []
+
+  for (const spec of args.specs) {
+    switch (spec.kind) {
+      case 'file-exists': {
+        results.push(await gradeFileExists(args.sandbox, spec.path))
+        break
+      }
+      case 'file-contains': {
+        results.push(await gradeFileContains(args.sandbox, spec.path, spec.pattern))
+        break
+      }
+      case 'run-command': {
+        results.push(
+          await gradeRunCommand(args.sandbox, spec.cmd, spec.args ?? [], spec.expectExit ?? 0)
+        )
+        break
+      }
+      case 'llm-judge': {
+        results.push(await gradeLlmJudge(spec.rubric, args.finalMessage, args.judgeModel))
+        break
+      }
+      default: {
+        const _exhaustive: never = spec
+        throw new Error(`Unhandled grader: ${JSON.stringify(_exhaustive)}`)
+      }
+    }
+  }
+
+  return results
+}

--- a/deno/docs/evals/run.ts
+++ b/deno/docs/evals/run.ts
@@ -1,0 +1,549 @@
+#!/usr/bin/env -S deno run -A
+/**
+ * Docs eval harness — cold-agent evals for SKMTC docs/skills.
+ *
+ * Spawns a headless `claude -p` agent per trial inside a throwaway
+ * sandbox containing only fixture files + snapshots of the docs under
+ * test, then grades the outcome (see graders.ts). Pass-rate is the
+ * docs' quality metric; turns/cost-to-success is the tiebreaker.
+ *
+ * Usage:
+ *   deno run -A run.ts                          # all tasks, 1 trial each
+ *   deno run -A run.ts --task smoke --trials 3
+ *   deno run -A run.ts --task diagnose-skipped-output --no-docs   # contamination control
+ *   deno run -A run.ts --label before-rewrite --trials 3
+ *
+ * Flags:
+ *   --task <id>         task to run (repeatable / comma-separated; default all)
+ *   --trials <n>        trials per task (default 1)
+ *   --no-docs           omit the docs snapshot (contamination control)
+ *   --label <name>      run label; results land in results/<label>.jsonl
+ *   --model <m>         doer model (default sonnet)
+ *   --judge-model <m>   judge model for llm-judge graders (default haiku)
+ *   --keep-sandbox      keep sandboxes of passing trials too (failures are always kept)
+ *
+ * Design + task-authoring conventions:
+ *   notes/plan-2026-07-05-docs-eval-harness.md
+ */
+
+import { parseArgs } from 'jsr:@std/cli@^1/parse-args'
+import { parse as parseYaml } from 'jsr:@std/yaml@^1'
+import { basename, dirname, fromFileUrl, join } from 'jsr:@std/path@^1'
+import { copy } from 'jsr:@std/fs@^1'
+import { parseGraderSpec, runGraders, type GraderResult, type GraderSpec } from './graders.ts'
+
+const evalsDir = dirname(fromFileUrl(import.meta.url))
+const repoRoot = join(evalsDir, '..', '..', '..')
+
+const AGENT_TIMEOUT_MS = 15 * 60_000
+
+/** Sandboxes run against the local mirror registry with this CLI
+ * version — the only self-consistent world today. Public jsr.io is
+ * blocked twice over: `deno bundle` fails to load jsr specifiers
+ * from jsr.io at all (repro'd standalone on deno 2.9.1, works
+ * against the mirror), and jsr.io's gen-* packages are ancient.
+ * See the plan's "Environment discoveries". Revisit when either
+ * clears; then this shim machinery can go. */
+const SANDBOX_CLI_VERSION = '0.9.21'
+
+const SKMTC_PERMS = [
+  '--allow-read',
+  '--allow-write',
+  '--allow-net',
+  '--allow-env',
+  '--allow-run=deno,sh',
+  '--allow-sys=homedir'
+]
+
+type Task = {
+  id: string
+  docs: string[]
+  fixture: string | undefined
+  maxTurns: number
+  graders: GraderSpec[]
+  prompt: string
+}
+
+type ClaudeEnvelope = {
+  isError: boolean
+  result: string
+  numTurns: number | null
+  /** Claude Code's own list-price accounting of the run's token
+   * usage (`total_cost_usd`). The spawned agents authenticate with
+   * the user's Claude Code OAuth credential — runs are covered by
+   * the subscription, so this is NOTIONAL, not billed spend. Kept
+   * as a comparable effort metric alongside tokens/turns. */
+  notionalUsd: number | null
+  outputTokens: number | null
+  sessionId: string | null
+}
+
+type TrialRow = {
+  runLabel: string
+  task: string
+  trial: number
+  docsMode: 'with-docs' | 'no-docs'
+  docsSha: string
+  model: string
+  pass: boolean
+  graders: GraderResult[]
+  numTurns: number | null
+  outputTokens: number | null
+  /** Notional list-price accounting from the claude envelope — runs
+   * are on the user's subscription; nothing is billed per-run. */
+  notionalUsd: number | null
+  durationMs: number
+  isError: boolean
+  timedOut: boolean
+  sandbox: string | null
+  sessionId: string | null
+  finalMessage: string
+  timestamp: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const loadTask = async (taskPath: string): Promise<Task> => {
+  const raw = await Deno.readTextFile(taskPath)
+  const context = basename(taskPath)
+
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+  if (!match) throw new Error(`${context}: missing YAML frontmatter`)
+
+  const frontmatter = parseYaml(match[1])
+  if (!isRecord(frontmatter)) throw new Error(`${context}: frontmatter must be a mapping`)
+
+  const { id, docs, fixture, maxTurns, graders } = frontmatter
+
+  if (typeof id !== 'string') throw new Error(`${context}: 'id' must be a string`)
+  if (!Array.isArray(docs) || !docs.every(entry => typeof entry === 'string')) {
+    throw new Error(`${context}: 'docs' must be a string array (repo-relative paths)`)
+  }
+  if (fixture !== undefined && typeof fixture !== 'string') {
+    throw new Error(`${context}: 'fixture' must be a string when present`)
+  }
+  if (typeof maxTurns !== 'number') throw new Error(`${context}: 'maxTurns' must be a number`)
+  if (!Array.isArray(graders) || graders.length === 0) {
+    throw new Error(`${context}: 'graders' must be a non-empty array`)
+  }
+
+  const prompt = match[2].trim()
+  if (prompt.length === 0) throw new Error(`${context}: prompt body is empty`)
+
+  return {
+    id,
+    docs: docs.filter((entry): entry is string => typeof entry === 'string'),
+    fixture,
+    maxTurns,
+    graders: graders.map((spec, index) => parseGraderSpec(spec, `${context} graders[${index}]`)),
+    prompt
+  }
+}
+
+const docsSha = async (): Promise<string> => {
+  const rev = await new Deno.Command('git', {
+    args: ['rev-parse', '--short', 'HEAD'],
+    cwd: repoRoot,
+    stdout: 'piped',
+    stderr: 'piped'
+  }).output()
+  const sha = new TextDecoder().decode(rev.stdout).trim() || 'unknown'
+
+  const status = await new Deno.Command('git', {
+    args: ['status', '--porcelain', '--', 'deno/docs'],
+    cwd: repoRoot,
+    stdout: 'piped',
+    stderr: 'piped'
+  }).output()
+  const dirty = new TextDecoder().decode(status.stdout).trim().length > 0
+
+  return dirty ? `${sha}-dirty` : sha
+}
+
+/** Copy a docs entry into <sandbox>/docs/. A SKILL.md is renamed to
+ * <its-directory>.md so the sandbox docs folder reads naturally. */
+const copyDocEntry = async (entry: string, sandbox: string): Promise<void> => {
+  const source = join(repoRoot, entry)
+  const stat = await Deno.stat(source)
+  const docsDir = join(sandbox, 'docs')
+  await Deno.mkdir(docsDir, { recursive: true })
+
+  if (stat.isDirectory) {
+    await copy(source, join(docsDir, basename(entry)), { overwrite: true })
+    return
+  }
+
+  const name =
+    basename(entry) === 'SKILL.md' ? `${basename(dirname(entry))}.md` : basename(entry)
+  await Deno.copyFile(source, join(docsDir, name))
+}
+
+/** Seed the fresh config dir with working credentials. A fresh
+ * CLAUDE_CONFIG_DIR does NOT inherit auth (verified 2026-07-05): on
+ * macOS the live OAuth token sits in the Keychain, and the custom
+ * config dir only reads its own `.credentials.json`. So: keychain
+ * blob first, `~/.claude/.credentials.json` copy as the fallback.
+ * The caller must scrub the config dir after the run — sandboxes can
+ * be kept for autopsy and must not retain a token. */
+const seedCredentials = async (configDir: string): Promise<void> => {
+  const target = join(configDir, '.credentials.json')
+
+  if (Deno.build.os === 'darwin') {
+    const keychain = await new Deno.Command('security', {
+      args: ['find-generic-password', '-s', 'Claude Code-credentials', '-w'],
+      stdout: 'piped',
+      stderr: 'piped'
+    }).output()
+    if (keychain.success) {
+      await Deno.writeTextFile(target, new TextDecoder().decode(keychain.stdout))
+      await Deno.chmod(target, 0o600)
+      return
+    }
+  }
+
+  const home = Deno.env.get('HOME')
+  if (!home) throw new Error('cannot seed credentials: no keychain entry and no HOME')
+  await Deno.copyFile(join(home, '.claude', '.credentials.json'), target)
+  await Deno.chmod(target, 0o600)
+}
+
+/** Child env for the agent: parent env minus CLAUDE* (nested-session
+ * leakage), plus a fresh CLAUDE_CONFIG_DIR for isolation. */
+const agentEnv = (configDir: string): Record<string, string> => {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(Deno.env.toObject())) {
+    if (key.startsWith('CLAUDE')) continue
+    env[key] = value
+  }
+  env.CLAUDE_CONFIG_DIR = configDir
+  return env
+}
+
+const parseEnvelope = (stdout: string): ClaudeEnvelope => {
+  const parsed = JSON.parse(stdout)
+  if (!isRecord(parsed)) throw new Error('claude envelope is not an object')
+  // `result` is absent on abnormal terminations (e.g. subtype
+  // error_max_turns) — still a valid envelope; the trial fails via
+  // is_error but turns/cost must be recorded.
+  const usage = isRecord(parsed.usage) ? parsed.usage : {}
+
+  return {
+    isError: parsed.is_error === true,
+    result:
+      typeof parsed.result === 'string'
+        ? parsed.result
+        : `(no final message; subtype: ${String(parsed.subtype)})`,
+    numTurns: typeof parsed.num_turns === 'number' ? parsed.num_turns : null,
+    notionalUsd: typeof parsed.total_cost_usd === 'number' ? parsed.total_cost_usd : null,
+    outputTokens: typeof usage.output_tokens === 'number' ? usage.output_tokens : null,
+    sessionId: typeof parsed.session_id === 'string' ? parsed.session_id : null
+  }
+}
+
+const spawnAgent = async (args: {
+  prompt: string
+  sandbox: string
+  maxTurns: number
+  model: string
+}): Promise<{ envelope: ClaudeEnvelope | null; timedOut: boolean; rawStderr: string }> => {
+  const configDir = join(args.sandbox, '.claude-config')
+  await Deno.mkdir(configDir, { recursive: true })
+  await seedCredentials(configDir)
+
+  const child = new Deno.Command('claude', {
+    args: [
+      '-p',
+      args.prompt,
+      '--output-format',
+      'json',
+      '--max-turns',
+      String(args.maxTurns),
+      '--model',
+      args.model,
+      '--dangerously-skip-permissions'
+    ],
+    cwd: args.sandbox,
+    clearEnv: true,
+    env: agentEnv(configDir),
+    stdout: 'piped',
+    stderr: 'piped'
+  }).spawn()
+
+  const timer = setTimeout(() => {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // already exited
+    }
+  }, AGENT_TIMEOUT_MS)
+
+  const output = await child.output()
+  clearTimeout(timer)
+
+  // Scrub the seeded credential immediately — the sandbox may be kept
+  // for autopsy. The rest of the config dir (transcripts) stays.
+  await Deno.remove(join(configDir, '.credentials.json')).catch(() => {})
+
+  const stdout = new TextDecoder().decode(output.stdout)
+  const stderr = new TextDecoder().decode(output.stderr)
+
+  if (!output.success && stdout.trim().length === 0) {
+    return { envelope: null, timedOut: output.signal === 'SIGKILL', rawStderr: stderr }
+  }
+
+  try {
+    return { envelope: parseEnvelope(stdout), timedOut: false, rawStderr: stderr }
+  } catch (error) {
+    return {
+      envelope: null,
+      timedOut: false,
+      rawStderr: `${error instanceof Error ? error.message : String(error)}\n${stderr}\n${stdout}`
+    }
+  }
+}
+
+/** Write a sandbox-local `skmtc` shim pinned to SANDBOX_CLI_VERSION
+ * against the mirror registry. Returns the bin dir to prepend to
+ * PATH, or null when no mirror URL is known. */
+const writeSandboxCliShim = async (
+  sandbox: string,
+  mirrorJsrUrl: string | null
+): Promise<string | null> => {
+  if (!mirrorJsrUrl) return null
+
+  const binDir = join(sandbox, 'bin')
+  await Deno.mkdir(binDir, { recursive: true })
+  const shimPath = join(binDir, 'skmtc')
+  await Deno.writeTextFile(
+    shimPath,
+    [
+      '#!/bin/sh',
+      `exec env JSR_URL=${mirrorJsrUrl} deno run ${SKMTC_PERMS.join(' ')} --unstable-worker-options 'jsr:@skmtc/cli@${SANDBOX_CLI_VERSION}' "$@"`,
+      ''
+    ].join('\n')
+  )
+  await Deno.chmod(shimPath, 0o755)
+  return binDir
+}
+
+const runTrial = async (args: {
+  task: Task
+  trial: number
+  runLabel: string
+  sha: string
+  model: string
+  judgeModel: string
+  withDocs: boolean
+  keepSandbox: boolean
+  mirrorJsrUrl: string | null
+}): Promise<TrialRow> => {
+  const { task } = args
+  const sandbox = await Deno.makeTempDir({ prefix: `skmtc-eval-${task.id}-` })
+  const started = Date.now()
+
+  // Trials run sequentially, so a set/restore of the process PATH is
+  // safe — fixture setup, the agent, and run-command graders all
+  // inherit the sandbox-local skmtc shim.
+  const binDir = await writeSandboxCliShim(sandbox, args.mirrorJsrUrl)
+  const originalPath = Deno.env.get('PATH') ?? ''
+  if (binDir) Deno.env.set('PATH', `${binDir}:${originalPath}`)
+
+  try {
+    return await runTrialInner({ ...args, sandbox, started })
+  } finally {
+    if (binDir) Deno.env.set('PATH', originalPath)
+  }
+}
+
+const runTrialInner = async (args: {
+  task: Task
+  trial: number
+  runLabel: string
+  sha: string
+  model: string
+  judgeModel: string
+  withDocs: boolean
+  keepSandbox: boolean
+  sandbox: string
+  started: number
+}): Promise<TrialRow> => {
+  const { task, sandbox, started } = args
+
+  if (task.fixture) {
+    const setupPath = join(evalsDir, 'fixtures', task.fixture, 'setup.ts')
+    const setup = await new Deno.Command('deno', {
+      args: ['run', '-A', setupPath, sandbox],
+      cwd: sandbox,
+      stdout: 'piped',
+      stderr: 'piped'
+    }).output()
+    if (!setup.success) {
+      throw new Error(
+        `fixture setup failed for ${task.id}: ${new TextDecoder().decode(setup.stderr)}`
+      )
+    }
+  }
+
+  const useDocs = args.withDocs && task.docs.length > 0
+  if (useDocs) {
+    for (const entry of task.docs) {
+      await copyDocEntry(entry, sandbox)
+    }
+  }
+
+  const prompt = useDocs
+    ? `${task.prompt}\n\nReference documentation is available in the docs/ directory of this workspace. Read the relevant files before starting.`
+    : task.prompt
+
+  const { envelope, timedOut, rawStderr } = await spawnAgent({
+    prompt,
+    sandbox,
+    maxTurns: task.maxTurns,
+    model: args.model
+  })
+
+  const finalMessage = envelope?.result ?? `(agent produced no result envelope) ${rawStderr}`
+
+  const graders = envelope
+    ? await runGraders({
+        specs: task.graders,
+        sandbox,
+        finalMessage,
+        judgeModel: args.judgeModel
+      })
+    : []
+
+  const pass = envelope !== null && !envelope.isError && graders.every(result => result.pass)
+
+  const keep = !pass || args.keepSandbox
+  if (!keep) {
+    await Deno.remove(sandbox, { recursive: true })
+  }
+
+  return {
+    runLabel: args.runLabel,
+    task: task.id,
+    trial: args.trial,
+    docsMode: useDocs ? 'with-docs' : 'no-docs',
+    docsSha: args.sha,
+    model: args.model,
+    pass,
+    graders,
+    numTurns: envelope?.numTurns ?? null,
+    outputTokens: envelope?.outputTokens ?? null,
+    notionalUsd: envelope?.notionalUsd ?? null,
+    durationMs: Date.now() - started,
+    isError: envelope?.isError ?? true,
+    timedOut,
+    sandbox: keep ? sandbox : null,
+    sessionId: envelope?.sessionId ?? null,
+    finalMessage,
+    timestamp: new Date().toISOString()
+  }
+}
+
+const listTaskIds = async (): Promise<string[]> => {
+  const ids: string[] = []
+  for await (const entry of Deno.readDir(join(evalsDir, 'tasks'))) {
+    if (entry.isFile && entry.name.endsWith('.md')) {
+      ids.push(entry.name.replace(/\.md$/, ''))
+    }
+  }
+  return ids.sort()
+}
+
+const main = async (): Promise<void> => {
+  // Capture the mirror URL for the sandbox CLI shim, then strip
+  // JSR_URL from the harness env so nothing outside the shim
+  // accidentally resolves against it (the installed system skmtc
+  // dies when JSR_URL points at the mirror — registry split; see
+  // the plan's "Environment discoveries").
+  const mirrorJsrUrl = Deno.env.get('JSR_URL') ?? null
+  Deno.env.delete('JSR_URL')
+
+  const flags = parseArgs(Deno.args, {
+    string: ['task', 'trials', 'label', 'model', 'judge-model'],
+    boolean: ['no-docs', 'keep-sandbox'],
+    collect: ['task'],
+    default: { trials: '1', model: 'sonnet', 'judge-model': 'haiku' }
+  })
+
+  const trials = Number.parseInt(flags.trials, 10)
+  if (!Number.isFinite(trials) || trials < 1) {
+    console.error(`invalid --trials: ${flags.trials}`)
+    Deno.exit(2)
+  }
+
+  const requested = flags.task.flatMap(value => value.split(',')).filter(Boolean)
+  const taskIds = requested.length > 0 ? requested : await listTaskIds()
+  const runLabel = flags.label ?? `adhoc-${new Date().toISOString().slice(0, 10)}`
+  const sha = await docsSha()
+
+  const resultsDir = join(evalsDir, 'results')
+  await Deno.mkdir(resultsDir, { recursive: true })
+  const resultsPath = join(resultsDir, `${runLabel}.jsonl`)
+
+  const rows: TrialRow[] = []
+
+  for (const taskId of taskIds) {
+    const task = await loadTask(join(evalsDir, 'tasks', `${taskId}.md`))
+
+    for (let trial = 1; trial <= trials; trial++) {
+      console.log(`▶ ${task.id} trial ${trial}/${trials} (${flags['no-docs'] ? 'no-docs' : 'with-docs'})`)
+
+      const row = await runTrial({
+        task,
+        trial,
+        runLabel,
+        sha,
+        model: flags.model,
+        judgeModel: flags['judge-model'],
+        withDocs: !flags['no-docs'],
+        keepSandbox: flags['keep-sandbox'],
+        mirrorJsrUrl
+      })
+
+      rows.push(row)
+      await Deno.writeTextFile(resultsPath, `${JSON.stringify(row)}\n`, { append: true })
+
+      const verdict = row.pass ? 'PASS' : 'FAIL'
+      const failedGraders = row.graders.filter(result => !result.pass)
+      const tokens =
+        row.outputTokens !== null ? `${(row.outputTokens / 1000).toFixed(1)}k out-tokens` : '?'
+      console.log(
+        `  ${verdict} turns=${row.numTurns ?? '?'} ${tokens} ${Math.round(
+          row.durationMs / 1000
+        )}s${row.timedOut ? ' TIMED-OUT' : ''}`
+      )
+      for (const failed of failedGraders) {
+        console.log(`    ✗ ${failed.kind}: ${failed.detail}`)
+      }
+      if (row.sandbox) console.log(`    sandbox: ${row.sandbox}`)
+    }
+  }
+
+  console.log(`\n== summary (${runLabel}, docs @ ${sha}) ==`)
+  for (const taskId of taskIds) {
+    const taskRows = rows.filter(row => row.task === taskId)
+    const passes = taskRows.filter(row => row.pass).length
+    const avgTurns =
+      taskRows.filter(row => row.numTurns !== null).length > 0
+        ? (
+            taskRows.reduce((sum, row) => sum + (row.numTurns ?? 0), 0) /
+            taskRows.filter(row => row.numTurns !== null).length
+          ).toFixed(1)
+        : '?'
+    const outputTokens = taskRows.reduce((sum, row) => sum + (row.outputTokens ?? 0), 0)
+    console.log(
+      `  ${taskId}: ${passes}/${taskRows.length} pass, avg turns ${avgTurns}, ${(
+        outputTokens / 1000
+      ).toFixed(1)}k out-tokens`
+    )
+  }
+  console.log(`results: ${resultsPath}`)
+
+  Deno.exit(rows.every(row => row.pass) ? 0 : 1)
+}
+
+await main()

--- a/deno/docs/evals/tasks/author-model-generator.md
+++ b/deno/docs/evals/tasks/author-model-generator.md
@@ -1,0 +1,53 @@
+---
+id: author-model-generator
+fixture: author-model-generator
+docs:
+  - deno/docs/skills/skmtc-generator/SKILL.md
+  - deno/docs/skills/skmtc-lang-typescript/SKILL.md
+  - deno/docs/skills/skmtc-cli/SKILL.md
+maxTurns: 60
+graders:
+  - kind: run-command
+    cmd: skmtc
+    args: ['bundle', 'lab', '--json']
+  - kind: run-command
+    cmd: skmtc
+    args: ['generate', 'lab', '--json']
+  - kind: file-exists
+    path: app/src/types/Pet.generated.ts
+  - kind: file-contains
+    path: app/src/types/Pet.generated.ts
+    pattern: 'export type Pet'
+  - kind: file-contains
+    path: app/src/types/Order.generated.ts
+    pattern: 'export type Order'
+  - kind: run-command
+    cmd: deno
+    args: ['check', 'app/src/types/Pet.generated.ts', 'app/src/types/Order.generated.ts']
+---
+This workspace contains an SKMTC root (the .skmtc/ directory) with an
+initialized but empty project named `lab`, and schema.json — an
+OpenAPI document with two component schemas (Pet, Order). The skmtc
+CLI is installed and working.
+
+Author a local SKMTC generator, from scratch, that emits one
+TypeScript type alias per schema model:
+
+- Package name: `@acme/gen-types`
+- For each model in components.schemas, emit a file at
+  `@/types/<RefName>.generated.ts` (so Pet lands at
+  app/src/types/Pet.generated.ts) containing an exported type alias
+  named exactly after the model (e.g. `export type Pet = { ... }`).
+  Model property types map to TypeScript equivalents; non-required
+  properties are optional.
+- Wire the generator into the `lab` project so `skmtc bundle lab`
+  and `skmtc generate lab` succeed and produce the files.
+
+Environment facts (registry state, not derivable from the docs): pin
+`@skmtc/core` to `jsr:@skmtc/core@0.23.2` and `@skmtc/lang-typescript`
+to `jsr:@skmtc/lang-typescript@0.12.8` wherever your generator source
+needs them. Other bare specifiers you use must also be pinned in the
+generator's deno.json (e.g. `@std/path`: `jsr:@std/path@^1.1.2`).
+
+When done, run the generation to confirm output, and summarize what
+you built in your final answer.

--- a/deno/docs/evals/tasks/diagnose-skipped-output.md
+++ b/deno/docs/evals/tasks/diagnose-skipped-output.md
@@ -1,0 +1,37 @@
+---
+id: diagnose-skipped-output
+fixture: diagnose-skipped-output
+docs:
+  - deno/docs/skills/skmtc-debug/SKILL.md
+  - deno/docs/skills/skmtc-cli/SKILL.md
+maxTurns: 50
+graders:
+  - kind: run-command
+    cmd: skmtc
+    args: ['generate', 'lab', '--json']
+  - kind: file-exists
+    path: app/src/types/pet.generated.ts
+  - kind: file-contains
+    path: app/src/types/pet.generated.ts
+    pattern: 'Pet'
+  - kind: llm-judge
+    rubric: >
+      Pass only if the answer identifies the root cause as the skip
+      filter in the project's client.json settings (the generator
+      @skmtc/gen-typescript being listed under settings.skip, i.e.
+      deny-listed / excluded by configuration). Naming the wrong cause
+      (schema problem, bundle staleness, missing install, isSupported
+      gate) fails, even if the output was somehow fixed.
+---
+This workspace contains an SKMTC root (the .skmtc/ directory) with a
+project named `lab`, and schema.json — the OpenAPI document the
+project generates from. The skmtc CLI is installed and working.
+
+The problem: running `skmtc generate lab` completes successfully, but
+no TypeScript model output ever appears under app/src. The
+@skmtc/gen-typescript generator is installed and should be producing
+a type per schema model.
+
+Investigate why there is no output, fix the project so generating
+produces the TypeScript types, and run the generation to confirm.
+State the root cause clearly in your final answer.

--- a/deno/docs/evals/tasks/rewrite-flawed-page.md
+++ b/deno/docs/evals/tasks/rewrite-flawed-page.md
@@ -1,0 +1,44 @@
+---
+id: rewrite-flawed-page
+fixture: rewrite-flawed-page
+docs:
+  - deno/docs/skills/docs-writing/SKILL.md
+  - deno/docs/skills/docs-writing/templates.md
+maxTurns: 30
+graders:
+  - kind: file-exists
+    path: guides/export-data.md
+  - kind: file-contains
+    path: guides/export-data.md
+    pattern: "--overwrite"
+  - kind: run-command
+    cmd: deno
+    args: ["run", "--allow-read", "--allow-write", "tool/export.ts", "--help"]
+  - kind: llm-judge
+    rubric: >
+      Pass only if the rewritten guides/export-data.md (a) documents
+      the real --overwrite flag and no longer presents --force as an
+      existing option, (b) states the tool's real defaults — output
+      directory dist/ and format json — matching tool/export.ts,
+      (c) opens by stating the task the page accomplishes (with any
+      prerequisites) instead of project history, with the design
+      rationale digression removed or moved out of the how-to,
+      (d) contains no filler ("simply", "easily", "just",
+      "obviously"), no "please" in instructions, no time-bound
+      qualifiers ("currently", "new", "will" for tool behavior), and
+      no "click here"-style link text, (e) presents steps as numbered
+      single-action imperatives that state the expected result (such
+      as which file appears), and (f) uses one consistent term for
+      the exported output instead of alternating between "export
+      file", "output bundle", and "artifact". Fail if the page
+      invents any flag or default not present in tool/export.ts, even
+      if the prose is otherwise clean.
+---
+
+This workspace contains a small Deno CLI at tool/export.ts that exports table
+data, and a how-to page at guides/export-data.md that documents it.
+
+The page has quality problems, and some of what it says the tool does is wrong.
+Rewrite guides/export-data.md in place so it accurately serves a developer who
+wants to export their data with this tool. Keep it a how-to page. Do not modify
+tool/export.ts — the source is the ground truth for what the tool actually does.

--- a/deno/docs/evals/tasks/smoke.md
+++ b/deno/docs/evals/tasks/smoke.md
@@ -1,0 +1,15 @@
+---
+id: smoke
+fixture: smoke
+docs: []
+maxTurns: 10
+graders:
+  - kind: file-exists
+    path: answer.txt
+  - kind: file-contains
+    path: answer.txt
+    pattern: ZEPHYR-42
+---
+This workspace contains a few project files. One of them states a
+deploy codeword. Find the codeword and write it — just the codeword,
+nothing else — to a new file called answer.txt in the workspace root.

--- a/deno/docs/explanation/why-clone-to-customize.md
+++ b/deno/docs/explanation/why-clone-to-customize.md
@@ -1,244 +1,221 @@
 # Why clone-to-customize
 
-> The design choice behind treating generators as application code
-> you own — and why this beats configuration-driven customization
-> for SKMTC's intended use.
+> The design choice behind treating generators as application code you own — and
+> why this beats configuration-driven customization for SKMTC's intended use.
 
 ## The question
 
-When a user needs the generator to produce something slightly
-different — a different fetch wrapper, a different naming
-convention, a custom field renderer — there are two paths a
-codegen tool can offer:
+When a user needs the generator to produce something slightly different — a
+different fetch wrapper, a different naming convention, a custom field renderer
+— there are two paths a codegen tool can offer:
 
-1. **Configuration.** Expose flags/plugins/templates. Users edit
-   config; the generator stays under the maintainer's control.
-2. **Cloning.** Ship the generator as source code. Users copy it
-   into their project and edit the source directly.
+1. **Configuration.** Expose flags/plugins/templates. Users edit config; the
+   generator stays under the maintainer's control.
+2. **Cloning.** Ship the generator as source code. Users copy it into their
+   project and edit the source directly.
 
-SKMTC chose cloning. This doc explains why, and when that's the
-wrong choice.
+SKMTC chose cloning. This doc explains why, and when that's the wrong choice.
 
 ## The short answer
 
-Customization needs vary too much to be flattened into a
-configuration schema. Every config flag either covers one user's
-case and ignores ten others' — or grows the surface to cover all
-ten, becoming unreadable and creating flag-interaction bugs. The
-end state of "configuration-only" codegen is invariably a plugin
-system, which is just cloning with a more expensive contract.
+Customization needs vary too much to be flattened into a configuration schema.
+Every config flag either covers one user's case and ignores ten others' — or
+grows the surface to cover all ten, becoming unreadable and creating
+flag-interaction bugs. The end state of "configuration-only" codegen is
+invariably a plugin system, which is just cloning with a more expensive
+contract.
 
-Cloning skips the dance: give people source code, let them edit it,
-and trade auto-upgrades for full control. The model works for
-shadcn/ui (UI components vendored as source), and it works here.
+Cloning skips the dance: give people source code, let them edit it, and trade
+auto-upgrades for full control. The model works for shadcn/ui (UI components
+vendored as source), and it works here.
 
 ## The alternative: configuration
 
 The configuration-first approach is well-trodden. Tools like
-`openapi-generator`, `orval`, and (to a lesser extent) `kubb`
-expose extensive configuration surfaces — flags, plugins,
-templates, hooks — that let users shape output without touching
-the generator's source.
+`openapi-generator`, `orval`, and (to a lesser extent) `kubb` expose extensive
+configuration surfaces — flags, plugins, templates, hooks — that let users shape
+output without touching the generator's source.
 
 ### Pros of configuration
 
-- **Auto-upgrade story.** When the upstream generator publishes a
-  new version, users bump the dependency and get the fix or
-  feature. No merge needed.
-- **Declarative.** A `codegen.config.js` file fully describes the
-  output. Reproducible, reviewable.
-- **Small footprint in the consumer repo.** Generated artifacts
-  live in the repo; the generator itself doesn't.
-- **Documented surface.** Config schemas can be exhaustively
-  documented; users learn the system by reading the schema.
+- **Auto-upgrade story.** When the upstream generator publishes a new version,
+  users bump the dependency and get the fix or feature. No merge needed.
+- **Declarative.** A `codegen.config.js` file fully describes the output.
+  Reproducible, reviewable.
+- **Small footprint in the consumer repo.** Generated artifacts live in the
+  repo; the generator itself doesn't.
+- **Documented surface.** Config schemas can be exhaustively documented; users
+  learn the system by reading the schema.
 
 ### Cons of configuration
 
-- **Schema bloat.** Each new requested customization either gets
-  rejected (frustrating users) or accepted (growing the schema).
-  Over time the config surface gets unwieldy. orval's config has
-  dozens of options; openapi-generator's has hundreds.
-- **Flag interactions.** Two flags that work fine individually
-  produce broken output together. The combinatorial space is
-  unaudited; bugs surface only when users hit them.
-- **Eventually plugins are required anyway.** When config flags
-  can't cover a case, the maintainer adds a plugin system. Plugins
-  are mini-generators with an API contract. Now the maintenance
-  surface is config + plugins + the plugin API itself.
-- **Customization is bounded by maintainer imagination.** If the
-  maintainer didn't think of your use case, you can't do it.
-  Filing an issue and waiting is the only path.
+- **Schema bloat.** Each new requested customization either gets rejected
+  (frustrating users) or accepted (growing the schema). Over time the config
+  surface gets unwieldy. orval's config has dozens of options;
+  openapi-generator's has hundreds.
+- **Flag interactions.** Two flags that work fine individually produce broken
+  output together. The combinatorial space is unaudited; bugs surface only when
+  users hit them.
+- **Eventually plugins are required anyway.** When config flags can't cover a
+  case, the maintainer adds a plugin system. Plugins are mini-generators with an
+  API contract. Now the maintenance surface is config + plugins + the plugin API
+  itself.
+- **Customization is bounded by maintainer imagination.** If the maintainer
+  didn't think of your use case, you can't do it. Filing an issue and waiting is
+  the only path.
 
-The deeper problem: codegen consumers' customization needs are
-**heterogeneous by nature**. A team using shadcn wants different
-defaults than a team using DaisyUI; a team using Supabase wants
-different hooks than a team using a custom REST API; a team using
-SWR wants different mutation patterns than a team using TanStack
-Query. No configuration schema can anticipate all of these without
+The deeper problem: codegen consumers' customization needs are **heterogeneous
+by nature**. A team using shadcn wants different defaults than a team using
+DaisyUI; a team using Supabase wants different hooks than a team using a custom
+REST API; a team using SWR wants different mutation patterns than a team using
+TanStack Query. No configuration schema can anticipate all of these without
 either being trivially limiting or impossibly large.
 
 ## The choice: clone-to-customize
 
-The cloning approach: every stock generator is published source
-code. Users `skmtc clone` (or copy manually) the generator into
-their project and edit the source. No central plugin API, no
-configuration schema beyond what each generator's `enrichments`
-explicitly exposes.
+The cloning approach: every stock generator is published source code. Users
+`skmtc clone` (or copy manually) the generator into their project and edit the
+source. No central plugin API, no configuration schema beyond what each
+generator's `enrichments` explicitly exposes.
 
-This is the same model as shadcn/ui — components are vendored as
-source into the consumer's repo. The maintainer publishes
-"reference implementations" that users own once they install them.
+This is the same model as shadcn/ui — components are vendored as source into the
+consumer's repo. The maintainer publishes "reference implementations" that users
+own once they install them.
 
 ### Pros of cloning
 
-- **Full control.** Want to change how nullable is encoded? Edit
-  the source. Want to rename `useGetUsers` to `useUsers`? Edit
-  the source. No flag, no plugin, no PR upstream.
-- **Lives like app code.** The cloned generator is TypeScript
-  in your repo. Code review, refactoring tools, grep, git blame —
-  all work normally.
-- **No upgrade-surface lock-in.** The engine API stays small and
-  stable (Apache 2.0 with patent grant); cloned generators don't
-  depend on the maintainer adding flags they need.
-- **Discoverable by reading.** Want to know how a generator renders
-  forms? Read its `src/`. The source is short — most stock
-  generators are 200-500 lines. Documentation isn't the entry
-  point; code is.
-- **Forks become first-class.** A team forks `gen-shadcn-form` to
-  produce `gen-acme-form`. Six months later they don't merge
-  changes back — they don't have to. The fork is *their generator*.
+- **Full control.** Want to change how nullable is encoded? Edit the source.
+  Want to rename `useGetUsers` to `useUsers`? Edit the source. No flag, no
+  plugin, no PR upstream.
+- **Lives like app code.** The cloned generator is TypeScript in your repo. Code
+  review, refactoring tools, grep, git blame — all work normally.
+- **No upgrade-surface lock-in.** The engine API stays small and stable (Apache
+  2.0 with patent grant); cloned generators don't depend on the maintainer
+  adding flags they need.
+- **Discoverable by reading.** Want to know how a generator renders forms? Read
+  its `src/`. The source is short — most stock generators are 200-500 lines.
+  Documentation isn't the entry point; code is.
+- **Forks become first-class.** A team forks `gen-shadcn-form` to produce
+  `gen-acme-form`. Six months later they don't merge changes back — they don't
+  have to. The fork is _their generator_.
 
 ### Cons of cloning
 
-- **No auto-upgrades.** Upstream fixes don't reach cloned
-  generators automatically. Users must manually merge or accept
-  divergence.
-- **Knowledge cost.** Cloning a generator requires reading and
-  modifying TypeScript. A team without TS expertise can't easily
-  customize.
-- **Documentation gradient.** Generic stock-generator docs don't
-  fully apply to clones. Each clone is potentially different from
-  upstream.
-- **Divergence over time.** Five teams cloning `gen-zod` end up
-  with five different generators. Each one valid; collectively
-  not interoperable.
+- **No auto-upgrades.** Upstream fixes don't reach cloned generators
+  automatically. Users must manually merge or accept divergence.
+- **Knowledge cost.** Cloning a generator requires reading and modifying
+  TypeScript. For a team without TS expertise, that is a real barrier to
+  customizing.
+- **Documentation gradient.** Generic stock-generator docs don't fully apply to
+  clones. Each clone is potentially different from upstream.
+- **Divergence over time.** Five teams cloning `gen-zod` end up with five
+  different generators. Each one valid; collectively not interoperable.
 
 ## How SKMTC mitigates the cloning downsides
 
-The model isn't "ship source code and hope for the best." Several
-choices reduce the friction:
+The model isn't "ship source code and hope for the best." Several choices reduce
+the friction:
 
-- **Stock generators are intentionally small.** Most are 200-500
-  lines of TypeScript. The maintenance overhead of cloning one is
-  low. Compare with cloning a 5,000-line generator with deep
-  inheritance — that's untenable, and SKMTC's generators stay
-  under that ceiling on purpose.
-- **The engine API (`@skmtc/core`) is stable.** Apache 2.0
-  licensed, semver-honored, intentionally small. Cloned
-  generators depend on `@skmtc/core` directly, so its stability is
-  load-bearing. Breaking changes are rare and announced.
-- **The licensing split signals intent.** Engine: Apache 2.0
-  (patent grant, contributor CLA appropriate). Stock generators:
-  MIT (permissive, fork-friendly). The asymmetry tells users
-  exactly which parts to treat as platform vs which to treat as
-  templates.
-- **Enrichments cover per-instance customization without
-  requiring a clone.** When the customization is "this operation's
-  form has a different submit label," enrichments handle it via
-  `client.json`. Cloning is only required when *behavior* differs,
-  not when *content* differs.
-- **JSR makes the install-then-clone flow frictionless.** Install
-  via `skmtc install` to read the source. Clone via
-  `skmtc clone` when you decide to customize.
+- **Stock generators are intentionally small.** Most are 200-500 lines of
+  TypeScript. The maintenance overhead of cloning one is low. Compare with
+  cloning a 5,000-line generator with deep inheritance — that's untenable, and
+  SKMTC's generators stay under that ceiling on purpose.
+- **The engine API (`@skmtc/core`) is stable.** Apache 2.0 licensed,
+  semver-honored, intentionally small. Cloned generators depend on `@skmtc/core`
+  directly, so its stability is load-bearing. Breaking changes are rare and
+  announced.
+- **The licensing split signals intent.** Engine: Apache 2.0 (patent grant,
+  contributor CLA appropriate). Stock generators: MIT (permissive,
+  fork-friendly). The asymmetry tells users exactly which parts to treat as
+  platform vs which to treat as templates.
+- **Enrichments cover per-instance customization without requiring a clone.**
+  When the customization is "this operation's form has a different submit
+  label," enrichments handle it via `client.json`. Cloning is only required when
+  _behavior_ differs, not when _content_ differs.
+- **JSR makes the install-then-clone flow frictionless.** Install via
+  `skmtc install` to read the source. Clone via `skmtc clone` when you decide to
+  customize.
 
 ## The mechanical reason stock generators stay small
 
-The pros/cons above describe the philosophy. The mechanical reason
-SKMTC actively *resists* adding configuration flags to stock generators
-is concrete: every config flag is a runtime branch every consumer
-bundles.
+The pros/cons above describe the philosophy. The mechanical reason SKMTC
+actively _resists_ adding configuration flags to stock generators is concrete:
+every config flag is a runtime branch every consumer bundles.
 
-A `toMyGenEntry({ emitDocument?: boolean })` flag on a stock generator
-expands into something like:
+A `toMyGenEntry({ emitDocument?: boolean })` flag on a stock generator expands
+into something like:
 
 ```ts
 if (config.emitDocument) {
-  context.insertOperation({ projection: DocumentProjection, operation })
+  context.insertOperation({ projection: DocumentProjection, operation });
 }
-context.insertOperation({ projection: ResultProjection, operation })
+context.insertOperation({ projection: ResultProjection, operation });
 ```
 
-Whichever value any one consumer passes, the bundled generator code
-keeps both branches. Every consumer's `bundle.js` carries the runtime
-check and the dead-code-eliminated other path. The flag is shared
-infrastructure for a binary decision that — once the consumer has
-made it — they will never change.
+Whichever value any one consumer passes, the bundled generator code keeps both
+branches. Every consumer's `bundle.js` carries the runtime check and the
+dead-code-eliminated other path. The flag is shared infrastructure for a binary
+decision that — once the consumer has made it — they will never change.
 
-Cloning resolves the branch at source-edit time. The clone keeps the
-branch it wants; the other branch is deleted. The cloned generator's
-runtime is smaller, the unwanted Definition never registers, and the
-customization is greppable in one file.
+Cloning resolves the branch at source-edit time. The clone keeps the branch it
+wants; the other branch is deleted. The cloned generator's runtime is smaller,
+the unwanted Definition never registers, and the customization is greppable in
+one file.
 
 ### The diagnostic question for a config flag
 
-When a stock-generator author considers adding a flag, the test is:
-*would two consumers of this package legitimately set this flag to
-different values?*
+When a stock-generator author considers adding a flag, the test is: _would two
+consumers of this package legitimately set this flag to different values?_
 
-- **If yes**, the configuration is **parametric** — the values vary
-  per consumer's input, the shape of the configuration is the same
-  across consumers, and only the values differ. Example:
-  `toTypescriptEntry({ scalars: {...} })`. Each consumer's API has
-  different scalar names; the names cannot be hardcoded. This is the
-  legitimate role of generator-level config: parameters that no
+- **If yes**, the configuration is **parametric** — the values vary per
+  consumer's input, the shape of the configuration is the same across consumers,
+  and only the values differ. Example: `toTypescriptEntry({ scalars: {...} })`.
+  Each consumer's API has different scalar names; the names cannot be hardcoded.
+  This is the legitimate role of generator-level config: parameters that no
   reasonable consumer could share.
 
-- **If no**, the flag is a **binary feature toggle** — the author is
-  trying to ship two slightly different generators in one package.
-  Clone-to-customize handles this naturally. The first consumer
-  clones and keeps the feature; the second consumer clones and
-  removes it. Neither pays the cost of the other's branch.
+- **If no**, the flag is a **binary feature toggle** — the author is trying to
+  ship two slightly different generators in one package. Clone-to-customize
+  handles this naturally. The first consumer clones and keeps the feature; the
+  second consumer clones and removes it. Neither pays the cost of the other's
+  branch.
 
-Per-operation enrichments occupy a separate axis — they're per-instance
-content (label, description, submit text), not per-consumer behavior.
-Enrichments don't trigger this test; they're how SKMTC handles content
-variation without requiring a clone.
+Per-operation enrichments occupy a separate axis — they're per-instance content
+(label, description, submit text), not per-consumer behavior. Enrichments don't
+trigger this test; they're how SKMTC handles content variation without requiring
+a clone.
 
 ## When this is the wrong choice
 
-The cloning model assumes a certain kind of team and a certain
-kind of project. It's wrong when:
+The cloning model assumes a certain kind of team and a certain kind of project.
+It's wrong when:
 
-- **You have hundreds of consumers needing centralized control.**
-  An internal API team with 50 downstream consumers can't ship
-  source-code generators; the consumers would all diverge. Use
-  configuration-driven codegen with a strict maintained schema.
-- **Your team can't read or write TypeScript.** Cloning assumes
-  TS literacy. Mixed-skill teams may benefit from a more
-  config-driven tool.
-- **You need cross-team consistency more than per-team
-  flexibility.** If "every team must produce hooks the same way" is a
-  hard requirement, a configurable tool with no escape hatches is
-  safer than a cloneable tool with infinite escape hatches.
-- **Your generator changes weekly.** Frequent updates favor auto-
-  upgrade. Cloned generators amortize the merge cost — fine if
-  you clone once and maintain it; painful if upstream churns.
-- **You're building a SaaS that generates code for thousands of
-  customers.** Cloning would need to happen per-customer, which
-  is operationally heavy. A configuration-based tool fits SaaS
-  better.
+- **You have hundreds of consumers needing centralized control.** An internal
+  API team with 50 downstream consumers can't ship source-code generators; the
+  consumers would all diverge. Use configuration-driven codegen with a strict
+  maintained schema.
+- **Your team can't read or write TypeScript.** Cloning assumes TS literacy.
+  Mixed-skill teams may benefit from a more config-driven tool.
+- **You need cross-team consistency more than per-team flexibility.** If "every
+  team must produce hooks the same way" is a hard requirement, a configurable
+  tool with no escape hatches is safer than a cloneable tool with infinite
+  escape hatches.
+- **Your generator changes weekly.** Frequent updates favor auto- upgrade.
+  Cloned generators amortize the merge cost — fine if you clone once and
+  maintain it; painful if upstream churns.
+- **You're building a SaaS that generates code for thousands of customers.**
+  Cloning would need to happen per-customer, which is operationally heavy. A
+  configuration-based tool fits SaaS better.
 
 SKMTC is designed for teams that:
 
-- Are small enough that one or a few engineers can own the
-  generator code
+- Are small enough that one or a few engineers can own the generator code
 - Want full control over generated code's style and conventions
 - Are willing to read and write TypeScript
 - Prefer source-code transparency over configuration abstraction
 
-If that's your team, the cloning model is freedom. If it isn't,
-the configuration model is freedom. Different tools, different
-constraints.
+If that's your team, the cloning model is freedom. If it isn't, the
+configuration model is freedom. Different tools, different constraints.
 
 ## A note on the configuration-vs-cloning spectrum
 
@@ -251,22 +228,21 @@ openapi-generator         kubb, hey-api               SKMTC
 orval                                                shadcn/ui
 ```
 
-Tools further left optimize for low-friction default usage at the
-cost of customization depth. Tools further right optimize for
-customization depth at the cost of upgrade ergonomics. SKMTC is
-explicitly at the right end of this spectrum — not because it's a
-better point, but because it's the right point for its target
-user.
+Tools further left optimize for low-friction default usage at the cost of
+customization depth. Tools further right optimize for customization depth at the
+cost of upgrade ergonomics. SKMTC is explicitly at the right end of this
+spectrum — not because it's a better point, but because it's the right point for
+its target user.
 
 ## See also
 
-- [Design philosophy](design-philosophy.md) — the broader principle
-  set this fits into
-- [Clone vs install concept](../concepts/clone-vs-install.md) —
-  practical guidance on which command to use
+- [Design philosophy](design-philosophy.md) — the broader principle set this
+  fits into
+- [Clone vs install concept](../concepts/clone-vs-install.md) — practical
+  guidance on which command to use
 - [Generators as packages concept](../concepts/generators-as-packages.md) —
   package shape and lifecycle
-- [Comparison to other tools](comparison-to-other-tools.md) — how
-  SKMTC's position compares against the codegen landscape
-- [`skmtc-generator` skill](../skills/skmtc-generator/SKILL.md) —
-  operational guide for cloning and authoring
+- [Comparison to other tools](comparison-to-other-tools.md) — how SKMTC's
+  position compares against the codegen landscape
+- [`skmtc-generator` skill](../skills/skmtc-generator/SKILL.md) — operational
+  guide for cloning and authoring

--- a/deno/docs/reference/api/to-artifacts.md
+++ b/deno/docs/reference/api/to-artifacts.md
@@ -1,16 +1,14 @@
 # toArtifacts
 
-> The top-level engine function that runs the SKMTC generation
-> pipeline end-to-end: **Parse → Generate → Render**. Returns the
-> generated artifacts and the manifest. This is what the Worker
-> invokes on `GENERATE` message receipt; direct callers (bench
-> scripts, embedded use cases) can also invoke it.
+> The top-level engine function that runs the SKMTC generation pipeline
+> end-to-end: **Parse → Generate → Render**. Returns the generated artifacts and
+> the manifest. This is what the Worker invokes on `GENERATE` message receipt;
+> direct callers (bench scripts, embedded use cases) can also invoke it.
 
-Everything before `toArtifacts` (the CLI, the Worker bootstrap, the
-generator map construction) is orchestration. Everything after it
-is the engine. The function takes a parsed OAS-or-GQL document, a
-client settings object, and a generator map factory — and produces
-the artifacts and manifest.
+Everything before `toArtifacts` (the CLI, the Worker bootstrap, the generator
+map construction) is orchestration. Everything after it is the engine. The
+function takes a parsed OAS-or-GQL document, a client settings object, and a
+generator map factory — and produces the artifacts and manifest.
 
 ## Source
 
@@ -20,65 +18,63 @@ the artifacts and manifest.
 
 ```ts
 export async function toArtifacts<E = undefined>(
-  args: TransformArgs<E>
+  args: TransformArgs<E>,
 ): Promise<{
-  artifacts: Record<string, string>
-  manifest: ManifestContent
-}>
+  artifacts: Record<string, string>;
+  manifest: ManifestContent;
+}>;
 
 export type TransformArgs<E> = {
-  traceId: string
-  spanId: string
-  document: SkmtcDocumentInput
-  settings: ClientSettings | undefined
-  logsPath?: string
-  stackTrail: StackTrail
-  toGeneratorConfigMap: () => GeneratorsMapContainer<E>
-  startAt: number
-  silent: boolean
-}
+  traceId: string;
+  spanId: string;
+  document: SkmtcDocumentInput;
+  settings: ClientSettings | undefined;
+  logsPath?: string;
+  stackTrail: StackTrail;
+  toGeneratorConfigMap: () => GeneratorsMapContainer<E>;
+  startAt: number;
+  silent: boolean;
+};
 ```
 
 ## Parameters
 
 ### `traceId` and `spanId`
 
-Tracing IDs propagated from the CLI invocation. They thread through
-the `StackTrail` and end up in log lines (when logging is enabled),
-making it possible to correlate engine output with CLI runs.
+Tracing IDs propagated from the CLI invocation. They thread through the
+`StackTrail` and end up in log lines (when logging is enabled), making it
+possible to correlate engine output with CLI runs.
 
-The CLI generates a fresh `traceId` per invocation and a fresh
-`spanId` per child operation. Direct callers can pass any
-unique-enough strings (e.g., timestamps + nonces).
+The CLI generates a fresh `traceId` per invocation and a fresh `spanId` per
+child operation. Direct callers can pass any unique-enough strings (e.g.,
+timestamps + nonces).
 
 ### `document`
 
-The parsed input document. Accepts either an OAS document object or
-a GraphQL schema string:
+The parsed input document. Accepts either an OAS document object or a GraphQL
+schema string:
 
 ```ts
 type SkmtcDocumentInput =
-  | { type: 'oas'; value: OpenAPIV3.Document<Record<string, never>> }
-  | { type: 'gql'; value: string | GraphQLSchema }
+  | { type: "oas"; value: OpenAPIV3.Document<Record<string, never>> }
+  | { type: "gql"; value: string | GraphQLSchema };
 ```
 
-Both variants carry the source as `value` — the field name is
-uniform across protocols. For OAS, `value` is a normalized
-`OpenAPIV3.Document` (Swagger 2 / OAS 3.1 inputs are
-auto-converted to 3.0 by `@skmtc/convert` before reaching this
-boundary). For GraphQL, `value` is either an SDL string (parsed
-via `buildSchema` inside the pipeline) or a pre-built
-`GraphQLSchema` instance (used as-is).
+Both variants carry the source as `value` — the field name is uniform across
+protocols. For OAS, `value` is a normalized `OpenAPIV3.Document` (Swagger 2 /
+OAS 3.1 inputs are auto-converted to 3.0 by `@skmtc/convert` before reaching
+this boundary). For GraphQL, `value` is either an SDL string (parsed via
+`buildSchema` inside the pipeline) or a pre-built `GraphQLSchema` instance (used
+as-is).
 
 The post-parse internal shape is the parallel
-[`SkmtcParsedDocument`](../../concepts/the-three-phases.md) union,
-which also keys the protocol payload on `value` (`OasDocument` or
-`GqlDocument`).
+[`SkmtcParsedDocument`](../../concepts/the-three-phases.md) union, which also
+keys the protocol payload on `value` (`OasDocument` or `GqlDocument`).
 
 ### `settings`
 
-The validated [`ClientSettings`](../settings/client-json-schema.md)
-from `client.json`. Carries:
+The validated [`ClientSettings`](../settings/client-json-schema.md) from
+`client.json`. Carries:
 
 - `basePath` — the output directory (relative to the manifest root)
 - `paths` — per-operation path overrides
@@ -86,102 +82,99 @@ from `client.json`. Carries:
 - `skip` — operations to skip
 - `exclude` — components to exclude
 
-Pass `undefined` when running without a settings file (rare; most
-callers have at least minimal settings).
+Pass `undefined` when running without a settings file (rare; most callers have
+at least minimal settings).
 
 ### `toGeneratorConfigMap`
 
-A **factory function** that returns the generator map. Called by
-`toArtifacts` to obtain the current set of installed generators:
+A **factory function** that returns the generator map. Called by `toArtifacts`
+to obtain the current set of installed generators:
 
 ```ts
 type GeneratorsMapContainer<E> = {
-  generators: Record<string, GeneratorConfigInput<E>>
-}
+  generators: Record<string, GeneratorConfigInput<E>>;
+};
 
-toGeneratorConfigMap: () => GeneratorsMapContainer<E>
+toGeneratorConfigMap: (() => GeneratorsMapContainer<E>);
 ```
 
-**Why a factory function rather than the map directly?** It defers
-construction until the engine is ready to consume it. This lets the
-generator-bundling step (which may run lazily) happen at the right
-point in the pipeline.
+**Why a factory function rather than the map directly?** It defers construction
+until the engine is ready to consume it. This lets the generator-bundling step
+(which may run lazily) happen at the right point in the pipeline.
 
-Each generator config carries its `Entry` (the `toOasOperationEntry`
-/ `toModelEntry` result) and its enrichment schema. The engine
-iterates the map to dispatch work.
+Each generator config carries its `Entry` (the `toOasOperationEntry` /
+`toModelEntry` result) and its enrichment schema. The engine iterates the map to
+dispatch work.
 
 ### `stackTrail`
 
-A `StackTrail` instance threading through Parse and Generate. Carries
-the current "where in the document/generator graph are we" context
-for error messages and diagnostics. See [API: StackTrail](stack-trail.md).
+A `StackTrail` instance threading through Parse and Generate. Carries the
+current "where in the document/generator graph are we" context for error
+messages and diagnostics. See [API: StackTrail](stack-trail.md).
 
-The CLI creates an empty `StackTrail` at the top of `toArtifacts`
-and passes it down.
+The CLI creates an empty `StackTrail` at the top of `toArtifacts` and passes it
+down.
 
 ### `silent`, `logsPath`
 
 #### `logsPath`
 
-When set, structured logs are written to this path during the run.
-When unset, logs are written via console only.
+When set, structured logs are written to this path during the run. When unset,
+logs are written via console only.
 
-The CLI sets `logsPath` to a per-invocation directory under the
-project's `.skmtc/logs/`. Direct callers typically omit it.
+The CLI sets `logsPath` to a per-invocation directory under the project's
+`.skmtc/logs/`. Direct callers typically omit it.
 
 #### `silent`
 
-When `true`, suppresses log output. The CLI sets `silent: false` for
-normal runs; bench scripts and tests typically set `silent: true`.
+When `true`, suppresses log output. The CLI sets `silent: false` for normal
+runs; bench scripts and tests typically set `silent: true`.
 
 #### `startAt`
 
-A `performance.now()` (or `Date.now()`) snapshot taken before
-`toArtifacts` is called. Used for the duration calculation in the
-returned `ManifestContent`. The engine subtracts `startAt` from
-`Date.now()` at the end of the run to compute total elapsed time.
+A `performance.now()` (or `Date.now()`) snapshot taken before `toArtifacts` is
+called. Used for the duration calculation in the returned `ManifestContent`. The
+engine subtracts `startAt` from `Date.now()` at the end of the run to compute
+total elapsed time.
 
 ## Returns
 
 ```ts
 Promise<{
-  artifacts: Record<string, string>
-  manifest: ManifestContent
-}>
+  artifacts: Record<string, string>;
+  manifest: ManifestContent;
+}>;
 ```
 
 ### `artifacts`
 
-Map from absolute artifact path → file contents (string). The path
-keys include the basePath prefix when settings provide it; otherwise
-they're relative to the artifact root.
+Map from absolute artifact path → file contents (string). The path keys include
+the basePath prefix when settings provide it; otherwise they're relative to the
+artifact root.
 
-The CLI writes each `[path, contents]` pair to disk as the post-engine
-step. The engine itself doesn't touch the filesystem — `toArtifacts`
-returns a pure value.
+The CLI writes each `[path, contents]` pair to disk as the post-engine step. The
+engine itself doesn't touch the filesystem — `toArtifacts` returns a pure value.
 
 ### `manifest`
 
 ```ts
 type ManifestContent = {
-  files: Record<string, ManifestFileEntry>
-  durationMs: number
-  diagnostics: DiagnosticItem[]
+  files: Record<string, ManifestFileEntry>;
+  durationMs: number;
+  diagnostics: DiagnosticItem[];
   // ...
-}
+};
 ```
 
 The manifest summarizes what was generated:
 
-- **`files`** — per-artifact metadata (generator key, source operation
-  or component, generation time)
+- **`files`** — per-artifact metadata (generator key, source operation or
+  component, generation time)
 - **`durationMs`** — total elapsed (using `startAt`)
 - **`diagnostics`** — parse and generate issues, severity-ranked
 
-The CLI writes the manifest to `manifest.json` alongside the
-artifacts. Direct callers can inspect it for diagnostics or skip
-writing it.
+The CLI writes the manifest to `manifest.json` alongside the artifacts. Direct
+callers can inspect it for diagnostics or skip writing it.
 
 ## Behavior
 
@@ -195,106 +188,104 @@ toArtifacts
 ```
 
 Each phase creates and tears down its own context (`ParseContext`,
-`GenerateContext`, `RenderContext`). See [the three phases concept](../../concepts/the-three-phases.md)
-for the detailed flow.
+`GenerateContext`, `RenderContext`). See
+[the three phases concept](../../concepts/the-three-phases.md) for the detailed
+flow.
 
-The phases are sequential and synchronous within the engine (the
-function is `async` for I/O readiness, not concurrency). Errors from
-Parse cascade to Generate via `removeErroredItems` (one-hop pruning);
-Generate errors don't cascade to Render — the partial output is
-returned.
+The phases are sequential and synchronous within the engine (the function is
+`async` for I/O readiness, not concurrency). Errors from Parse cascade to
+Generate via `removeErroredItems` (one-hop pruning); Generate errors don't
+cascade to Render — the partial output is returned.
 
 ## Example
 
 ### From a bench script
 
-When you want to measure engine performance without the CLI/worker
-overhead:
+When you want to measure engine performance without the CLI/worker overhead:
 
 ```ts
-import { toArtifacts, StackTrail } from '@skmtc/core'
-import { toGeneratorConfigMap } from './my-generators.ts'
+import { StackTrail, toArtifacts } from "@skmtc/core";
+import { toGeneratorConfigMap } from "./my-generators.ts";
 
-const startAt = performance.now()
+const startAt = performance.now();
 const result = await toArtifacts({
-  traceId: 'bench-001',
-  spanId: 'bench-001',
-  document: { type: 'oas', value: openApiSpec },
+  traceId: "bench-001",
+  spanId: "bench-001",
+  document: { type: "oas", value: openApiSpec },
   settings: clientSettings,
   stackTrail: new StackTrail(),
   toGeneratorConfigMap,
   startAt,
-  silent: true
-})
+  silent: true,
+});
 
 console.log(
-  `Generated ${Object.keys(result.artifacts).length} files in ${result.manifest.durationMs}ms`
-)
+  `Generated ${
+    Object.keys(result.artifacts).length
+  } files in ${result.manifest.durationMs}ms`,
+);
 ```
 
 ### From the Worker
 
-The standard production path. Worker boots, receives `GENERATE`
-message, calls `toArtifacts`, posts result back:
+The standard production path. Worker boots, receives `GENERATE` message, calls
+`toArtifacts`, posts result back:
 
 ```ts
-self.addEventListener('message', async (event) => {
-  if (event.data.type === 'GENERATE') {
-    const { artifacts, manifest } = await toArtifacts(event.data.args)
-    self.postMessage({ type: 'RESULT', artifacts, manifest })
+self.addEventListener("message", async (event) => {
+  if (event.data.type === "GENERATE") {
+    const { artifacts, manifest } = await toArtifacts(event.data.args);
+    self.postMessage({ type: "RESULT", artifacts, manifest });
   }
-})
+});
 ```
 
 This is what `skmtc generate` triggers.
 
 ### From tests
 
-Tests of generator behavior typically build a minimal `openApiSpec`
-fixture, call `toArtifacts`, and assert on
-`result.artifacts['some/path.ts']`:
+Tests of generator behavior typically build a minimal `openApiSpec` fixture,
+call `toArtifacts`, and assert on `result.artifacts['some/path.ts']`:
 
 ```ts
-test('zod generator produces userBody for User schema', async () => {
+test("zod generator produces userBody for User schema", async () => {
   const result = await toArtifacts({
-    traceId: 't',
-    spanId: 't',
-    document: { type: 'oas', value: minimalSpec },
+    traceId: "t",
+    spanId: "t",
+    document: { type: "oas", value: minimalSpec },
     settings: undefined,
     stackTrail: new StackTrail(),
     toGeneratorConfigMap: () => ({ generators: { zod: ZodEntry } }),
     startAt: 0,
-    silent: true
-  })
+    silent: true,
+  });
 
-  expect(result.artifacts['models/User.generated.ts']).toContain('z.object')
-})
+  expect(result.artifacts["models/User.generated.ts"]).toContain("z.object");
+});
 ```
 
 ## Common questions
 
-### Why does `toArtifacts` need a `toGeneratorConfigMap` *function* rather than just a map?
+### Why does `toArtifacts` need a `toGeneratorConfigMap` _function_ rather than just a map?
 
-Deferred construction. The map factory is called once, at the top of
-the engine run, after Parse has produced the document. This lets
-generator initialization happen lazily — useful when generator
-construction is expensive, when generator selection depends on
-runtime state, or when the engine needs to control the timing of
-side effects in generator entry code.
+Deferred construction. The map factory is called once, at the top of the engine
+run, after Parse has produced the document. This lets generator initialization
+happen lazily — useful when generator construction is expensive, when generator
+selection depends on runtime state, or when the engine needs to control the
+timing of side effects in generator entry code.
 
-In practice, most callers' factories are simply
-`() => ({ generators: {...} })` with a static map. The function
-indirection has minimal cost.
+In practice, most callers' factories are `() => ({ generators: {...} })` with a
+static map. The function indirection has minimal cost.
 
 ### Does `toArtifacts` write to disk?
 
 No. The function is pure: it returns artifacts as in-memory
-`Record<path, contents>`. Disk writes happen in the CLI's
-worker-result handler, after `toArtifacts` returns.
+`Record<path, contents>`. Disk writes happen in the CLI's worker-result handler,
+after `toArtifacts` returns.
 
-This separation makes the engine testable (no fs cleanup) and
-embeddable (callers can route artifacts to any sink — git commits,
-in-memory diffs, S3, etc.).
+This separation makes the engine testable (no fs cleanup) and embeddable
+(callers can route artifacts to any sink — git commits, in-memory diffs, S3,
+etc.).
 
 ### What's the relationship between `toArtifacts` and the CLI?
 
@@ -303,61 +294,59 @@ The CLI handles:
 1. Bootstrap (load `deno.json`, `client.json`)
 2. Pre-parse OAS host-side (for the `structuredClone` reason)
 3. Spawn the worker
-4. Pass the args (which include the pre-parsed document) to the
-   worker
+4. Pass the args (which include the pre-parsed document) to the worker
 5. Worker calls `toArtifacts`
 6. CLI receives the result and persists artifacts + manifest
 
 `toArtifacts` is step 5. Steps 1–4 and 6 are CLI orchestration. See
-[the three phases](../../concepts/the-three-phases.md) for the
-full lifecycle.
+[the three phases](../../concepts/the-three-phases.md) for the full lifecycle.
 
 ### Why `async` if the phases are synchronous?
 
-The `async` is there for the few I/O moments the engine might invoke
-(e.g., dynamic generator loading in some paths). It's not used for
-concurrency between phases — the phases run sequentially.
+The `async` is there for the few I/O moments the engine might invoke (e.g.,
+dynamic generator loading in some paths). It's not used for concurrency between
+phases — the phases run sequentially.
 
-The `async` also gives the function a future-compatible signature:
-if any phase later needs awaitable work, the caller signature
-doesn't change.
+The `async` also gives the function a future-compatible signature: if any phase
+later needs awaitable work, the caller signature doesn't change.
 
 ### Can I run multiple `toArtifacts` invocations in parallel?
 
-Yes, but each call should get fresh `StackTrail` and unique
-`traceId` instances. The function itself is reentrant — its
-in-memory state lives in the contexts it creates, not in module
-globals.
+Yes, but each call should get fresh `StackTrail` and unique `traceId` instances.
+The function itself is reentrant — its in-memory state lives in the contexts it
+creates, not in module globals.
 
-In practice, parallelism across invocations is uncommon. The Worker
-serves one request at a time, and bench scripts typically run
-sequentially.
+In practice, parallelism across invocations is uncommon. The Worker serves one
+request at a time, and bench scripts typically run sequentially.
 
 ## Related types
 
 ```ts
 type SkmtcDocumentInput =
-  | { type: 'oas'; value: OpenAPIV3.Document<Record<string, never>> }
-  | { type: 'gql'; value: string | GraphQLSchema }
+  | { type: "oas"; value: OpenAPIV3.Document<Record<string, never>> }
+  | { type: "gql"; value: string | GraphQLSchema };
 
 type GeneratorsMapContainer<E> = {
-  generators: Record<string, GeneratorConfigInput<E>>
-}
+  generators: Record<string, GeneratorConfigInput<E>>;
+};
 
 type ManifestContent = {
-  files: Record<string, ManifestFileEntry>
-  durationMs: number
-  diagnostics: DiagnosticItem[]
-}
+  files: Record<string, ManifestFileEntry>;
+  durationMs: number;
+  diagnostics: DiagnosticItem[];
+};
 ```
 
 ## See also
 
-- [The three phases concept](../../concepts/the-three-phases.md) — Parse → Generate → Render in detail
-- [The worker runtime concept](../../concepts/the-worker-runtime.md) — how toArtifacts is invoked
+- [The three phases concept](../../concepts/the-three-phases.md) — Parse →
+  Generate → Render in detail
+- [The worker runtime concept](../../concepts/the-worker-runtime.md) — how
+  toArtifacts is invoked
 - [API: ParseContext](parse-context.md) — phase 1
 - [API: GenerateContext](generate-context.md) — phase 2
 - [API: RenderContext](render-context.md) — phase 3
 - [API: StackTrail](stack-trail.md) — tracing parameter
-- [Reference: client.json schema](../settings/client-json-schema.md) — what `settings` carries
+- [Reference: client.json schema](../settings/client-json-schema.md) — what
+  `settings` carries
 - [Glossary: toArtifacts, Manifest, Artifact](../glossary.md)

--- a/deno/docs/skills/README.md
+++ b/deno/docs/skills/README.md
@@ -1,145 +1,137 @@
 # Skills
 
-Operational skills that guide AI assistants working with SKMTC.
-Each skill is a subdirectory containing:
+Operational skills that guide AI assistants working with SKMTC. Each skill is a
+subdirectory containing:
 
-- `SKILL.md` — the loadable skill artifact with YAML frontmatter
-  (`name`, `version`, `description`, `allowed-tools`) and operational
-  content
-- `design.md` — design document describing what the skill should
-  contain, rationale for content boundaries, content-source mapping,
-  and open questions
+- `SKILL.md` — the loadable skill artifact with YAML frontmatter (`name`,
+  `version`, `description`, `allowed-tools`) and operational content
+- `design.md` — design document describing what the skill should contain,
+  rationale for content boundaries, content-source mapping, and open questions
 - `commands/` — optional slash command files for explicit invocation
 
 This directory is the canonical home for skills. The previous location
-`skmtc-platform/packages/skmtc-*-skill/` is legacy and has been
-superseded.
+`skmtc-platform/packages/skmtc-*-skill/` is legacy and has been superseded.
 
 ## The skill ecosystem
 
-| Skill | Purpose | Audience | Status |
-|---|---|---|---|
-| [`skmtc-architecture/`](skmtc-architecture/) | System mental model — what SKMTC is, how the engine works, how to build infrastructure around it | Infrastructure builders | **SKILL.md authored** (v0.1.0) |
-| [`skmtc-cli/`](skmtc-cli/) | Guide CLI usage — install, configure, run, integrate | Users (`using/`) | **SKILL.md authored** (v0.2.0); pulled from legacy + new content |
-| [`skmtc-generator/`](skmtc-generator/) | Guide generator authoring and editing | Authors (`extending/`) | **SKILL.md authored** (full: operational principles, scaffolds, task cards, variants) |
-| [`skmtc-debug/`](skmtc-debug/) | Diagnose failures — no output, wrong output, errors | Anyone debugging | **SKILL.md authored** (verify-first stance) |
-| [`skmtc-retro/`](skmtc-retro/) | Capture session friction/wins to friction log | Anyone (end of session) | Authored (v0.1.0); includes `/skmtc-retro` slash command |
-| [`skmtc-lang-typescript/`](skmtc-lang-typescript/) | The TypeScript target-language layer — the shape of emitted TS | Generator authors | Authored; the TEMPLATE for `skmtc-lang-<X>` skills |
-| [`skmtc-lang-kotlin/`](skmtc-lang-kotlin/) | The Kotlin target-language layer — the shape of emitted Kotlin | Generator authors | **SKILL.md authored** (v0.2.0; production through the milestone arc — lang-kotlin 0.5.0, gen-kotlin + gen-kotlin-spring) |
-| [`skmtc-lang-csharp/`](skmtc-lang-csharp/) | The C# target-language layer — the shape of emitted C# | Generator authors | **SKILL.md authored** (CS-A; lang-csharp 0.1.0 + gen-csharp 0.0.1) |
+| Skill                                              | Purpose                                                                                                                                                                                  | Audience                | Status                                                                                                                                                            |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`skmtc-architecture/`](skmtc-architecture/)       | System mental model — what SKMTC is, how the engine works, how to build infrastructure around it                                                                                         | Infrastructure builders | **SKILL.md authored** (v0.1.0)                                                                                                                                    |
+| [`skmtc-cli/`](skmtc-cli/)                         | Guide CLI usage — install, configure, run, integrate                                                                                                                                     | Users (`using/`)        | **SKILL.md authored** (v0.2.0); pulled from legacy + new content                                                                                                  |
+| [`skmtc-generator/`](skmtc-generator/)             | Guide generator authoring and editing                                                                                                                                                    | Authors (`extending/`)  | **SKILL.md authored** (full: operational principles, scaffolds, task cards, variants)                                                                             |
+| [`skmtc-debug/`](skmtc-debug/)                     | Diagnose failures — no output, wrong output, errors                                                                                                                                      | Anyone debugging        | **SKILL.md authored** (verify-first stance)                                                                                                                       |
+| [`skmtc-retro/`](skmtc-retro/)                     | Capture session friction/wins to friction log                                                                                                                                            | Anyone (end of session) | Authored (v0.1.0); includes `/skmtc-retro` slash command                                                                                                          |
+| [`skmtc-lang-typescript/`](skmtc-lang-typescript/) | The TypeScript target-language layer — the shape of emitted TS                                                                                                                           | Generator authors       | Authored; the TEMPLATE for `skmtc-lang-<X>` skills                                                                                                                |
+| [`skmtc-lang-kotlin/`](skmtc-lang-kotlin/)         | The Kotlin target-language layer — the shape of emitted Kotlin                                                                                                                           | Generator authors       | **SKILL.md authored** (v0.2.0; production through the milestone arc — lang-kotlin 0.5.0, gen-kotlin + gen-kotlin-spring)                                          |
+| [`skmtc-lang-csharp/`](skmtc-lang-csharp/)         | The C# target-language layer — the shape of emitted C#                                                                                                                                   | Generator authors       | **SKILL.md authored** (CS-A; lang-csharp 0.1.0 + gen-csharp 0.0.1)                                                                                                |
+| [`docs-writing/`](docs-writing/)                   | Documentation craft — audience, Diátaxis content types + compass, style/word rules, procedures, structure for humans + AI, API docs, page templates, mechanical enforcement, maintenance | Anyone writing docs     | **SKILL.md authored** (v0.2.0; Mintlify + Diátaxis + Google/Microsoft style guides + EPPO + WTD + Docs for Developers; companions `templates.md`, `mechanics.md`) |
 
-All four skills now live in this directory. The retro skill was moved
-here from `skmtc-platform/packages/skmtc-retro-skill/`. The cli skill
-was authored anew (content distilled from the legacy 1096-line file);
-generator and debug skills are skeletal stubs awaiting fuller content.
+All four skills now live in this directory. The retro skill was moved here from
+`skmtc-platform/packages/skmtc-retro-skill/`. The cli skill was authored anew
+(content distilled from the legacy 1096-line file); generator and debug skills
+are skeletal stubs awaiting fuller content.
 
 ## How skills relate to docs
 
-Skills are the **operational layer**; docs are the **reference
-layer**. The structural difference shapes the content split:
+Skills are the **operational layer**; docs are the **reference layer**. The
+structural difference shapes the content split:
 
-- **Skills push.** Loaded automatically by intent matching. Constrained
-  by working-context budget. Used at the moment of acting.
+- **Skills push.** Loaded automatically by intent matching. Constrained by
+  working-context budget. Used at the moment of acting.
 - **Docs pull.** Loaded on demand (Read tool, navigation). Length-
   unconstrained. Used when investigating.
 
 ### Content split
 
-| Content type | Skill | `llms.md` | Reference docs | Concept docs | Explanation docs | Tutorials / recipes |
-|---|---|---|---|---|---|---|
-| API signatures (full) | — | — | ✓ canonical | — | — | — |
-| API signatures (top 3–5) | ✓ inline | ✓ inline | ✓ canonical | — | — | — |
-| Operational principles | ✓ canonical (per skill) | ✓ canonical (full) | — | — | — | — |
-| Decision trees | ✓ canonical | ✓ | — | — | — | — |
-| Anti-patterns (top ~10) | ✓ | ✓ canonical (full) | — | — | — | — |
-| Code scaffolds | ✓ canonical | — | — | — | — | (in tutorials) |
-| Mental models (compressed) | ✓ | ✓ | — | — | — | — |
-| Mental models (full) | — | — | — | ✓ canonical | — | — |
-| Design rationale | — | — | — | — | ✓ canonical | — |
-| Tradeoffs accepted, alternatives rejected | — | — | — | — | ✓ canonical | — |
-| Tutorials, recipes | (pointers) | — | — | — | — | ✓ canonical |
-| Per-command reference | (one-liners) | — | ✓ canonical | — | — | — |
-| Per-generator reference | (one-liners) | — | ✓ canonical | — | — | — |
-| Trigger phrases / skill metadata | ✓ canonical | — | — | — | — | — |
+| Content type                              | Skill                   | `llms.md`          | Reference docs | Concept docs | Explanation docs | Tutorials / recipes |
+| ----------------------------------------- | ----------------------- | ------------------ | -------------- | ------------ | ---------------- | ------------------- |
+| API signatures (full)                     | —                       | —                  | ✓ canonical    | —            | —                | —                   |
+| API signatures (top 3–5)                  | ✓ inline                | ✓ inline           | ✓ canonical    | —            | —                | —                   |
+| Operational principles                    | ✓ canonical (per skill) | ✓ canonical (full) | —              | —            | —                | —                   |
+| Decision trees                            | ✓ canonical             | ✓                  | —              | —            | —                | —                   |
+| Anti-patterns (top ~10)                   | ✓                       | ✓ canonical (full) | —              | —            | —                | —                   |
+| Code scaffolds                            | ✓ canonical             | —                  | —              | —            | —                | (in tutorials)      |
+| Mental models (compressed)                | ✓                       | ✓                  | —              | —            | —                | —                   |
+| Mental models (full)                      | —                       | —                  | —              | ✓ canonical  | —                | —                   |
+| Design rationale                          | —                       | —                  | —              | —            | ✓ canonical      | —                   |
+| Tradeoffs accepted, alternatives rejected | —                       | —                  | —              | —            | ✓ canonical      | —                   |
+| Tutorials, recipes                        | (pointers)              | —                  | —              | —            | —                | ✓ canonical         |
+| Per-command reference                     | (one-liners)            | —                  | ✓ canonical    | —            | —                | —                   |
+| Per-generator reference                   | (one-liners)            | —                  | ✓ canonical    | —            | —                | —                   |
+| Trigger phrases / skill metadata          | ✓ canonical             | —                  | —              | —            | —                | —                   |
 
-**Rule of thumb:** anything an LLM might need *at the moment of
-acting* goes in the skill. Anything the LLM (or a human) might need
-*when investigating* goes in the docs.
+**Rule of thumb:** anything an LLM might need _at the moment of acting_ goes in
+the skill. Anything the LLM (or a human) might need _when investigating_ goes in
+the docs.
 
 ## Selective duplication policy
 
-Critical operational claims appear in multiple places. This is
-intentional, not accidental:
+Critical operational claims appear in multiple places. This is intentional, not
+accidental:
 
-1. **LLMs don't reliably follow links during single-shot reading.** A
-   skill that says "see `design-philosophy.md`" is, in practice,
-   equivalent to a skill that omits the philosophy.
-2. **Positional attention favors content high in the loaded artifact.**
-   Critical content needs to appear *high* in multiple artifacts to
-   survive attention drift.
-3. **Cost asymmetry.** A stale skill produces bad output every time
-   it's invoked. A stale reference doc just confuses one human reading
-   it. The maintenance investment in skill accuracy is justified.
+1. **LLMs don't reliably follow links during single-shot reading.** A skill that
+   says "see `design-philosophy.md`" is, in practice, equivalent to a skill that
+   omits the philosophy.
+2. **Positional attention favors content high in the loaded artifact.** Critical
+   content needs to appear _high_ in multiple artifacts to survive attention
+   drift.
+3. **Cost asymmetry.** A stale skill produces bad output every time it's
+   invoked. A stale reference doc just confuses one human reading it. The
+   maintenance investment in skill accuracy is justified.
 
 ### What gets duplicated
 
-- **The five facts that override default LLM intuitions** — top of
-  every skill, plus `llms.md`. Canonical in `llms.md`.
-- **The operational principles table** — full version in
-  `llms.md`; subset in each skill, weighted to the skill's audience.
-  Canonical in `llms.md`.
-- **Decision trees** — same content in skill and in `llms.md`.
-  Canonical in skill (since they're operational).
-- **Top ~10 anti-patterns with failure modes** — in skill;
-  full catalog in `llms.md`. Canonical in `llms.md`.
+- **The five facts that override default LLM intuitions** — top of every skill,
+  plus `llms.md`. Canonical in `llms.md`.
+- **The operational principles table** — full version in `llms.md`; subset in
+  each skill, weighted to the skill's audience. Canonical in `llms.md`.
+- **Decision trees** — same content in skill and in `llms.md`. Canonical in
+  skill (since they're operational).
+- **Top ~10 anti-patterns with failure modes** — in skill; full catalog in
+  `llms.md`. Canonical in `llms.md`.
 
 ### Drift management
 
-Each duplicated artifact has one designated canonical home. Other
-places derive from it. When the canonical version updates, the
-derivatives should be reviewed. This is a manual discipline today; a
-CI lint comparing hash-of-table-rendered could enforce it if drift
-becomes a problem.
+Each duplicated artifact has one designated canonical home. Other places derive
+from it. When the canonical version updates, the derivatives should be reviewed.
+This is a manual discipline today; a CI lint comparing hash-of-table-rendered
+could enforce it if drift becomes a problem.
 
 ## Boundaries between skills
 
-Skills overlap in trigger conditions but should have clear primary
-ownership:
+Skills overlap in trigger conditions but should have clear primary ownership:
 
-- **skmtc-architecture** owns: the system mental model — what SKMTC
-  is, how the engine works, how to build infrastructure around it.
-  The "understand the system" path; precedes the other three.
-- **skmtc-cli** owns: installing, configuring, running, integrating
-  with CI. The "normal usage" path.
-- **skmtc-generator** owns: writing, cloning, editing generator code.
-  The "extending" path.
-- **skmtc-debug** owns: diagnosing failures. The "broken" path. Applies
-  across both cli and generator contexts.
-- **skmtc-retro** owns: end-of-session reflection. The "what did we
-  learn" path. Distinct from all three by being meta-work.
+- **skmtc-architecture** owns: the system mental model — what SKMTC is, how the
+  engine works, how to build infrastructure around it. The "understand the
+  system" path; precedes the other three.
+- **skmtc-cli** owns: installing, configuring, running, integrating with CI. The
+  "normal usage" path.
+- **skmtc-generator** owns: writing, cloning, editing generator code. The
+  "extending" path.
+- **skmtc-debug** owns: diagnosing failures. The "broken" path. Applies across
+  both cli and generator contexts.
+- **skmtc-retro** owns: end-of-session reflection. The "what did we learn" path.
+  Distinct from all three by being meta-work.
 
-When triggers overlap (e.g., "my generator's output is wrong" — is
-that generator or debug?), the principle is: **whichever skill's
-operational stance the LLM should be in.** "My generator's output is
-wrong" → debug, because the verify-first stance is required.
+When triggers overlap (e.g., "my generator's output is wrong" — is that
+generator or debug?), the principle is: **whichever skill's operational stance
+the LLM should be in.** "My generator's output is wrong" → debug, because the
+verify-first stance is required.
 
 ## How outlines (this directory) relate to live skills
 
-Each outline file in this directory describes what the corresponding
-`SKILL.md` file in `skmtc-platform/packages/<skill-name>/` should
-contain. The outline is the *design document*; the SKILL.md is the
-*implementation*.
+Each outline file in this directory describes what the corresponding `SKILL.md`
+file in `skmtc-platform/packages/<skill-name>/` should contain. The outline is
+the _design document_; the SKILL.md is the _implementation_.
 
-When the implementation diverges from the outline, one of them is
-wrong:
+When the implementation diverges from the outline, one of them is wrong:
 
 - If the outline is wrong, update it to match the implementation.
-- If the implementation is wrong, update the skill to match the
-  outline.
+- If the implementation is wrong, update the skill to match the outline.
 
-Either way, drift between outline and skill should be a noticed
-condition, not a quiet one. The friction log is the venue for surfacing
-"the skill said X but the outline says Y" observations.
+Either way, drift between outline and skill should be a noticed condition, not a
+quiet one. The friction log is the venue for surfacing "the skill said X but the
+outline says Y" observations.
 
 ## Open questions across all skills
 
@@ -147,31 +139,29 @@ A few cross-cutting questions worth resolving as the skills mature:
 
 ### Boundary between skill and llms.md
 
-`llms.md` and the skills both contain operational content for LLMs.
-The current cut: `llms.md` is the **canonical aggregation** (read by
-LLMs explicitly directed to it); skills are **role-specific digests**
-(loaded by intent matching).
+`llms.md` and the skills both contain operational content for LLMs. The current
+cut: `llms.md` is the **canonical aggregation** (read by LLMs explicitly
+directed to it); skills are **role-specific digests** (loaded by intent
+matching).
 
-Open question: should `llms.md` mostly defer to skills (when a skill
-exists for the role) and shrink? Or stay as the canonical operational
-reference?
+Open question: should `llms.md` mostly defer to skills (when a skill exists for
+the role) and shrink? Or stay as the canonical operational reference?
 
 ### Skill versioning
 
-Currently each `SKILL.md` has a `version:` field. How do these versions
-evolve? Per-bug-fix? Per-feature? Same cadence as `@skmtc/core`?
+Currently each `SKILL.md` has a `version:` field. How do these versions evolve?
+Per-bug-fix? Per-feature? Same cadence as `@skmtc/core`?
 
 ### How outlines and skills stay in sync
 
-When a skill is updated, the outline should reflect the change (or
-vice versa). Today this is manual. As skills evolve, a CI check could
-verify that the outline references the right sections, the right
-example code, the right anti-pattern count.
+When a skill is updated, the outline should reflect the change (or vice versa).
+Today this is manual. As skills evolve, a CI check could verify that the outline
+references the right sections, the right example code, the right anti-pattern
+count.
 
 ### How retro entries graduate into skill / doc updates
 
-The retro skill produces friction-log entries. Some entries indicate
-skill gaps. The path from "friction logged" → "skill updated" is
-currently manual. As the volume of entries grows, a tighter loop
-(e.g., a weekly script that surfaces "entries referencing the skill")
-may help.
+The retro skill produces friction-log entries. Some entries indicate skill gaps.
+The path from "friction logged" → "skill updated" is currently manual. As the
+volume of entries grows, a tighter loop (e.g., a weekly script that surfaces
+"entries referencing the skill") may help.

--- a/deno/docs/skills/docs-writing/SKILL.md
+++ b/deno/docs/skills/docs-writing/SKILL.md
@@ -1,0 +1,690 @@
+---
+name: docs-writing
+version: 0.2.0
+description: |
+  Write, restructure, or review documentation — tutorials, how-to
+  guides, reference pages, concept/explanation docs, API references,
+  READMEs, changelogs, release notes, and troubleshooting guides.
+  Distills documentation craft from Mintlify's guides (compiled from
+  technical writers at Stripe, GitHub, Amplitude, and Anaconda), the
+  Diátaxis framework (including the compass and per-type voice), the
+  Google and Microsoft style guides, Every Page Is Page One, Write
+  the Docs, and Docs for Developers: audience analysis, content-type
+  selection, style and word-level rules, procedure writing, structure
+  for humans and AI agents, code-example standards, page templates
+  (templates.md), mechanical enforcement and llms.txt (mechanics.md),
+  maintenance, and success metrics.
+
+  Use this skill when the user asks to "write docs", "document this
+  feature", "improve this page", "review these docs", "write a
+  tutorial / how-to / reference page", "structure the docs",
+  "write API documentation", "write a README / changelog", or when
+  authoring any file under a `docs/` tree. For SKMTC docs
+  specifically, this skill governs the *craft* (what makes the page
+  good); the content split between skills, `llms.md`, and the docs
+  tree is governed by `docs/skills/README.md`.
+
+  Distinct from `skmtc-retro` (captures observations about work) and
+  the `skmtc-*` operational skills (guide doing the work) — this
+  skill guides writing *about* the work for readers.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Writing documentation
+
+Documentation craft distilled for the moment of writing. The core stance:
+**people don't read docs for fun; they arrive with a goal — and they read at
+most ~20–28% of the words on a page** (NN/g). Every rule below serves getting
+the reader from arrival to accomplished goal with minimum friction — and the
+same properties that serve a skimming human serve an AI agent reading the page.
+
+Companion files, read on demand:
+
+- `templates.md` — page skeletons + quality bars for how-to, tutorial,
+  reference, concept, README, changelog, release notes, and troubleshooting
+  pages.
+- `mechanics.md` — mechanical enforcement (Vale, markdownlint, link checking,
+  testing code examples) and the llms.txt format.
+
+## 1. The seven principles that override default writing intuitions
+
+Writing docs is not writing prose. These override what generic "good writing"
+instincts would suggest:
+
+1. **Verify before you document.** Never document behavior you haven't executed,
+   observed, or read in the source. LLM-written docs fail here in characteristic
+   ways: plausible flags that don't exist, documented _intent_ instead of actual
+   behavior, invented defaults, hedged claims papering over unchecked ones. If
+   you can't run it, read the code that implements it; if you can do neither,
+   mark the claim unverified rather than asserting it. This is the docs analogue
+   of `skmtc-debug`'s verify-first stance.
+
+2. **One page, one content type, one persona.** Decide _before_ drafting whether
+   the page is a tutorial, how-to, reference, or explanation (§3), and who it's
+   for (§2). "Writing for multiple audiences leads to compromises that satisfy
+   no one." A page that teaches AND exhaustively catalogs AND justifies design
+   does none of them well.
+
+3. **Lead with the answer, not the context.** Readers scan in an F-pattern and
+   abandon pages whose opening doesn't confirm what the title promised. Put the
+   outcome or instruction in the first paragraph; front-load the
+   information-carrying words in headings. A reader should be able to leave
+   after the first paragraph having gotten what they came for.
+
+4. **The curse of knowledge is the default failure mode.** You know how
+   everything works; the reader doesn't. State prerequisites explicitly, define
+   acronyms on first use, never assume internal conventions (naming schemes,
+   auth flows, team shorthand) are known. Validate against real evidence —
+   support tickets, friction logs, user questions — not assumptions. Test: could
+   someone who joined yesterday follow this?
+
+5. **Every page is page one.** Readers arrive from search engines, deep links,
+   and AI retrieval — never at your table of contents. Each page must establish
+   its own context (what it covers, who it's for, what it assumes) in its
+   opening. Reading-order dependencies ("as mentioned above", "in the previous
+   section") are forbidden; link to supporting material instead.
+
+6. **Code examples are load-bearing, not decorative.** Many readers only read
+   the code blocks. Every example must be complete and runnable as-copied —
+   imports, setup, the call, response handling. "A code example is worth a
+   thousand words."
+
+7. **Wrong docs are worse than no docs.** "Consider incorrect documentation to
+   be worse than missing documentation" (Write the Docs). Outdated or misleading
+   content wastes users' time and erodes trust in the whole product. When you
+   can't maintain a page, delete it — removal often serves users better than
+   retention.
+
+## 2. Know your audience
+
+Center the reader's goal, not the product's feature list.
+
+### The four personas
+
+| Persona                  | Needs                              | Serve with                                                                          |
+| ------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------- |
+| Technical decision maker | Evaluate fit and architecture      | Overviews, concept docs, comparison-friendly framing                                |
+| New end user             | Get to first success fast          | Getting-started tutorial, quickstart                                                |
+| Integrating developer    | Implement correctly                | How-tos, reference, complete examples                                               |
+| AI agent / LLM           | Retrieve and act without inference | Structure, explicit prerequisites, self-contained sections, unambiguous terminology |
+
+Pick **one** primary persona per page. The AI-agent persona is served by the
+same properties that serve skimming humans — clear headings, semantic markup,
+defined terms, runnable examples — so it rarely needs separate pages, but it
+does raise the bar on explicitness (§6).
+
+### Defeating the curse of knowledge
+
+- Talk to users (or their proxies: support, UX research, product). Harvest the
+  _terminology they actually use_ — it often differs from internal naming, and
+  it's what they'll search for.
+- **Keep a friction log**: use the product as a new user would and record every
+  step — expected vs. actual, every confusion, workaround, and surprise. Each
+  entry is either a docs fix or a product bug; file it as one or the other.
+  (This ecosystem already runs one at `docs/friction-log/`.)
+- Use the five W's to define a page's scope before writing: who is this for,
+  what will they accomplish, why would they need it, where/when does it apply —
+  then how.
+- Embed with support: recurring tickets are a ranked list of doc gaps.
+- Test docs by asking an AI assistant product questions and seeing whether the
+  docs let it answer correctly — a cheap proxy for "does the page carry its own
+  context".
+- **Assume the reader is qualified** for the page's task; don't explain basics
+  inline. Give unqualified readers enough context to _recognize_ they're on the
+  wrong page, plus a link to where they can qualify themselves — a page "can't
+  bring every possible reader up to speed without becoming a textbook."
+- Don't over-document niche edge cases in guides; route those to community
+  channels and keep guides focused on majority paths. (Reference is different —
+  see §3: exhaustive within its scope.)
+
+## 3. Content types (Diátaxis)
+
+Four types, distinguished by what the reader is trying to do. Assign each page
+exactly one type before drafting.
+
+| Type             | Reader's goal               | Reader's mode | Structure                            | Voice                              |
+| ---------------- | --------------------------- | ------------- | ------------------------------------ | ---------------------------------- |
+| **Tutorial**     | "Teach me by doing"         | Study         | Linear steps, guaranteed outcome     | Guiding: "we", first person plural |
+| **How-to guide** | "Solve my specific problem" | Work          | Problem → solution steps, may branch | Direct, conditional imperatives    |
+| **Reference**    | "Give me the precise fact"  | Work          | Scannable catalog, consistent format | Neutral, terse, austere            |
+| **Explanation**  | "Help me understand why"    | Study         | Discursive, conceptual               | Reflective, comparative            |
+
+### The compass — when the type is unclear
+
+Ask two questions about the content (works at page, section, or sentence level):
+
+1. Does it inform **action** (doing) or **cognition** (thinking)?
+2. Does it serve **acquisition** of skill (study) or **application** of skill
+   (work)?
+
+action + acquisition → tutorial · action + application → how-to · cognition +
+application → reference · cognition + acquisition → explanation.
+
+**Type is function, not difficulty.** An advanced course is still a tutorial (a
+lesson, safely in the instructor's hands); a trivial one-step procedure is still
+a how-to (a worker's task). "Beginner content = tutorial, advanced content =
+how-to" is Diátaxis's most common and most harmful misreading — classify by
+study-vs-work, never by difficulty.
+
+Navigation should mirror the split: Getting Started → Guides → Reference →
+Concepts. The SKMTC docs tree instantiates this as `using/tutorials/` +
+`using/how-to/` + `using/recipes/`, `extending/` (same trio), `reference/`, and
+`concepts/` + `explanation/`. **Recipes are how-to guides in recipe form** — the
+recipe is Diátaxis's own model for the type (assumes competence, answers one
+specific question, no teaching). The four types classify _needs_, not directory
+names; a section may be named anything so long as each page serves one need
+well.
+
+### Writing rules per type
+
+**Tutorials** — learning-oriented:
+
+- Open by stating exactly what the reader will have built/achieved at the end.
+- First person plural, teacher's voice: "In this tutorial, we will…";
+  unambiguous imperatives: "First, do x. Now, do y."
+- Every step delivers a **visible result**, and the text names it: "The output
+  should look something like…" — checkpoints let readers self-verify they're on
+  track.
+- Small incremental steps; a tutorial "doesn't offer choices or alternatives" —
+  one carefully-managed path.
+- Teach through experience, not explanation — link to explanation docs rather
+  than digressing: "We must do x before y because… (see [explanation] for
+  details)."
+- Must work every time: "so well constructed that things can't go wrong" — a
+  tutorial that fails at step 4 loses the user, possibly permanently. Expect
+  high maintenance cost as the product evolves.
+
+**How-to guides** — task-oriented:
+
+- Title is the task in the user's words ("Skip operations for one generator"),
+  not the feature's name.
+- **Conditional imperatives** carry the branching: "If you want x, do y. To
+  achieve w, do z." (Tutorials never branch; how-tos usually do.)
+- About goals, not machinery: address the real-world task, not a walkthrough of
+  the tool's controls.
+- Assume foundational knowledge; state the specific prerequisites, then skip the
+  obvious steps.
+- "Practical usability is more helpful than completeness" — only the context
+  necessary for _this_ task; offload option inventories to reference: "Refer to
+  the x reference for a full list."
+
+**Reference** — information-oriented:
+
+- "Austere and uncompromising": describe, and _only_ describe. Neutral statement
+  of fact; no instruction, no rationale.
+- Structure mirrors the product's structure, and entry order mirrors the source
+  of truth, so drift is visible.
+- Maximize scannability: tables, identical per-entry format, parallel phrasing,
+  one naming convention across every entry.
+- Copy-paste-ready examples per entry (examples illustrate without explaining —
+  they're welcome); required vs. optional marked explicitly; constraints and
+  defaults stated, not just the name restated.
+- Exhaustive within its declared scope — a reference that omits entries is
+  broken in a way a how-to never is.
+
+**Explanations** — understanding-oriented:
+
+- The "About" test: an explanation title should tolerate an implicit "About …"
+  prefix ("About user authentication"). If it can't, the page probably isn't
+  explanation.
+- Cover design decisions, constraints, and the alternatives that were rejected
+  (and why).
+- Opinion is allowed and required here: explanation "can and must consider
+  alternatives, counter-examples or multiple different approaches."
+- Explanation "tends to absorb other things" — expel instruction and technical
+  description to their proper homes.
+
+### Type-mixing smells
+
+- A tutorial that pauses for three paragraphs of rationale → move the rationale
+  to an explanation doc, link it.
+- A tutorial offering choices ("you could also use…") → cut; one path.
+- A reference entry with step-by-step setup → extract a how-to.
+- A how-to that exhaustively lists every option → extract reference material,
+  keep only the options the task needs.
+- A how-to that keeps stopping to teach → trust the reader's competence; link
+  the tutorial instead.
+- Time-sensitive content (release notes, announcements) in evergreen docs →
+  belongs in a changelog or blog (see `templates.md`).
+
+**Scoped exception — API reference surfaces.** Reference pages for an HTTP API
+may deliberately blend the catalog with per-language samples, request/response
+pairs, and short usage notes (the Stripe pattern, §8). That blend is confined to
+the API reference surface; docs-tree pages keep one type each.
+
+### Applying Diátaxis incrementally
+
+Don't restructure top-down into four empty boxes and shovel content in —
+"Diátaxis changes the structure of your documentation from the inside." The
+loop: choose something small; assess what user need it serves and how well;
+decide on a single next action; do it and publish immediately. Documentation is
+_never finished_ — but at every moment it can be _complete_: useful, correct,
+and coherent at its current scope. Never hold back an improvement waiting for
+"done".
+
+## 4. Style and tone
+
+- **Cut ruthlessly — within a section.** Every unnecessary word taxes a reader
+  who is there to get something done. But brevity governs sentences and
+  paragraphs; **explicitness governs boundaries**: restating context at a page
+  or section opening is not filler — it's the entry point for a reader (or
+  retrieval chunk) landing there (§1.5). Cut words, not context.
+- **Active voice, imperative mood.** "Create a file", not "a file should be
+  created".
+- **Second person.** "You" — the doc serves the reader's task. (Exception:
+  tutorials use "we" — §3.)
+- **Short paragraphs** (2–4 sentences), meaningful headings, lists for
+  enumerable things, tables for structured facts.
+- **One term per concept, everywhere.** "API key" and "API token" used
+  interchangeably reads as two different things. Pick one; grep for the other
+  (enforceable with a Vale `consistency` rule — `mechanics.md`).
+- **Don't narrate the obvious.** "Click Save to save" is negative value.
+  Document what isn't intuitive.
+- **Spelling and grammar are trust signals.** Errors in the docs read as errors
+  in the product.
+
+### Word-level rules (bad → good)
+
+The high-leverage subset of the Google and Microsoft style guides — rules a
+fluent writer (or LLM) gets wrong by default:
+
+- **Delete "simply", "easily", "just", "obviously", "of course".** What's easy
+  for the writer isn't for the reader; the sentence survives without them.
+  "Simply run the installer" → "Run the installer."
+- **No "please" in instructions.** "Please click Save" → "Click Save."
+- **Present tense for product behavior; never "will" or "would".** "The server
+  will send an acknowledgment" → "The server sends an acknowledgment."
+- **Timeless docs: ban "currently", "new", "now", "soon", "as of this writing",
+  "latest", "old", "eventually".** "The emulator now supports filters" → "The
+  emulator supports filters." If "new" is unavoidable, anchor it to a date.
+  Exception: changelogs and release notes.
+- **No anthropomorphism.** Software doesn't want, think, see, know, or care.
+  "The PC sees a new device" → "The PC detects a new device."
+- **"may" = permission only; "might" = possibility; "can" = ability.** "The call
+  may fail" → "The call might fail."
+- **"should" is ambiguous** — use "must" for requirements; rewrite
+  recommendations as "we recommend" or a direct imperative.
+- **Spell out Latin abbreviations**: "e.g." → "for example", "i.e." → "that is";
+  avoid "etc." (finish the list or use "such as").
+- **"allows you to" / "enables you to" → "lets you"** — or make the reader the
+  subject: "The API allows you to filter results" → "Filter results with…".
+- **"in order to" → "to"; "utilize"/"leverage" → "use".**
+- **Start instructions with the verb** — kill "You can…" and "There is/are…"
+  openers. "You can access the settings from…" → "Open the settings from…".
+- **Sentence-style capitalization for all headings.** Never Title Case. Oxford
+  comma always. Contractions are fine.
+- **"select"** for UI interaction (not "click"/"tap" — accurate for keyboard,
+  touch, and assistive tech); **select/clear** checkboxes (never
+  "check"/"uncheck").
+- **Never inflect code identifiers** — attach a noun and inflect that: "`Node`s"
+  → "`Node` objects"; "`ADDRESS`'s value" → "the `ADDRESS` constant's value".
+- **Inclusive defaults**: allowlist/blocklist, primary/replica, placeholder (not
+  dummy), "stops responding" (not hangs), singular "they" (never "he/she").
+
+### Writing for a global audience
+
+Docs are read by non-native speakers and machine translation:
+
+- Short sentences, one idea each; no more than two clauses chained with
+  and/or/but.
+- Keep optional function words — "Verify all tables migrated" → "Verify **that**
+  all tables **were** migrated."
+- Avoid ambiguous connectives: "once" → "after"/"when"; "while" →
+  "although"/"during"; "since"/"as" → "because" (unless temporal).
+- Place "only" immediately before the word it modifies: "Only request one token"
+  → "Request only one token."
+- No noun stacks (max two nouns as modifiers), no phrasal verbs where a single
+  verb exists, no idioms, colloquialisms, humor, or culture-bound references.
+- Dates: spell out the month ("January 19, 2026") or ISO 8601 (2026-01-19);
+  never 04/15/17; never seasons.
+
+Lean on the Google or Microsoft style guide for the long tail; automate
+enforcement with Vale in CI (`mechanics.md`) rather than relitigating style in
+review.
+
+## 5. Writing procedures
+
+Step sequences have their own mechanics (Google/Microsoft procedure rules):
+
+- **Numbered list; one action per step.** Combine actions only when they're
+  trivial and happen in the same place.
+- **Location and purpose before action**: "In Google Docs, select **File >
+  New**" — not "Select **File > New** in Google Docs". "To start a new run,
+  click…" — the goal first, so the reader can skip steps they don't need.
+- **State a step's result in the same paragraph as the action**, after it — not
+  as its own numbered step: "Drag the tiles to an open space. When a gray bar
+  appears, release them."
+- **A single-step procedure is one bullet**, not "1.".
+- **Optional steps start with "Optional:"**.
+- **End with the completing action** — the **Save**/**Apply** step; don't leave
+  the procedure hanging. If the end state isn't obvious, say what success looks
+  like.
+- **Menu paths**: bold items separated by ">" (**File > New > Document**); use
+  one convention throughout, and only when every hop uses the same interaction.
+- **One method per procedure.** Alternatives and keyboard shortcuts belong in a
+  reference table, not woven into the steps.
+- **Task-phrased, parallel headings** ("Create a profile", "Add an account");
+  don't follow the heading with a sentence that repeats it.
+
+## 6. Structure for humans AND AI agents
+
+The same page properties serve skimming humans, search engines, and LLM
+retrieval. Optimize once:
+
+- **Establish context in the opening**: what the page is about, who it's for,
+  where it fits — position in the nav tree doesn't travel with the page into a
+  search result or a retrieval chunk.
+- **Descriptive headings with honest information scent.** Readers choose links
+  and sections by an estimate of what's behind them — from the label alone.
+  "Rate limiting" beats "Keeping things under control"; phrase task headings the
+  way a user would ask ("Rotate an API key"). A heading should answer "is my
+  answer in this section?" without reading the section. Over-promising titles
+  get the page abandoned and burn trust.
+- **Semantic markup**: proper heading hierarchy (H2 → H3 → H4, no skipped
+  levels), lists for enumerations, tables for structured data (headers in the
+  first row only, no merged cells), fenced code blocks with language tags.
+- **Explicit prerequisites** at the top of task pages — humans skip them at
+  their own risk; AI agents cannot infer unstated context.
+- **Definitions before edge cases; common cases before advanced.**
+- **Stay on one level.** Don't oscillate between high-level principle and
+  low-level detail on one page; link _up_ to concepts and _down_ to reference
+  and let the reader change levels when they choose.
+- **Link richly, along subject affinity** — every page is a hub. Descriptive
+  anchors ("see the enrichments reference"), never "click here"; no positional
+  language ("above"/"below" → name the section or link it).
+- **Self-contained sections**: a section pulled out of the page by a retrieval
+  system should still make sense. Restate the subject noun (not "it"); restate
+  (briefly) rather than relying on "as mentioned above".
+- **Conform to type**: pages with the same purpose share the same sections in
+  the same order (`templates.md`) — predictability serves scanners, and a
+  defined shape makes gaps visible.
+- **Document error scenarios and deprecations explicitly** — error strings are
+  among the highest-value search and retrieval targets, and the least often
+  documented.
+- Delete or clearly mark outdated content: AI retrieval surfaces deprecated
+  pages with no sense of staleness.
+- **Ship the machine surface**: an `/llms.txt` index (and `llms-full.txt` if the
+  corpus fits a context window) — format and rules in `mechanics.md`.
+
+### Validating the structure
+
+- Analytics: where do readers enter, what do they search for ( especially
+  searches with zero results), where do they exit.
+- Session paths: do readers follow the navigation you designed, or fight it?
+- Direct tests: watch a user (or a new hire — an excellent proxy) try to answer
+  a specific question using only the docs.
+- Common pitfalls: overloaded top-level categories (seven items is a comfortable
+  limit for an unordered list), essential pages buried three levels deep,
+  section labels only insiders understand.
+
+## 7. Code examples
+
+The most-read part of any developer doc. Standards:
+
+- **Runnable as-copied.** Full workflow: imports, setup, authentication
+  placeholder, the call, response handling. A fragment that needs unstated
+  scaffolding is a support ticket.
+- **Realistic data** — not `foo`/`bar`; use values shaped like real usage so
+  readers can map the example onto their case.
+- **Placeholders in `UPPER_SNAKE_CASE`**, followed by "Replace the following:"
+  with one line per placeholder in order of appearance.
+- **Show the expected output/response** alongside the request, so readers can
+  verify success without guessing.
+- **Include error handling** in longer examples — it's where real integrations
+  spend their time.
+- **Multiple languages via tabs** where the audience spans ecosystems; every
+  tab's example kept equivalent.
+- **Test examples in CI.** A fenced code block is a claim; untested claims rot,
+  and an example that rots is worse than none (§1.7). Extraction and doc-testing
+  patterns per ecosystem are in `mechanics.md`; mark deliberately non-runnable
+  fragments so the untagged default stays "this must run".
+
+## 8. API documentation
+
+The specialized high-stakes case. Structure around the developer's journey, and
+measure it by **time-to-first-successful-call**.
+
+### Required components
+
+| Component       | Bar to clear                                                                                                    |
+| --------------- | --------------------------------------------------------------------------------------------------------------- |
+| Getting started | Working integration inside ~15 minutes; never buried                                                            |
+| Authentication  | Step-by-step credential setup, token placement, expiry and rate limits, per-method examples (curl + SDKs)       |
+| API reference   | Complete request/response cycles — paths, methods, parameters, schemas, status codes — not a bare endpoint list |
+| Guides          | Organized by real tasks ("Send a message", "Accept a payment"), not by endpoint inventory                       |
+| Error catalog   | Every error code with context and the _remediation_, including near-miss distinctions (400 vs 422)              |
+| Changelog       | Timestamped, discoverable, flags breaking changes and deprecations loudly (`templates.md` for the format)       |
+
+### Practices that separate the best API docs
+
+- **Pair generated reference with authored guides.** Auto-generation from an
+  OpenAPI spec is a starting point only — it has no editorial judgment, no
+  use-case coverage, no workflow ordering. Layer opinionated guides on top;
+  never ship the generated reference alone.
+- **Workflow-first organization** (the Stripe pattern): each reference page
+  carries descriptive titles, per-language samples, realistic request/response
+  pairs, and usage notes. This is the sanctioned type-blend — scoped to the API
+  reference surface (§3).
+- **Copy-paste-ready everywhere**, ideally with the reader's own test
+  credentials injected when docs are behind a logged-in state — but never
+  _require_ login to read the docs; gated docs kill self-service evaluation.
+- **Skimmable and searchable**: developers arrive with a task, not to read
+  linearly.
+- **Interactive playgrounds** on reference pages turn specs into executable
+  experiences.
+- **Design for LLM consumption**: consistent formatting and rich examples let AI
+  assistants generate correct integration code from your docs — an adoption
+  channel in its own right.
+
+## 9. Page templates
+
+`templates.md` holds compressed skeletons — ordered sections, a one-line note
+per section, and the 2–3 quality criteria separating a good instance from a
+mediocre one — for:
+
+how-to guide · tutorial · reference entry · concept/explanation · README ·
+changelog (Keep a Changelog format) · release notes · troubleshooting guide
+
+Use them as the "conform to type" baseline (§6): start from the skeleton, delete
+sections that genuinely don't apply, and keep the order. Two worth
+internalizing:
+
+- **README = cognitive funnel, not manual.** Broadest first — what it is (< 120
+  chars), who it's for, a runnable usage example — so the reader can bail out at
+  any depth having lost minimal time. Depth belongs in the docs tree; the README
+  links there. License last.
+- **Changelogs are for humans, not machines.** Never paste `git
+  log`. Group by
+  Added/Changed/Deprecated/Removed/Fixed/Security, newest first, ISO dates, an
+  `[Unreleased]` section at the top, and _always_ announce deprecations one
+  version before removal — selective entries "can be as dangerous as not having
+  a changelog".
+
+## 10. Media
+
+Media is supplementary. **If the workflow is clear in text alone, don't add
+visuals** — every asset is a maintenance liability that silently rots when the
+UI changes. Screenshots for UI elements that are hard to describe; diagrams as
+code (Mermaid — text-diffable) over image exports; video only for long
+procedures, and only with captions. Non-negotiable: alt text on images
+(descriptive and specific — "OAuth 2.0 flow", not "diagram"), and never present
+information _only_ in an image — it's invisible to screen readers, search, and
+AI retrieval alike.
+
+## 11. Discoverability (SEO and AEO)
+
+Most readers arrive from a search engine or an AI assistant, not your nav.
+**Answer Engine Optimization is §6 done well** — there is no separate trick:
+literal headings, self-contained sections, defined terms, stated prerequisites,
+complete examples, documented errors and deprecations, loud deprecation markers.
+The classic mechanical layer still applies: titles ~50–60 characters and meta
+descriptions ~150–160 frontloading the terms users actually search (harvested
+from user language, §2); descriptive link anchors; compressed images; a current
+sitemap. Skip structured-data gymnastics unless you have evidence your audience
+arrives through them.
+
+## 12. Maintenance
+
+Docs rot by default; only a system prevents it.
+
+- **Docs-as-code**: docs live in git, change via PRs, deploy automatically,
+  version alongside the code they describe. Review catches errors before
+  publication and lets engineers contribute through tools they already use.
+- **ARID, not DRY** — "Accept (some) Repetition In Documentation." Docs are read
+  in fragments, so they can't be as DRY as code: single-source what you can,
+  duplicate deliberately where the reader needs it in place — and give every
+  duplicated fact one designated canonical home so drift is detectable (this
+  ecosystem's selective-duplication policy in `docs/skills/README.md` is this
+  principle applied).
+- **Couple docs to shipping**: a user-facing change isn't done until its docs
+  are updated — enforce in the definition of done or PR template, and automate
+  detection of drift (e.g. flag when the OpenAPI spec changes but the guide
+  didn't).
+- **Automate the boring checks**: broken links, heading hierarchy, missing alt
+  text, filler words, terminology consistency, example compilation — the full
+  toolbox with configs is in `mechanics.md`.
+- **Edit in sequenced passes, one concern each** — drafting and editing are
+  different acts; never do both at once. The order: (1) technical accuracy — do
+  the instructions produce the promised result; (2) completeness — can the
+  reader succeed with what's here; (3) structure — do headings and prerequisites
+  guide the reader; (4) clarity and brevity — cut. Self-review with the §13
+  checklist first, then peer review with a _specific ask_, then expert technical
+  review for complex topics.
+- **Prioritize by impact, not schedule**: the 10 most-viewed pages get
+  disproportionate attention. Use the traffic × rating grid:
+  high-traffic/low-rating pages are the urgent queue; low-traffic/ high-rating
+  pages hold patterns worth replicating.
+- **Assign ownership.** Documentation without a named owner diffuses into no
+  one's job and quietly dies.
+- **Deprecate before deleting**: mark the content deprecated in place, point to
+  the replacement, give notice — then delete what no longer serves users (§1.7).
+
+## 13. Measuring success
+
+Numbers require interpretation — "don't fall into the trap that a bigger number
+means better performance."
+
+| Signal                                     | Reading it honestly                                             |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| Page views                                 | Interest — or bots, or a product bug driving people to the docs |
+| Time on page                               | Engagement — or frustration hunting for an answer               |
+| Zero-result searches                       | Direct gap list; the highest-signal analytic                    |
+| Thumbs-up ratio                            | Target ~75%+; below that, the page misleads or misses           |
+| Support ticket volume on documented topics | The docs' business case: each deflected ticket is the win       |
+| AI-assistant query logs                    | What users actually ask, in their words — feeds §2              |
+
+Compare against your own baseline over time, not absolute thresholds. Tie the
+program to business outcomes: onboarding speed, support deflection, retention.
+
+## 14. Pre-publish checklist
+
+Before a page ships:
+
+- [ ] Every behavioral claim verified — executed, observed, or read in source;
+      anything unverifiable is marked, not asserted (§1.1)
+- [ ] One content type, chosen via the compass if unclear; no type-mixing smells
+      (§3)
+- [ ] One primary persona; prerequisites stated at the top
+- [ ] The answer/outcome appears in the first paragraph; the opening establishes
+      context for a reader arriving from search
+- [ ] Headings are descriptive, front-load key terms, and don't skip levels
+- [ ] Every code example runs as-copied and shows expected output; non-runnable
+      fragments are marked
+- [ ] Terminology consistent — grep for known synonyms of key terms
+- [ ] No filler (`simply|easily|just|obviously`), no time-bound words
+      (`currently|new|soon`) outside release notes, present tense for product
+      behavior (§4)
+- [ ] Procedures follow §5: one action per step, location before action, results
+      stated, completing action present
+- [ ] Page conforms to its type's skeleton (`templates.md`)
+- [ ] Errors and edge cases the reader will hit are documented
+- [ ] Links have descriptive anchors and resolve; no positional language
+- [ ] Images have alt text; media passes the "necessary?" test (§10)
+- [ ] Title/description frontload searchable terms
+- [ ] The page has an owner and a reason to exist that analytics could later
+      confirm
+
+## 15. Task cards
+
+### Card: Documenting a new feature
+
+1. Identify the persona and their goal (§2). Write the five W's.
+2. **Verify the behavior first** (§1.1): run the feature, note the actual
+   commands, flags, outputs, and failure modes — this raw material is the
+   draft's skeleton and its fact-check.
+3. Split the material by type (§3): quickstart steps → tutorial or how-to;
+   option/flag inventory → reference; design rationale → explanation. Resist the
+   single mega-page.
+4. Outline first — every step the reader needs, then reorder to the reader's
+   flow. Draft the how-to first (it forces the user-goal framing) from its
+   `templates.md` skeleton, then extract reference entries, then backfill
+   explanation.
+5. Write and _run_ every code example.
+6. Edit in passes — accuracy, completeness, structure, brevity (§12) — then run
+   the §14 checklist; place pages in the tree by type.
+
+### Card: Reviewing/auditing an existing page
+
+1. Determine its intended type (use the compass, §3) and persona. If
+   undeclarable, that's finding #1.
+2. Check the opening: does it establish context and state what the page
+   delivers?
+3. Run examples. Diff terminology against the rest of the docs.
+4. Check staleness against the product's current behavior — wrong content is the
+   highest-severity finding (§1.7).
+5. Grep for the mechanical smells: filler words, time-bound words, "click here",
+   skipped heading levels (§14).
+6. Verdict per finding: fix, split (type-mixing), or delete.
+
+### Card: Standing up docs for a new project
+
+1. Skeleton by type: Getting Started → How-to Guides → Reference → Concepts
+   (§3), pages from `templates.md`.
+2. Write the getting-started path first and make it bulletproof — working result
+   in ≤15 minutes.
+3. Reference next (breadth), explanations last (depth).
+4. Wire the maintenance system before content grows: docs-as-code, link
+   checking, prose lint, docs-updated-with-change policy, and the machine
+   surface (llms.txt) — configs in `mechanics.md`.
+5. Thereafter improve incrementally (§3): one small published step at a time;
+   never a big-bang restructure.
+
+## 16. Sources
+
+Distilled July 2026 from:
+
+- Mintlify Guides — https://mintlify.com/guides/introduction
+  (`know-your-audience`, `content-types`, `writing-style-tips`, `navigation`,
+  `media`, `seo`, `maintenance`, `success`), itself compiled from interviews
+  with technical writers at Stripe, Amplitude, Anaconda, and GitHub; plus
+  Mintlify's API-documentation recommendations and developer-docs blog posts
+- Diátaxis framework — https://diataxis.fr (the four types, the compass,
+  tutorials-vs-how-to, complex hierarchies, per-type language guidance, quality;
+  Daniele Procida)
+- Google developer documentation style guide —
+  https://developers.google.com/style (word list, tense, anthropomorphism,
+  timeless documentation, procedures, link text, accessibility, translation)
+- Microsoft Writing Style Guide — https://learn.microsoft.com/en-us/style-guide/
+  (top 10 tips, bias-free communication, global communications, step-by-step
+  instructions)
+- Every Page Is Page One — Mark Baker (the seven characteristics of EPPO topics;
+  information foraging) — https://everypageispageone.com
+- Write the Docs — https://www.writethedocs.org/guide/ (docs principles incl.
+  ARID, docs-as-code, style guides)
+- Docs for Developers (Bhatti, Corleissen, Lambourne, Nunez, Waterhouse) —
+  https://docsfordevelopers.com (friction log, drafting process, editing passes,
+  content taxonomy)
+- Nielsen Norman Group — how little users read, the F-shaped pattern,
+  information scent — https://www.nngroup.com/articles/
+- The Good Docs Project templates — https://thegooddocsproject.dev (via
+  `templates.md`)
+- Keep a Changelog 1.1.0 — https://keepachangelog.com (via `templates.md`)
+- Art of README + standard-readme (via `templates.md`)
+- llms.txt spec — https://llmstxt.org; Vale — https://vale.sh; markdownlint;
+  lychee (via `mechanics.md`)

--- a/deno/docs/skills/docs-writing/design.md
+++ b/deno/docs/skills/docs-writing/design.md
@@ -1,0 +1,174 @@
+# docs-writing skill — design document
+
+## Purpose
+
+A craft skill: how to write good documentation, loaded at the moment of writing
+or reviewing any docs page. Unlike the `skmtc-*` skills it is not SKMTC-specific
+— the content is general documentation craft — but it lives in this ecosystem
+because the SKMTC docs tree is its primary application surface, and because the
+docs tree already instantiates the skill's central framework (Diátaxis) in its
+directory layout (`using/tutorials/`, `using/how-to/`, `using/recipes/`,
+`reference/`, `concepts/`, `explanation/`).
+
+## Artifact layout (v0.2.0)
+
+- `SKILL.md` — the operational core, loaded on invocation: the seven principles,
+  audience, Diátaxis (+ compass), style and word rules, procedures, structure,
+  code examples, API docs, maintenance, checklist, task cards.
+- `templates.md` — page skeletons + quality bars for eight page types; read on
+  demand when drafting a page of that type.
+- `mechanics.md` — the automatable subset (Vale, markdownlint, lychee,
+  doc-testing) and the llms.txt format; read when wiring CI or the machine
+  surface, not when writing prose.
+
+The split follows the ecosystem's skills-push/docs-pull model: material needed
+at the moment of writing stays in SKILL.md; material needed when setting up
+checks or starting a specific page type moves to companions.
+
+## Content sources
+
+v0.1.0 was distilled July 2026 from Mintlify's published documentation-craft
+material (itself compiled from interviews with technical writers at Stripe,
+Amplitude, Anaconda, GitHub) plus the Diátaxis four-type model. v0.2.0
+diversified the source base to correct the single-vendor emphasis.
+
+| Section                         | Source                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| §1 Seven principles             | §1.1 original (verify-first, the agent-as-writer stance, mirroring `skmtc-debug`); §1.2 Mintlify; §1.3 Mintlify + NN/g (F-pattern, ~20% reading); §1.4 Mintlify + Docs for Developers (validation); §1.5 Every Page Is Page One (Baker); §1.6 Mintlify; §1.7 Mintlify + Write the Docs ("incorrect worse than missing") |
+| §2 Know your audience           | Mintlify `know-your-audience` + five W's; friction log from Docs for Developers; "assume the reader is qualified" from EPPO                                                                                                                                                                                             |
+| §3 Content types                | diataxis.fr in depth: the compass, tutorials-vs-how-to (type ≠ difficulty), per-type voice ("we", conditional imperatives, the "About" test), complex-hierarchies (recipes ruling), incremental application, "always complete never finished" (Procida)                                                                 |
+| §4 Style and tone               | Mintlify `writing-style-tips`; word-level rules from the Google style guide (word list, tense, anthropomorphism, timeless docs) + Microsoft (top 10 tips, bias-free, global comms); brevity/explicitness scoping rule original (see decision log)                                                                       |
+| §5 Procedures                   | Google `procedures` + Microsoft step-by-step instructions                                                                                                                                                                                                                                                               |
+| §6 Structure                    | Mintlify `navigation`/`seo` + EPPO (context, one level, link richly, conform to type) + NN/g information scent                                                                                                                                                                                                          |
+| §7 Code examples                | Mintlify + Google placeholder conventions; testing pointer to mechanics.md                                                                                                                                                                                                                                              |
+| §8 API documentation            | Mintlify API-docs recommendations (components table, Stripe/Twilio exemplars, time-to-first-call)                                                                                                                                                                                                                       |
+| §9 Templates pointer            | templates.md: Good Docs Project, Keep a Changelog 1.1.0, Art of README, standard-readme                                                                                                                                                                                                                                 |
+| §10 Media                       | Mintlify `media`, compressed                                                                                                                                                                                                                                                                                            |
+| §11 Discoverability             | Mintlify `seo`, compressed; AEO = §6 framing retained                                                                                                                                                                                                                                                                   |
+| §12 Maintenance                 | Mintlify `maintenance` + WTD ARID + Docs for Developers (editing passes, deprecate-before-delete, ownership)                                                                                                                                                                                                            |
+| §13 Measuring success           | Mintlify `success` + traffic × rating grid                                                                                                                                                                                                                                                                              |
+| §14–15 Checklist and task cards | Original synthesis in the house skill style; updated for verify-first, compass, templates, editing passes                                                                                                                                                                                                               |
+| mechanics.md                    | vale.sh docs + errata-ai packages; markdownlint; lychee; GitLab docs pipeline; pytest-examples/MDX/mdbook; llmstxt.org + adoption reporting                                                                                                                                                                             |
+| templates.md                    | Good Docs Project template repo (how-to, tutorial, reference, concept, README, changelog, release notes, troubleshooting); Keep a Changelog 1.1.0; Art of README; standard-readme spec                                                                                                                                  |
+
+## Decision log — contested seams
+
+Where credible sources disagree, the skill encodes one side rather than
+presenting options (a skill offering "A or B" just re-litigates the choice every
+invocation). Each entry records the tension, the chosen side, and why — so
+future maintainers don't "fix" a decision without knowing it was one.
+
+1. **Diátaxis type purity vs. Stripe-style blended pages.** Both work; mixed
+   per-page adoption nullifies both. Chosen: purity governs the docs tree (type
+   declared by directory); the workflow-blend is a _scoped carve-out_ for API
+   reference surfaces only (§3 smells + §8). Rationale: the tree is already
+   committed to type-per-directory, and the carve-out matches how the pattern is
+   actually used by its exemplars.
+2. **"Cut ruthlessly" vs. "restate context" (brevity vs. explicitness).**
+   Chosen: a scoping rule — brevity governs within a sentence/paragraph;
+   explicitness governs page and section _boundaries_ (openings, prerequisites,
+   restated subjects), since boundaries are retrieval/entry points (EPPO + AEO).
+   "Cut words, not context." (§4 first bullet.)
+3. **Exhaustive reference vs. don't document niche edge cases.** Chosen: scoped
+   by type — exhaustiveness is a property of reference _within its declared
+   scope_; edge-case triage applies to guides (§2 last bullet, §3 reference
+   rules).
+4. **"click" (Google) vs. "select" (Microsoft).** Chosen: select —
+   input-neutral, accurate for keyboard/touch/assistive tech, no per-device
+   forking (§4 word rules).
+5. **Menu-path separator bolding (Google bolds the whole path; Microsoft doesn't
+   bold ">").** Chosen: bold items with ">" separators, one convention
+   throughout — consistency matters more than the variant (§5).
+6. **DRY vs. duplication.** Chosen: ARID with designated canonical homes (§12),
+   which is also the ecosystem's existing selective-duplication policy — a
+   synthesis with a drift-check mechanism, not an average.
+7. **Voice register (Microsoft's marketing-brisk vs. Google's
+   restrained-conversational).** Chosen: Google's restraint — developers read
+   docs under stress; contractions yes, chirpiness no.
+8. **Recipes vs. the four types.** Resolved, not contested: diataxis.fr itself
+   names the recipe as the model how-to form and says the four types classify
+   needs, not directory names (§3).
+
+## Content boundaries
+
+**In scope:** the craft of a docs page — audience, type selection, style,
+structure, examples, media, discoverability, maintenance process, metrics — plus
+page templates and the mechanical enforcement toolbox as companions. Applies to
+any project's docs.
+
+**Out of scope, deliberately:**
+
+- _Where SKMTC content goes_ (skill vs `llms.md` vs docs tree, the
+  selective-duplication policy, canonical homes) — owned by
+  `docs/skills/README.md`. The SKILL.md description points there.
+- _Writing SKILL.md files themselves_ — skills are an operational artifact with
+  their own conventions (frontmatter, trigger phrases, anti-pattern tables); a
+  future `skill-authoring` skill could own that.
+- _Mintlify the product_ (mint.json, components, hosting) — this skill takes
+  their writing guidance, not their tooling.
+- _Specific Vale rule catalogs beyond the examples_ — mechanics.md shows the
+  patterns; a project's actual rule set lives with the project.
+
+## Design choices
+
+- **Name is unprefixed** (`docs-writing`, not `skmtc-docs-writing`) because the
+  content is project-agnostic. The SKMTC-specific touches — the tree mapping and
+  the `verify-docs.ts` / friction-log pointers — are kept minimal so the skill
+  stays portable.
+- **House style preserved**: numbered sections, "principles that override
+  default intuitions" opener, decision tables, task cards, and a verification
+  checklist, matching `skmtc-generator` / `skmtc-cli` so the skill family reads
+  uniformly.
+- **"Seven principles" framing** mirrors the "N facts" opener convention of the
+  sibling skills. Verify-first was added as principle #1 in v0.2.0 because the
+  skill's writer is usually an LLM, and LLM-written docs fail differently from
+  human-written docs (hallucinated flags, documented intent vs. behavior) — the
+  highest-leverage correction goes first.
+- **AI-agent readership is folded into every structural section** rather than
+  ghettoized in one — AEO and human skimmability are the same optimization. The
+  agent-as-_writer_ stance (verify-first) is separate and lives in §1.1.
+- **Companions over one mega-file**: templates and mechanics are needed at
+  different moments than the craft rules; splitting keeps the loaded artifact
+  dense (positional attention, context budget) while the companions stay a Read
+  away.
+
+## Changelog
+
+- **0.2.0 (July 2026)** — diversified sources beyond Mintlify (Diátaxis in
+  depth, Google/Microsoft style guides, EPPO, Write the Docs, Docs for
+  Developers, NN/g, Good Docs Project, Keep a Changelog, llms.txt, Vale). Added:
+  verify-first principle (§1.1), the compass, type≠difficulty, per-type voice,
+  recipes ruling, incremental application, word-level bad→good rules, global-
+  audience rules, procedures section, EPPO structure rules (context / one level
+  / link richly / conform to type), information scent, editing passes, ARID,
+  deprecate-before-delete, llms.txt. Resolved the contested seams (decision log
+  above). Split templates.md and mechanics.md out as companions. Compressed
+  media/SEO/metrics. Added Bash to allowed-tools (running examples is part of
+  the craft).
+- **0.1.0 (July 2026)** — initial distillation from Mintlify guides plus the
+  Diátaxis four-type model.
+
+## Verification loop (wired 2026-07-06)
+
+- **CI counterpart** — `deno/docs/verify-docs.ts` checks 4 and 5: the §3
+  Diátaxis tree mapping stays in sync with the real directory layout (both
+  directions, incl. the extending-mirrors-using claim), and a zero-tolerance
+  filler-word guard (`simply`/`easily`/`obviously`/`as of this writing`) across
+  the reader-facing tree. "just" and "currently" are deliberately not checked —
+  too many legitimate uses (version-scoped capability statements); those stay a
+  review concern. The seven pre-existing filler hits were fixed when the guard
+  landed.
+- **Eval coverage** — `docs/evals/tasks/rewrite-flawed-page.md`: a flawed how-to
+  page whose central fault is factual drift against a ground-truth CLI
+  (`--force` documented, `--overwrite` real), plus the §4/§5/§6 prose faults.
+  The llm-judge rubric is keyed to the §14 checklist; the fixture self-verifies
+  the tool's real behavior and the planted faults. Fails any rewrite that keeps
+  invented flags, however clean the prose — the verify-first discriminator.
+
+## Open questions
+
+- Does this skill need trigger wiring into the user-level skill list
+  (`~/.claude/skills/`) like the `skmtc-*` skills, or is repo-local loading
+  sufficient? (Currently symlinked at user level.)
+- Whether §10–§11 (media, discoverability) should also move to a companion if
+  SKILL.md grows further.

--- a/deno/docs/skills/docs-writing/mechanics.md
+++ b/deno/docs/skills/docs-writing/mechanics.md
@@ -1,0 +1,184 @@
+# Mechanical enforcement and the machine surface
+
+Companion to `SKILL.md` — the automatable subset of the craft rules, and the
+llms.txt format. Read when wiring docs checks into CI or standing up the
+machine-readable surface, not at the moment of writing a page.
+
+Distilled July 2026 from https://vale.sh, https://llmstxt.org,
+https://github.com/DavidAnson/markdownlint,
+https://github.com/lycheeverse/lychee, and GitLab's docs-testing pipeline
+(https://docs.gitlab.com/development/documentation/testing/).
+
+## What's automatable vs. not
+
+Automatable (put in CI, stop relitigating in review): filler words,
+banned/time-bound terms, terminology consistency, heading hierarchy, code-fence
+language tags, missing alt text, broken links, sentence-case headings, example
+execution.
+
+Not automatable (the review's actual job): type purity, verified behavior claims
+(SKILL.md §1.1), information scent of headings, persona fit, whether the opening
+establishes context, alt-text _quality_.
+
+## Vale — prose linting
+
+Vale (https://vale.sh) is a single-binary CLI that lints prose against YAML
+rules; it's markdown-aware (skips code blocks by default) and ships ready-made
+packages for the major style guides: `Google`, `Microsoft`, `write-good` (weasel
+words, passive voice), `proselint`, `alex` (insensitive language).
+
+Minimal realistic `.vale.ini` for a markdown docs tree:
+
+```ini
+StylesPath = .vale/styles
+MinAlertLevel = warning
+Packages = Google
+
+# Project-accepted/rejected terms:
+# .vale/styles/config/vocabularies/Docs/{accept.txt,reject.txt}
+Vocab = Docs
+
+[*.md]
+BasedOnStyles = Vale, Google, Docs
+# Tone down an inherited rule without forking the package:
+Google.Passive = suggestion
+```
+
+Custom house rules go in `.vale/styles/Docs/*.yml`. The rule types that map
+directly onto SKILL.md's style rules:
+
+**`existence` — ban filler words** (§4):
+
+```yaml
+# .vale/styles/Docs/Filler.yml
+extends: existence
+message: "Remove filler: '%s' adds no information."
+level: error
+ignorecase: true
+tokens:
+  - simply
+  - easily
+  - just
+  - obviously
+  - clearly
+  - of course
+```
+
+A second `existence` rule with `currently|new|soon|as of this
+writing|latest`
+enforces timeless docs (§4) — scope it to exclude changelog paths via a per-glob
+section in `.vale.ini`.
+
+**`consistency` — one term per concept** (§4). `either` lists variant pairs of
+which only one may appear per document:
+
+```yaml
+# .vale/styles/Docs/TermConsistency.yml
+extends: consistency
+message: "Inconsistent term: pick one of '%s' per document."
+level: error
+ignorecase: true
+either:
+  API key: API token
+  sign in: log in
+  config file: configuration file
+```
+
+**`substitution` — enforce the canonical term**, with editor auto-fix:
+
+```yaml
+# .vale/styles/Docs/Terms.yml
+extends: substitution
+message: "Use '%s' instead of '%s'."
+level: warning
+ignorecase: true
+action:
+  name: replace
+swap:
+  "e-mail": email
+  "repo": repository
+  "whitelist": allowlist
+  "blacklist": blocklist
+```
+
+Other rule types available: `occurrence` (e.g. max sentence length),
+`repetition`, `conditional`, `capitalization` (e.g. sentence-case headings),
+`metric` (readability thresholds), `spelling`, `sequence`, `script`.
+
+## Structural checks — markdownlint + lychee
+
+**markdownlint** (`markdownlint-cli2` in CI) — the rules that carry docs
+quality, mapping to SKILL.md §6:
+
+- `MD001` — heading levels increment by one (no H2 → H4)
+- `MD040` — fenced code blocks declare a language
+- `MD045` — images have alt text
+- `MD042` — no empty links
+
+**lychee** — async link checker for markdown. Run internal-link checks on every
+PR (`--offline`, or an include/exclude split) and external-link checks on a
+weekly schedule — external checks on every PR are flaky (rate limits, transient
+5xx). Supports `.lycheeignore` and `--accept 200,429`.
+
+GitLab's docs pipeline pairs exactly these: Vale + markdownlint (+ link
+checking) as the standard stack.
+
+## Testing code examples
+
+A fenced code block is a claim; untested claims rot (SKILL.md §1.7, §7).
+Patterns by ecosystem:
+
+- **Rust**: doctests built in; `mdbook test` executes blocks in a markdown book.
+- **Python**: `pytest --doctest-glob='*.md'`; or **pytest-examples** (Pydantic
+  team) — finds Python blocks in markdown, lints, executes, checks printed
+  output, and can rewrite blocks in place.
+- **OCaml**: MDX, integrated into dune.
+- **Generic / this repo**: extract fenced blocks by info-string tag with a small
+  script and execute them in CI; at minimum, type-check snippets by
+  concatenating them into a scratch module. Mark deliberately non-runnable
+  fragments with a distinct tag so the untagged default stays "this must run".
+
+In this tree, `deno/docs/verify-docs.ts` hosts docs-writing's mechanical checks:
+the Diátaxis tree-mapping sync and the filler-word guard (checks 4 and 5). A
+fenced-block extractor running under `deno check` would cover the TypeScript
+examples next.
+
+## llms.txt — the machine-readable docs index
+
+Spec: https://llmstxt.org. A markdown file at the site root giving LLMs a
+curated map of the docs — context windows can't hold a whole site, so hand
+agents a short index of clean markdown instead of letting them scrape HTML.
+
+Format (order fixed; only the H1 is required):
+
+```markdown
+# Project name
+
+> One-paragraph summary: the key facts an agent needs first.
+
+Optional freeform background paragraphs (no headings).
+
+## Section name
+
+- [Page title](https://url): one-line description — what it covers and when to
+  read it
+
+## Optional
+
+- [Secondary link](https://url): links here may be skipped when context is short
+```
+
+- `llms.txt` is the index; `llms-full.txt` concatenates the entire corpus into
+  one file so a single URL loads full context. Ship both if the corpus fits a
+  context window; the index alone otherwise.
+- Entry descriptions: one line, concrete, front-loaded — "Reference for the runs
+  API: endpoints, auth, pagination", not "Learn more about runs".
+- Test it: expand the file into an LLM context and ask real product questions
+  against it.
+- Honest caveat: no major crawler is confirmed to request llms.txt unprompted.
+  Its proven value is deliberate use — humans and agents fetching it as context
+  — not passive SEO. Adoption is near-standard among dev-tool docs (Anthropic,
+  Stripe, Cloudflare, Vercel; Mintlify auto-generates it), so its absence now
+  reads as a gap.
+- The companion convention: serve a clean `.md` variant of every page (append
+  `.md` to the page URL).

--- a/deno/docs/skills/docs-writing/templates.md
+++ b/deno/docs/skills/docs-writing/templates.md
@@ -1,0 +1,202 @@
+# Page templates
+
+Compressed skeletons per page type: ordered sections, a one-line note per
+section, and the quality criteria that separate a good instance from a mediocre
+one. Companion to `SKILL.md` §9 — start from the skeleton, delete sections that
+genuinely don't apply, keep the order ("conform to type", SKILL.md §6).
+
+Distilled July 2026 from The Good Docs Project templates
+(https://thegooddocsproject.dev/template/, source repo
+https://gitlab.com/tgdp/templates), Keep a Changelog 1.1.0
+(https://keepachangelog.com/en/1.1.0/), Art of README
+(https://github.com/hackergrrl/art-of-readme), and standard-readme
+(https://github.com/RichardLitt/standard-readme).
+
+## How-to guide
+
+```
+# {Verb} {object}                — bare-infinitive task title ("Connect to the VM
+                                   instance"), not an "-ing" form or a feature noun
+Overview                         — 1–2 sentences: "This guide shows you how to {task}."
+                                   Optionally when/why you'd do it
+Before you start (optional)      — bulleted prerequisites: access, tools, prior setup
+## {Task name}                   — numbered steps, each starting with an action verb
+   Step                          — instruction + optional context/code + expected result
+   Substeps                      — only when a step genuinely decomposes
+## {Sub-task} (optional)         — only for big tasks; same step structure
+See also                         — related how-tos, concepts, troubleshooting
+```
+
+Quality bar:
+
+- **One task per page**, documenting the single safest/most common method —
+  never two ways to do the same thing. Max ~8–10 steps before splitting into
+  sub-tasks.
+- **No concept explanations in the body**; conditional imperatives ("If you want
+  X, do Y") carry the branching; link out at the bottom, not inline everywhere.
+- **Tested end-to-end** against the current release, in order.
+
+## Tutorial
+
+```
+# {Tutorial title}
+Overview                         — what you'll build, audience, and verb-led learning
+                                   objectives: "By the end, you'll be able to {verb}…"
+Background (optional)            — product context / why this matters
+Before you start                 — ALL prerequisites: knowledge, software, environment
+## {Stage} (repeat per stage)    — brief context, then numbered imperative steps
+   Each step                     — instruction + code + expected result (checkpoint)
+Summary                          — the skills actually gained
+Next steps                       — follow-on tutorials, tasks, or docs
+```
+
+Quality bar:
+
+- **Guaranteed success**: a managed start-to-end path that eliminates the
+  unexpected; assume no practical knowledge; state every tool and config.
+- **Checkpoints everywhere**: every step shows its expected result so the
+  learner self-verifies.
+- **Learning-oriented**: objectives written first and used to scope the content;
+  the summary proves they were met.
+
+## Reference entry
+
+```
+# {Reference title}
+{Scope statement}                — 1–2 sentences: what this lists, how it relates to
+                                   other docs
+## {Entry group}                 — table or structured list; SAME format and order for
+                                   every entry, mirroring the source of truth
+   Field table                   — Field | Description | Example
+   Command table                 — Command | Description | Argument(s) | Example
+   Per parameter                 — required vs optional explicit; concrete example value;
+                                   constraints and defaults stated
+## Commands (optional)           — code blocks where a table is too cramped
+```
+
+Quality bar:
+
+- **Ruthless consistency**: identical columns, phrasing pattern, and ordering —
+  the reader predicts where information lives before looking.
+- **Every entry has an example** and an explicit required/optional designation;
+  descriptions state constraints and defaults, never just restate the name.
+- **Entry order mirrors the code/API documented**, so drift is visible.
+
+## Concept / explanation
+
+```
+# {Concept name}                 — tolerates an implicit "About …" prefix
+Intro (no heading)               — the concept, why it matters, what this page covers
+Definition                       — "{X} is …" / "{X} solves …"; diagram with caption
+Background (optional)            — origin, design rationale, alternatives rejected
+Use cases                        — what the reader can do once they understand this
+Comparison (optional)            — table vs. alternatives/related options
+Related resources (optional)     — links grouped by kind
+```
+
+Quality bar:
+
+- **Zero procedural steps** — numbered instructions mean the content belongs in
+  a how-to; link instead.
+- **Anchored in the reader's problem**: use cases and comparisons say _when_ to
+  reach for this, not just what it is.
+- **One concept per page**, with a definition a newcomer could quote.
+
+## README
+
+```
+# {Project name}                 — matches the repo/package name; badges few + meaningful
+One-liner                        — <120 chars answering "what is this?"; screenshot/demo
+                                   if visual
+Who this is for                  — target user + objective; caveats/limitations UP FRONT
+Table of contents                — only if the README exceeds ~100 lines
+Install                          — copy-pasteable block; prerequisites first
+Usage                            — the smallest real, runnable example in action
+API (optional)                   — signatures, or a link to the full reference
+Troubleshooting / FAQ (optional) — issue → solution for the top failure modes
+Contributing                     — where to ask, PR expectations
+Additional docs / help           — links to the docs tree and support channels
+License                          — SPDX name + owner; ALWAYS the final section
+```
+
+Principles:
+
+1. **Cognitive funnel**: broadest → most specific, so the reader can bail out at
+   any depth having lost minimal time. The widest end answers "is this what I
+   need?" before anything else.
+2. **The README is a filter, not a manual**: say what it is, show it in action,
+   show how to use it. Depth lives in the docs tree.
+3. **Usage before API/installation detail** — a runnable example communicates
+   fit faster than prose.
+4. **As short as possible without being shorter**; never rely on images for
+   critical information.
+5. Docs are complete "when someone can use your module without ever having to
+   look at its code" (standard-readme).
+
+## Changelog (Keep a Changelog)
+
+```
+# Changelog
+## [Unreleased]                  — accumulate upcoming changes; at release, retitle
+## [X.Y.Z] - YYYY-MM-DD          — SemVer + ISO 8601; newest first; version links to diff
+### Added                        — new features
+### Changed                      — changes in existing functionality
+### Deprecated                   — soon-to-be-removed (announce BEFORE removing)
+### Removed                      — now-removed features
+### Fixed                        — bug fixes
+### Security                     — vulnerability fixes, called out explicitly
+## [X.Y.W] - YYYY-MM-DD [YANKED] — pulled releases stay listed, tagged
+```
+
+Principles: changelogs are **for humans, not machines**; every version gets an
+entry; group by change type; latest first; ISO dates; say whether you follow
+SemVer. Entries start with a verb and describe the user-visible effect.
+
+Anti-patterns:
+
+- **Commit-log dumps** — commits document code evolution; a changelog
+  communicates noteworthy differences to users.
+- **Ignoring deprecations** — users must be able to upgrade to a version listing
+  the deprecation, migrate, then upgrade past the removal.
+- **Regional dates** — anything but YYYY-MM-DD is ambiguous.
+- **Selective entries** — partial coverage "can be as dangerous as not having a
+  changelog"; it destroys trust in all of it.
+
+## Release notes (audience-facing, per release)
+
+```
+# Release notes — {Product} {version}
+{Release date}                   — + optional 1–3 sentence summary
+## New features                  — **Name** + what it enables + the user benefit
+## Features requiring action     — anything needing config/migration to activate
+## Improvements                  — quantified where possible
+## API updates                   — endpoint and behavior changes for integrators
+## Bug fixes                     — "Fixed issue where {problem}…"
+### Known issues                 — acknowledged problems + fix status
+## Deprecation notices           — feature + end-of-support date + migration path
+```
+
+Difference from a changelog: **benefit-first prose, not diffs** ("you can
+now…"); action items separated so users can scan for "what do I have to do?";
+deprecations always pair a sunset date with a named migration path.
+
+## Troubleshooting guide
+
+```
+# Troubleshooting {product/feature}
+Scope statement                  — what this guide covers
+## {Symptom}                     — heading = what the user SEES: exact error text or
+                                   the observable misbehavior (repeat per symptom)
+### Cause                        — one cause at a time; multiple causes → multiple blocks
+### Solution / workaround        — steps for THIS cause, ending with what success
+                                   looks like
+### For more information         — related articles, runbooks
+```
+
+Quality bar:
+
+- **Symptom-first organization** — what the user experiences and would search
+  for, never cause-first or architecture-first.
+- **Strict symptom → cause → resolution triples**; every resolution states the
+  expected post-fix behavior.
+- **Error text quoted exactly** so Ctrl-F and search engines hit.

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -20,6 +20,13 @@
  *      identifier-factory names, and the value-protocol exports in
  *      `lang-kotlin` source must all appear in the skmtc-lang-kotlin
  *      skill (catches "six-type" wording and missing-protocol drift).
+ *   4. DOCS-WRITING TREE SYNC — the docs-writing skill's §3 Diátaxis
+ *      mapping names every content directory that exists on disk, and
+ *      extending/ mirrors using/'s subdirectory trio.
+ *   5. FILLER-WORD GUARD — "simply"/"easily"/"obviously"/"as of this
+ *      writing" (banned by docs-writing §4) must not appear in the
+ *      reader-facing tree (using/extending/reference/concepts/
+ *      explanation).
  *
  *   exit 0 — all checks hold.
  *   exit 1 — one or more failed; each failure names file + expectation.
@@ -30,33 +37,33 @@
  * `deno task verify-docs`.
  */
 
-import { dirname, fromFileUrl, join } from 'jsr:@std/path@^1'
+import { dirname, fromFileUrl, join } from "jsr:@std/path@^1";
 
-const docsDir = dirname(fromFileUrl(import.meta.url))
-const denoDir = join(docsDir, '..')
+const docsDir = dirname(fromFileUrl(import.meta.url));
+const denoDir = join(docsDir, "..");
 
-let failures = 0
+let failures = 0;
 
 const fail = (message: string): void => {
-  failures++
-  console.log(`FAIL  ${message}`)
-}
+  failures++;
+  console.log(`FAIL  ${message}`);
+};
 
 const pass = (message: string): void => {
-  console.log(`ok    ${message}`)
-}
+  console.log(`ok    ${message}`);
+};
 
 const numberWords: Record<number, string> = {
-  2: 'two',
-  3: 'three',
-  4: 'four',
-  5: 'five',
-  6: 'six',
-  7: 'seven',
-  8: 'eight',
-  9: 'nine',
-  10: 'ten'
-}
+  2: "two",
+  3: "three",
+  4: "four",
+  5: "five",
+  6: "six",
+  7: "seven",
+  8: "eight",
+  9: "nine",
+  10: "ten",
+};
 
 // ---------------------------------------------------------------------
 // 1. Fact-list sync: skmtc-generator SKILL.md §1 ↔ llms.md "Read this
@@ -64,68 +71,82 @@ const numberWords: Record<number, string> = {
 //    match its own list length.
 // ---------------------------------------------------------------------
 
-type FactList = { headerWord: string | undefined; count: number }
+type FactList = { headerWord: string | undefined; count: number };
 
-const parseFactList = (text: string, headerPattern: RegExp): FactList | undefined => {
-  const lines = text.split('\n')
-  const start = lines.findIndex(line => headerPattern.test(line))
+const parseFactList = (
+  text: string,
+  headerPattern: RegExp,
+): FactList | undefined => {
+  const lines = text.split("\n");
+  const start = lines.findIndex((line) => headerPattern.test(line));
 
   if (start === -1) {
-    return undefined
+    return undefined;
   }
 
   const headerWord = lines[start].match(
-    new RegExp(`(${Object.values(numberWords).join('|')}) facts`, 'i')
-  )?.[1]?.toLowerCase()
+    new RegExp(`(${Object.values(numberWords).join("|")}) facts`, "i"),
+  )?.[1]?.toLowerCase();
 
-  let count = 0
+  let count = 0;
   for (const line of lines.slice(start + 1)) {
-    if (/^## /.test(line)) break
-    if (/^\d+\. \*\*/.test(line)) count++
+    if (/^## /.test(line)) break;
+    if (/^\d+\. \*\*/.test(line)) count++;
   }
 
-  return { headerWord, count }
-}
+  return { headerWord, count };
+};
 
-const llmsPath = join(docsDir, 'llms.md')
-const generatorSkillPath = join(docsDir, 'skills', 'skmtc-generator', 'SKILL.md')
+const llmsPath = join(docsDir, "llms.md");
+const generatorSkillPath = join(
+  docsDir,
+  "skills",
+  "skmtc-generator",
+  "SKILL.md",
+);
 
 const llmsFacts = parseFactList(
   await Deno.readTextFile(llmsPath),
-  /^## Read this first/
-)
+  /^## Read this first/,
+);
 const skillFacts = parseFactList(
   await Deno.readTextFile(generatorSkillPath),
-  /^## 1\. The \w+ facts/
-)
+  /^## 1\. The \w+ facts/,
+);
 
 if (!llmsFacts) {
-  fail('llms.md: "Read this first" section not found')
+  fail('llms.md: "Read this first" section not found');
 } else if (!skillFacts) {
-  fail('skmtc-generator SKILL.md: "§1 The <n> facts" section not found')
+  fail('skmtc-generator SKILL.md: "§1 The <n> facts" section not found');
 } else {
   if (llmsFacts.count !== skillFacts.count) {
     fail(
       `fact-list drift: llms.md has ${llmsFacts.count} facts, ` +
         `skmtc-generator SKILL.md §1 has ${skillFacts.count} — re-sync them ` +
-        `(the generator skill mirrors llms.md; the other skills tune their own lists)`
-    )
+        `(the generator skill mirrors llms.md; the other skills tune their own lists)`,
+    );
   } else {
-    pass(`fact-list sync: llms.md and generator skill both list ${llmsFacts.count} facts`)
+    pass(
+      `fact-list sync: llms.md and generator skill both list ${llmsFacts.count} facts`,
+    );
   }
 
-  for (const [name, facts] of [
-    ['llms.md', llmsFacts],
-    ['skmtc-generator SKILL.md', skillFacts]
-  ] as const) {
-    const expected = numberWords[facts.count]
+  for (
+    const [name, facts] of [
+      ["llms.md", llmsFacts],
+      ["skmtc-generator SKILL.md", skillFacts],
+    ] as const
+  ) {
+    const expected = numberWords[facts.count];
     if (facts.headerWord !== expected) {
       fail(
-        `${name}: header says "${facts.headerWord ?? '<no number word>'} facts" ` +
-          `but the list has ${facts.count} items (expected "${expected}")`
-      )
+        `${name}: header says "${
+          facts.headerWord ?? "<no number word>"
+        } facts" ` +
+          `but the list has ${facts.count} items (expected "${expected}")`,
+      );
     } else {
-      pass(`${name}: header word matches list length`)
+      pass(`${name}: header word matches list length`);
     }
   }
 }
@@ -137,60 +158,71 @@ if (!llmsFacts) {
 // ---------------------------------------------------------------------
 
 const deadModelPatterns: { name: string; pattern: RegExp }[] = [
-  { name: 'resolveLang', pattern: /resolveLang/ },
+  { name: "resolveLang", pattern: /resolveLang/ },
   { name: "engine-start lang error", pattern: /declares no 'lang'/ },
-  { name: 'required lang field', pattern: /required\*?\*? `lang` field/ },
-  { name: 'lang declared on the entry', pattern: /entry declares (?:a|the generator's) `?lang`?/ },
-  { name: 'lang resolved by generatorId', pattern: /resolv\w+ (?:it|the language) by `?generatorId`?/ }
-]
+  { name: "required lang field", pattern: /required\*?\*? `lang` field/ },
+  {
+    name: "lang declared on the entry",
+    pattern: /entry declares (?:a|the generator's) `?lang`?/,
+  },
+  {
+    name: "lang resolved by generatorId",
+    pattern: /resolv\w+ (?:it|the language) by `?generatorId`?/,
+  },
+];
 
 const historicalMarkers =
-  /no longer|deleted|superseded|unwound|there is no|gone|incorrect|pre-0\.8|0\.7\.x|interim|historical|was the/i
+  /no longer|deleted|superseded|unwound|there is no|gone|incorrect|pre-0\.8|0\.7\.x|interim|historical|was the/i;
 
-const surfaceFiles: string[] = [llmsPath]
+const surfaceFiles: string[] = [llmsPath];
 
 const collect = async (dir: string, suffixes: string[]): Promise<void> => {
   for await (const entry of Deno.readDir(dir)) {
-    const path = join(dir, entry.name)
+    const path = join(dir, entry.name);
     if (entry.isDirectory) {
-      await collect(path, suffixes)
-    } else if (suffixes.some(suffix => entry.name.endsWith(suffix))) {
-      surfaceFiles.push(path)
+      await collect(path, suffixes);
+    } else if (suffixes.some((suffix) => entry.name.endsWith(suffix))) {
+      surfaceFiles.push(path);
     }
   }
-}
+};
 
-await collect(join(docsDir, 'concepts'), ['.md'])
-await collect(join(docsDir, 'reference'), ['.md'])
-for await (const entry of Deno.readDir(join(docsDir, 'skills'))) {
-  if (!entry.isDirectory) continue
-  const skillFile = join(docsDir, 'skills', entry.name, 'SKILL.md')
+await collect(join(docsDir, "concepts"), [".md"]);
+await collect(join(docsDir, "reference"), [".md"]);
+for await (const entry of Deno.readDir(join(docsDir, "skills"))) {
+  if (!entry.isDirectory) continue;
+  const skillFile = join(docsDir, "skills", entry.name, "SKILL.md");
   try {
-    await Deno.stat(skillFile)
-    surfaceFiles.push(skillFile)
+    await Deno.stat(skillFile);
+    surfaceFiles.push(skillFile);
   } catch {
     // skill dir without SKILL.md — nothing to check
   }
 }
-await collect(join(docsDir, 'skills', 'skmtc-generator', 'eval'), ['.md', '.json'])
+await collect(join(docsDir, "skills", "skmtc-generator", "eval"), [
+  ".md",
+  ".json",
+]);
 
-let deadModelHits = 0
+let deadModelHits = 0;
 for (const file of surfaceFiles) {
-  const lines = (await Deno.readTextFile(file)).split('\n')
+  const lines = (await Deno.readTextFile(file)).split("\n");
   lines.forEach((line, index) => {
     for (const { name, pattern } of deadModelPatterns) {
       if (pattern.test(line) && !historicalMarkers.test(line)) {
-        deadModelHits++
+        deadModelHits++;
         fail(
           `dead-model claim (${name}) without a historical marker: ` +
-            `${file.replace(denoDir + '/', '')}:${index + 1}`
-        )
+            `${file.replace(denoDir + "/", "")}:${index + 1}`,
+        );
       }
     }
-  })
+  });
 }
 if (deadModelHits === 0) {
-  pass(`dead-model guard: no affirmative 0.7.x interim-model claims across ${surfaceFiles.length} files`)
+  pass(
+    `dead-model guard: no affirmative 0.7.x interim-model claims across ${surfaceFiles.length} files`,
+  );
 }
 
 // ---------------------------------------------------------------------
@@ -198,51 +230,200 @@ if (deadModelHits === 0) {
 // ---------------------------------------------------------------------
 
 const languageSyncTargets = [
-  { packageDirectory: 'lang-kotlin', skillName: 'skmtc-lang-kotlin', guardPrefix: 'isKt' },
-  { packageDirectory: 'lang-csharp', skillName: 'skmtc-lang-csharp', guardPrefix: 'isCs' }
-]
+  {
+    packageDirectory: "lang-kotlin",
+    skillName: "skmtc-lang-kotlin",
+    guardPrefix: "isKt",
+  },
+  {
+    packageDirectory: "lang-csharp",
+    skillName: "skmtc-lang-csharp",
+    guardPrefix: "isCs",
+  },
+];
 
-for (const { packageDirectory, skillName, guardPrefix } of languageSyncTargets) {
-  const skillPath = join(docsDir, 'skills', skillName, 'SKILL.md')
-  const skill = await Deno.readTextFile(skillPath)
+for (
+  const { packageDirectory, skillName, guardPrefix } of languageSyncTargets
+) {
+  const skillPath = join(docsDir, "skills", skillName, "SKILL.md");
+  const skill = await Deno.readTextFile(skillPath);
   const factories = await Deno.readTextFile(
-    join(denoDir, packageDirectory, 'src', 'createIdentifier.ts')
-  )
-  const packageMod = await Deno.readTextFile(join(denoDir, packageDirectory, 'mod.ts'))
+    join(denoDir, packageDirectory, "src", "createIdentifier.ts"),
+  );
+  const packageMod = await Deno.readTextFile(
+    join(denoDir, packageDirectory, "mod.ts"),
+  );
 
   const factoryNames = [
-    ...new Set([...factories.matchAll(/export const (create[A-Z]\w+)/g)].map(m => m[1]))
-  ]
+    ...new Set(
+      [...factories.matchAll(/export const (create[A-Z]\w+)/g)].map((m) =>
+        m[1]
+      ),
+    ),
+  ];
 
-  const kindWord = numberWords[factoryNames.length]
+  const kindWord = numberWords[factoryNames.length];
   if (!skill.includes(`${kindWord} entity kinds`)) {
     fail(
       `${skillName} SKILL.md: expected "${kindWord} entity kinds" ` +
-        `(${packageDirectory} exports ${factoryNames.length} identifier factories: ${factoryNames.join(', ')})`
-    )
+        `(${packageDirectory} exports ${factoryNames.length} identifier factories: ${
+          factoryNames.join(", ")
+        })`,
+    );
   } else {
-    pass(`${packageDirectory} type vocabulary: skill says "${kindWord} entity kinds" matching ${factoryNames.length} factories`)
+    pass(
+      `${packageDirectory} type vocabulary: skill says "${kindWord} entity kinds" matching ${factoryNames.length} factories`,
+    );
   }
 
   for (const factory of factoryNames) {
     if (!skill.includes(factory)) {
-      fail(`${skillName} SKILL.md: identifier factory ${factory} is exported but never mentioned`)
+      fail(
+        `${skillName} SKILL.md: identifier factory ${factory} is exported but never mentioned`,
+      );
     }
   }
 
-  const guardPattern = new RegExp(`\\b(${guardPrefix}[A-Z]\\w+)`, 'g')
-  const protocolGuards = [...new Set([...packageMod.matchAll(guardPattern)].map(m => m[1]))]
+  const guardPattern = new RegExp(`\\b(${guardPrefix}[A-Z]\\w+)`, "g");
+  const protocolGuards = [
+    ...new Set([...packageMod.matchAll(guardPattern)].map((m) => m[1])),
+  ];
   for (const guard of protocolGuards) {
     if (!skill.includes(guard)) {
-      fail(`${skillName} SKILL.md: value-protocol guard ${guard} is exported but never mentioned`)
+      fail(
+        `${skillName} SKILL.md: value-protocol guard ${guard} is exported but never mentioned`,
+      );
     }
   }
-  if (protocolGuards.every(guard => skill.includes(guard))) {
-    pass(`${packageDirectory} protocols: all ${protocolGuards.length} exported guards (${protocolGuards.join(', ')}) appear in the skill`)
+  if (protocolGuards.every((guard) => skill.includes(guard))) {
+    pass(
+      `${packageDirectory} protocols: all ${protocolGuards.length} exported guards (${
+        protocolGuards.join(", ")
+      }) appear in the skill`,
+    );
   }
 }
 
 // ---------------------------------------------------------------------
+// 4. Docs-writing tree sync — the docs-writing skill's §3 parenthetical
+//    maps Diátaxis onto this tree's directory names. The v0.1.0 mapping
+//    had already drifted (recipes/ existed but wasn't mentioned), so
+//    both directions are checked: every content directory on disk is
+//    named in the skill, and extending/ mirrors using/'s trio (the
+//    skill claims "same trio").
+// ---------------------------------------------------------------------
 
-console.log(`\n${failures === 0 ? 'All doc-sync checks hold.' : `${failures} check(s) failed.`}`)
-Deno.exit(failures > 0 ? 1 : 0)
+const docsWritingSkillPath = join(
+  docsDir,
+  "skills",
+  "docs-writing",
+  "SKILL.md",
+);
+const docsWritingSkill = await Deno.readTextFile(docsWritingSkillPath);
+
+const listSubdirectories = async (dir: string): Promise<string[]> => {
+  const names: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isDirectory) names.push(entry.name);
+  }
+  return names.sort();
+};
+
+const usingSubdirectories = await listSubdirectories(join(docsDir, "using"));
+const extendingSubdirectories = await listSubdirectories(
+  join(docsDir, "extending"),
+);
+
+let treeSyncFailures = 0;
+
+for (const name of usingSubdirectories) {
+  if (!docsWritingSkill.includes(`using/${name}/`)) {
+    treeSyncFailures++;
+    fail(
+      `docs-writing SKILL.md: docs/using/${name}/ exists but the §3 tree mapping doesn't name \`using/${name}/\``,
+    );
+  }
+}
+
+if (usingSubdirectories.join(",") !== extendingSubdirectories.join(",")) {
+  treeSyncFailures++;
+  fail(
+    `docs-writing SKILL.md claims extending/ mirrors using/'s trio, but ` +
+      `using/ has [${usingSubdirectories.join(", ")}] and extending/ has [${
+        extendingSubdirectories.join(", ")
+      }]`,
+  );
+}
+
+for (const name of ["extending/", "reference/", "concepts/", "explanation/"]) {
+  if (!docsWritingSkill.includes(`\`${name}\``)) {
+    treeSyncFailures++;
+    fail(`docs-writing SKILL.md: §3 tree mapping doesn't name \`${name}\``);
+  }
+}
+
+if (treeSyncFailures === 0) {
+  pass(
+    `docs-writing tree sync: skill names all ${usingSubdirectories.length} using/ subdirectories ` +
+      `+ the top-level content dirs; extending/ mirrors using/`,
+  );
+}
+
+// ---------------------------------------------------------------------
+// 5. Filler-word guard — the docs-writing skill (§4) bans "simply",
+//    "easily", "obviously", and "as of this writing" as filler that
+//    condescends when the step isn't easy for the reader. Enforced
+//    zero-tolerance across the reader-facing tree. Deliberately NOT
+//    checked: "just" and "currently" — both have too many legitimate
+//    uses here ("just-in-time", version-scoped capability statements
+//    like "does not currently retry"); those stay a review concern.
+//    skills/ is excluded: the docs-writing skill quotes the banned
+//    words as counter-examples.
+// ---------------------------------------------------------------------
+
+const fillerPattern = /\b(simply|easily|obviously)\b|as of this writing/i;
+
+const readerFacingFiles: string[] = [];
+for (
+  const dir of ["using", "extending", "reference", "concepts", "explanation"]
+) {
+  const collectMarkdown = async (root: string): Promise<void> => {
+    for await (const entry of Deno.readDir(root)) {
+      const path = join(root, entry.name);
+      if (entry.isDirectory) await collectMarkdown(path);
+      else if (entry.name.endsWith(".md")) readerFacingFiles.push(path);
+    }
+  };
+  await collectMarkdown(join(docsDir, dir));
+}
+
+let fillerHits = 0;
+for (const file of readerFacingFiles) {
+  const lines = (await Deno.readTextFile(file)).split("\n");
+  lines.forEach((line, index) => {
+    const match = line.match(fillerPattern);
+    if (match) {
+      fillerHits++;
+      fail(
+        `filler word "${match[0]}" (banned by docs-writing §4): ` +
+          `${file.replace(denoDir + "/", "")}:${index + 1}`,
+      );
+    }
+  });
+}
+if (fillerHits === 0) {
+  pass(
+    `filler-word guard: no simply/easily/obviously across ${readerFacingFiles.length} reader-facing files`,
+  );
+}
+
+// ---------------------------------------------------------------------
+
+console.log(
+  `\n${
+    failures === 0
+      ? "All doc-sync checks hold."
+      : `${failures} check(s) failed.`
+  }`,
+);
+Deno.exit(failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Reworks the `docs-writing` skill from a single-source (Mintlify) distillation into a verified, template-backed craft skill, and lands the docs eval harness it plugs into.

### docs-writing v0.2.0 (`deno/docs/skills/docs-writing/`)
- **Diversified sources**: Diátaxis in depth (the compass, type≠difficulty, per-type voice, the recipes ruling), Google + Microsoft style guides (word-level bad→good rules, procedure mechanics, global-audience rules), Every Page Is Page One, Write the Docs (ARID), Docs for Developers (friction log, sequenced editing passes), NN/g reading research.
- **Verify-first is principle #1**: never document behavior you haven't executed or read in source — the agent-as-writer failure mode (hallucinated flags, documented intent vs. behavior).
- **Contested seams resolved as house policy**, with a decision log in `design.md` so choices don't get relitigated (Diátaxis purity with a scoped API-reference carve-out; "cut words, not context"; select over click; ARID with canonical homes).
- **Companions**: `templates.md` (eight page skeletons + quality bars — how-to, tutorial, reference, concept, README, changelog, release notes, troubleshooting) and `mechanics.md` (Vale/markdownlint/lychee/doc-testing configs + the llms.txt format).

### Verification loop
- **`verify-docs.ts` checks 4+5**: Diátaxis tree-mapping sync (both directions — catches the drift class where `using/recipes/` existed but the skill didn't name it) and a zero-tolerance filler-word guard (`simply`/`easily`/`obviously`/`as of this writing`) across the 137 reader-facing docs files. The seven pre-existing filler hits are fixed in this PR. `just`/`currently` deliberately not checked (too many legitimate version-scoped uses). The file is normalized to `deno fmt` in passing — it predated fmt compliance, hence the quote-churn in the diff.
- **`evals/`**: the docs eval harness (runner, graders, calibrate, smoke/diagnose/author tasks — previously uncommitted, awaiting review) plus a new **`rewrite-flawed-page`** task exercising the docs-writing skill: a flawed how-to page whose central fault is a documented `--force` flag that doesn't exist in the ground-truth CLI (`--overwrite` is real). The llm-judge rubric is keyed to the skill's pre-publish checklist and fails any rewrite that keeps invented flags, however clean the prose. The fixture is self-verifying (proves the tool's real behavior and the planted faults) with no skmtc/network dependency. Not yet run — needs a with-docs + no-docs trial pair.

## Test plan
- [x] `deno run --allow-read deno/docs/verify-docs.ts` — all 10 checks pass
- [x] `deno fmt --check` clean on all touched files
- [x] `rewrite-flawed-page` fixture executed end-to-end against a scratch sandbox (self-verification passes; planted CLI type-checks)
- [ ] Eval trial pair (with-docs + no-docs) for `rewrite-flawed-page` — deliberately deferred (paid agent runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)