### PR TITLE
fix(vite): add repository field so npm provenance passes

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -2,6 +2,14 @@
   "name": "@skmtc/vite",
   "version": "0.1.0",
   "type": "module",
+  "license": "Apache-2.0",
+  "homepage": "https://skm.tc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/skmtc/skmtc.git",
+    "directory": "packages/vite"
+  },
+  "bugs": "https://github.com/skmtc/skmtc/issues",
   "sideEffects": false,
   "files": [
     "dist"


### PR DESCRIPTION
The release run for `@skmtc/vite@0.1.0` (from #29) built and signed fine but failed at the final npm step:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/skmtc/skmtc" from provenance
```

`npm publish --provenance` cross-checks `package.json` `repository.url` against the OIDC build provenance, and the manifest had no `repository` field.

## Fix
- Add `repository` (`https://github.com/skmtc/skmtc.git`, `directory: packages/vite`), plus `license`/`homepage`/`bugs`.

`0.1.0` was rejected by the 422 (never actually published), so once this merges the publish workflow republishes `0.1.0` cleanly — no version bump needed. Trusted Publisher config on npmjs.com is already in place.