### PR TITLE
docs: switch install instructions to the skm.tc curl installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@
 ### Install Skmtc
 
 ```bash
-deno install -g -A --unstable-worker-options jsr:@skmtc/cli@0.0.405 -n skmtc -f
+curl -fsSL https://skm.tc/install | sh
 ```
 
-**Skmtc** runs on [Deno](https://deno.com). You can install it using 
-- `curl -fsSL https://deno.land/install.sh | sh` on MacOS/Linux
-- `irm https://deno.land/install.ps1 | iex` on Windows
+This installs the latest `skmtc` CLI, bootstrapping [Deno](https://deno.com)
+(its runtime) automatically if it isn't already installed. To pin a specific
+version, set `SKMTC_VERSION`:
+
+```bash
+SKMTC_VERSION=0.9.26 curl -fsSL https://skm.tc/install | sh
+```
 
 ### Create project and generate artifacts using TUI
 

--- a/deno/cli/README.md
+++ b/deno/cli/README.md
@@ -15,11 +15,13 @@
 
 ## 🚀 Quick Start
 
-Skmtc is a Deno CLI. Install it from JSR:
+Skmtc is a Deno CLI. Install the latest version with:
 
 ```bash
-deno install -g -A --unstable-worker-options jsr:@skmtc/cli -n skmtc -f
+curl -fsSL https://skm.tc/install | sh
 ```
+
+This bootstraps [Deno](https://deno.com) (the runtime) automatically if needed.
 
 ### Running code generators
 
@@ -125,10 +127,11 @@ Yes! The generated code is framework-agnostic TypeScript that works with any bui
 
 ## 🛠️ Local development
 
-For day-to-day work the published JSR install is the right choice:
+For day-to-day work the published install is the right choice — pin a version
+with `SKMTC_VERSION`:
 
 ```bash
-deno install -g -A --unstable-worker-options jsr:@skmtc/cli@<version> -n skmtc -f
+SKMTC_VERSION=<version> curl -fsSL https://skm.tc/install | sh
 ```
 
 To install a binary that tracks your **local checkout** instead, use `deno compile` rather than `deno install`:

--- a/deno/core/README.md
+++ b/deno/core/README.md
@@ -13,11 +13,13 @@
 
 ## 🚀 Quick Start
 
-Skmtc is a Deno CLI. Install it from JSR:
+Skmtc is a Deno CLI. Install the latest version with:
 
 ```bash
-deno install -g -A --unstable-worker-options jsr:@skmtc/cli -n skmtc -f
+curl -fsSL https://skm.tc/install | sh
 ```
+
+This bootstraps [Deno](https://deno.com) (the runtime) automatically if needed.
 
 ### Running code generators
 

--- a/deno/docs/README.md
+++ b/deno/docs/README.md
@@ -3,7 +3,7 @@
 Generate idiomatic TypeScript source code from an OpenAPI v3 or GraphQL schema. Types, validators, query hooks, mocks, forms, and server routes — all from one schema, in one run, all consistent with each other.
 
 ```bash
-deno install --allow-read --allow-write --allow-net --allow-env --allow-run=deno,sh --allow-sys=homedir -g --unstable-worker-options -n skmtc jsr:@skmtc/cli
+curl -fsSL https://skm.tc/install | sh
 skmtc init my-api ./
 skmtc install @skmtc/gen-typescript @skmtc/gen-zod @skmtc/gen-tanstack-query-fetch-zod my-api
 skmtc generate my-api ./openapi.json
@@ -77,7 +77,7 @@ See [`explanation/comparison-to-other-tools.md`](explanation/comparison-to-other
 
 ## Quick start
 
-1. Install the CLI: `deno install --allow-read --allow-write --allow-net --allow-env --allow-run=deno,sh --allow-sys=homedir -g --unstable-worker-options -n skmtc jsr:@skmtc/cli`
+1. Install the CLI: `curl -fsSL https://skm.tc/install | sh`
 2. Create a project: `skmtc init my-api ./`
 3. Install generators: `skmtc install @skmtc/gen-typescript @skmtc/gen-zod my-api`
 4. Configure a schema source in `.skmtc/my-api/.settings/client.json`


### PR DESCRIPTION
## Summary

Replaces the raw `deno install` incantations in the root, CLI, core and docs READMEs with the hosted installer:

```bash
curl -fsSL https://skm.tc/install | sh
```

The script bootstraps Deno automatically if it isn't on PATH, applies the right permission flags and `--unstable-worker-options`, and always installs the latest published CLI (`--minimum-dependency-age=0`, so a fresh release installs immediately). Version pinning is documented via `SKMTC_VERSION=<version>`.

This matches the new skmtc-hub logged-out homepage (skmtc/skmtc-hub#15), which presents the same one-liner, so every entry point now gives identical install instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)