### PR TITLE
feat(cli): add -v / --version flag

### DIFF
--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {

--- a/deno/cli/mod.ts
+++ b/deno/cli/mod.ts
@@ -1,6 +1,7 @@
 import { Command, EnumType } from '@cliffy/command'
 import { assertJsrReachable, JsrRegistryUnreachableError } from '@/lib/jsr-registry.ts'
 import { getCommandDescriptor } from '@/lib/cli-schema.ts'
+import denoJson from './deno.json' with { type: 'json' }
 
 // Sentry.init({
 //   dsn: 'https://9904234a7aabfeff2145622ccb0824e3@o4508018789646336.ingest.de.sentry.io/4509532871262288'
@@ -31,6 +32,9 @@ const COMMANDS_THAT_SKIP_REGISTRY_CHECK = new Set<string>([
 ])
 
 const shouldSkipRegistryCheck = (args: readonly string[]): boolean => {
+  // `skmtc --version` / `-v` prints a local constant — it must stay
+  // instant and work offline, so never gate it behind the JSR check.
+  if (args[0] === '--version' || args[0] === '-v') return true
   const firstArg = args.find(arg => !arg.startsWith('-'))
   if (!firstArg) return false
   return COMMANDS_THAT_SKIP_REGISTRY_CHECK.has(firstArg)
@@ -544,6 +548,16 @@ const run = async () => {
 
   await new Command()
     .description('Generate code from an OpenAPI or GraphQL schema')
+    // Root-local (not global) so it never clashes with `publish
+    // --version <v>`. `standalone` means it can't be combined with a
+    // subcommand; the action prints the version and exits.
+    .option('-v, --version', 'Show the SKMTC CLI version and exit.', {
+      standalone: true,
+      action: () => {
+        console.log(denoJson.version)
+        Deno.exit(0)
+      }
+    })
     .action(async _flags => {
       const { runPrompt } = await import('@/prompt/run-prompt.tsx')
       await runPrompt()


### PR DESCRIPTION
## What

`skmtc` had no way to report its own version — `skmtc --version` errored with `Unknown option "--version"` (and there was no `version` subcommand). This adds a root-level `-v, --version` flag that prints the CLI version and exits.

Surfaced while cold-walking the getting-started tutorial: Step 1's `skmtc --version` verify command didn't exist.

## How

- Prints the version read from the CLI's own `deno.json` via `import ... with { type: 'json' }` — the same source-of-truth pattern `doctor` and `agent-context` already use (no hardcoded/drifting constant).
- Lowercase **`-v`** as well as `--version` (cliffy's built-in `.version()` only registers capital `-V`).
- **Root-local** option, not a global one, so it never collides with the existing `publish --version <version>` option.
- **Offline-safe**: skips the JSR reachability pre-flight so the flag is instant and works without a network.

## Release

Bumps `@skmtc/cli` `0.9.26 → 0.9.27` so the merge-to-`main` cascade publishes it to jsr.io.

## Verification

- `skmtc --version` and `skmtc -v` → print `0.9.27`, exit 0
- `--help` lists `-v, --version  Show the SKMTC CLI version and exit.`
- `skmtc publish --help` still shows its own `--version <version>` (unaffected)
- `deno check mod.ts` clean; `deno publish --dry-run` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)