### PR TITLE
fix(vite): items probe branch must be structural, not an indexed access

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://skm.tc",

--- a/packages/vite/src/input-matcher.test.ts
+++ b/packages/vite/src/input-matcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import ts from 'typescript'
 import {
   classify,
   renderProbe,
@@ -6,6 +7,31 @@ import {
   type MatcherSubject,
   type ProbeLayout
 } from './input-matcher.ts'
+
+// Type-check a self-contained probe string and return its error messages —
+// lib files come from disk (ts.sys), only the probe file is served in-memory.
+const typeErrorsOf = (source: string): string[] => {
+  const fileName = '/probe.ts'
+  const options: ts.CompilerOptions = {
+    noEmit: true,
+    strict: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2020
+  }
+  const host = ts.createCompilerHost(options)
+  const getSourceFile = host.getSourceFile.bind(host)
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? ts.createSourceFile(fileName, source, ts.ScriptTarget.ES2020, true)
+      : getSourceFile(name, languageVersion, onError, shouldCreate)
+  host.fileExists = (name) => name === fileName || ts.sys.fileExists(name)
+  host.readFile = (name) => (name === fileName ? source : ts.sys.readFile(name))
+  const program = ts.createProgram([fileName], options, host)
+  return ts
+    .getPreEmitDiagnostics(program)
+    .filter((diagnostic) => diagnostic.file?.fileName === fileName)
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+}
 
 const operation = (path: string, method: string): MatcherSubject => ({
   type: 'operation',
@@ -213,11 +239,33 @@ describe('renderProbe', () => {
     })
     const lines = layout.text.split('\n')
     expect(lines).toContain(`type __D0 = ApplicantModelPagedResult['_embedded']`)
+    // The `items` fallback is a STRUCTURAL `extends { items }` check, never an
+    // indexed access — see the compile test below for why.
     expect(lines).toContain(
-      `type __D1 = NonNullable<__D0> extends ReadonlyArray<infer __El1> ? __El1 : NonNullable<__D0>['items']`
+      `type __D1 = NonNullable<__D0> extends ReadonlyArray<infer __El1> ? __El1 : NonNullable<__D0> extends { items: infer __It1 } ? __It1 : never`
     )
     expect(lines).toContain(`type __D2 = NonNullable<__D1>['name']`)
     expect(layout.text).toContain('type __F = __D2')
+  })
+
+  it('the `items` probe COMPILES against an array element (regression)', () => {
+    // Guards the real bug: an indexed-access fallback `SomeArray['items']` in the
+    // conditional's non-taken branch is still type-checked by TS and errors,
+    // breaking every list column. A string check alone missed it — compile it.
+    const layout = renderProbe({
+      modelName: 'Envelope',
+      modelImportPath: './fixture',
+      moduleTypeSource: 'export type S<F> = F',
+      moduleTypeName: 'S',
+      segments: ['_embedded', 'items', 'name'],
+      candidates: []
+    })
+    // Swap the import for an inline model so the probe is self-contained.
+    const source = layout.text.replace(
+      /^import type .*$/m,
+      'type Envelope = { _embedded?: Array<{ name: string }> | null }'
+    )
+    expect(typeErrorsOf(source)).toEqual([])
   })
 
   it('escapes quotes and backslashes in property segments', () => {

--- a/packages/vite/src/input-matcher.ts
+++ b/packages/vite/src/input-matcher.ts
@@ -193,12 +193,16 @@ export const renderProbe = (input: ProbeInput): ProbeLayout => {
   segments.forEach((segment, index) => {
     segmentLines.push(lines.length)
     const base = index === 0 ? modelName : `NonNullable<__D${index - 1}>`
-    // `items` steps into the array's element. The conditional keeps it correct
-    // even if a real object property is literally named `items` — only the
-    // array branch fires when the base actually is an array.
+    // `items` steps into the array's element — OR, if a real object property is
+    // literally named `items`, into that property (e.g. `/worksOrders/{id}`).
+    // The fallback MUST be a structural `extends { items }` check, NOT an
+    // indexed access `${base}['items']`: TS eagerly type-checks the non-taken
+    // conditional branch, and `SomeArray['items']` is an error (arrays have no
+    // `items`), which would break the common array case. `extends { items }`
+    // resolves to `never` instead of erroring.
     lines.push(
       segment === ARRAY_ITEM_SEGMENT
-        ? `type __D${index} = ${base} extends ReadonlyArray<infer __El${index}> ? __El${index} : ${base}['items']`
+        ? `type __D${index} = ${base} extends ReadonlyArray<infer __El${index}> ? __El${index} : ${base} extends { items: infer __It${index} } ? __It${index} : never`
         : `type __D${index} = ${base}['${escapeSegment(segment)}']`
     )
   })


### PR DESCRIPTION
`@skmtc/vite@0.2.0` broke **every list column** in the picker: the `items` array-element step's conditional used an indexed-access fallback `SomeArray['items']`, and TypeScript **eagerly type-checks the non-taken branch of a conditional type**, so `AreaModel[]['items']` errored (`Property 'items' does not exist`). The probe failed to compile → the matcher reported `path-broken at "items"` (e.g. *"'items' no longer exists on AreaModelPagedResult"*).

## Fix
Structural fallback `X extends { items: infer I } ? I : never` — resolves to `never` without erroring, so:
- array `_embedded` → `items` → element ✓ compiles
- object with a real `items` array property (`/worksOrders/{id}`) → `items` → the property, then `items` → its element ✓

## Test
Adds a test that **compiles** a rendered probe (verified it fails on the old form: `Property 'items' does not exist on type '{ name: string; }[]'`, passes on the new). The prior test only asserted the probe *string*, which is exactly why this slipped through 0.2.0.

Patch bump to `0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)