### PR TITLE
chore(vite): bump @skmtc/vite 0.1.0 → 0.1.1

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://skm.tc",


### PR DESCRIPTION
Bumps `@skmtc/vite` `0.1.0` → `0.1.1` so the loopback token handshake (merged in #31) actually gets published to npm.

#31 was merged while its head was still at version `0.1.0`, so the Publish workflow saw npm already had `0.1.0` and skipped — the handshake feature is on `main` but unpublished. This is the one-line follow-up: on merge to `main`, the Publish workflow will build `dist/` and `npm publish` `0.1.1`.

Diff is a single line (the `version` field). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)