### PR TITLE
fix(vite): monorepo preview support (@skmtc/vite 0.2.3)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://skm.tc",

--- a/packages/vite/src/manifest.test.ts
+++ b/packages/vite/src/manifest.test.ts
@@ -54,3 +54,47 @@ describe('readPreviews', () => {
     expect(await readPreviews(join(root, 'nope'), project)).toEqual([])
   })
 })
+
+describe('readPreviews — monorepo basePath', () => {
+  const project = 'lighthouse-ui'
+  let root: string
+
+  // Monorepo layout: the skmtc project lives at the repo root but the app is
+  // nested (`basePath: apps/lighthouse-ui/src`), so `files` keys are full
+  // on-disk paths (`apps/…`). The `@/…` `destinationPath` — not the key — is
+  // what a preview's `exportPath` matches. Building the emitted set from the
+  // raw keys treats every preview as a phantom → 0 previews (the bug).
+  const monorepoManifest = {
+    files: {
+      'apps/lighthouse-ui/src/tables/ContactsTable.generated.tsx': {
+        lines: 1,
+        destinationPath: '@/tables/ContactsTable.generated.tsx'
+      }
+    },
+    previews: {
+      ContactsTable: {
+        name: 'ContactsTable',
+        module: {
+          name: 'ContactsTable',
+          exportPath: '@/tables/ContactsTable.generated.tsx'
+        },
+        source: { type: 'model', refName: 'Contacts' }
+      }
+    }
+  }
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'skmtc-previews-monorepo-'))
+    const dir = join(root, '.skmtc', project, '.settings')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'manifest.json'), JSON.stringify(monorepoManifest))
+  })
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('keeps previews when files keys are basePath-prefixed but destinationPath is @/-aliased', async () => {
+    const previews = await readPreviews(root, project)
+    expect(previews.map((preview) => preview.name)).toEqual(['ContactsTable'])
+  })
+})

--- a/packages/vite/src/manifest.test.ts
+++ b/packages/vite/src/manifest.test.ts
@@ -2,10 +2,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { readPreviews } from './manifest.ts'
+import { readPreviews, toModuleUrl } from './manifest.ts'
 
 describe('readPreviews', () => {
   const project = 'demo'
+  const basePath = 'src'
   let root: string
 
   // One preview backed by an emitted file (renderable) and one phantom: a
@@ -46,17 +47,25 @@ describe('readPreviews', () => {
   })
 
   it('drops phantom previews whose module was never written to disk', async () => {
-    const previews = await readPreviews(root, project)
+    const previews = await readPreviews(root, project, basePath)
     expect(previews.map((preview) => preview.name)).toEqual(['EnquiryTypeMultiSelectField'])
   })
 
+  it('resolves each preview to a Vite-servable /@fs/ module url', async () => {
+    const [preview] = await readPreviews(root, project, basePath)
+    expect(preview.module.url).toBe(
+      `/@fs${join(root, basePath, 'inputs/enums/EnquiryTypeMultiSelectField.generated.tsx')}`
+    )
+  })
+
   it('returns [] when the manifest is missing', async () => {
-    expect(await readPreviews(join(root, 'nope'), project)).toEqual([])
+    expect(await readPreviews(join(root, 'nope'), project, basePath)).toEqual([])
   })
 })
 
 describe('readPreviews — monorepo basePath', () => {
   const project = 'lighthouse-ui'
+  const basePath = 'apps/lighthouse-ui/src'
   let root: string
 
   // Monorepo layout: the skmtc project lives at the repo root but the app is
@@ -94,7 +103,36 @@ describe('readPreviews — monorepo basePath', () => {
   })
 
   it('keeps previews when files keys are basePath-prefixed but destinationPath is @/-aliased', async () => {
-    const previews = await readPreviews(root, project)
+    const previews = await readPreviews(root, project, basePath)
     expect(previews.map((preview) => preview.name)).toEqual(['ContactsTable'])
+  })
+
+  // Symptom 2: the module url must be an absolute /@fs/ path (Vite-root-
+  // independent), NOT the basePath-rooted `/apps/lighthouse-ui/src/…` that the
+  // nested app's Vite can't serve (SPA fallback → text/html → rejected as JS).
+  it('resolves the module url via /@fs/ absolute path, not a basePath-rooted url', async () => {
+    const [preview] = await readPreviews(root, project, basePath)
+    expect(preview.module.url).toBe(
+      `/@fs${join(root, basePath, 'tables/ContactsTable.generated.tsx')}`
+    )
+    // Absolute (/@fs/…), so it survives the Vite-root/skmtc-root split; NOT the
+    // bare basePath-rooted `/apps/lighthouse-ui/src/…` the nested app can't serve.
+    expect(preview.module.url.startsWith('/@fs/')).toBe(true)
+    expect(preview.module.url.startsWith('/apps/')).toBe(false)
+  })
+})
+
+describe('toModuleUrl', () => {
+  it('addresses the file via /@fs/ regardless of basePath depth', () => {
+    expect(toModuleUrl('/repo', 'apps/x/src', '@/tables/Foo.generated.tsx')).toBe(
+      '/@fs/repo/apps/x/src/tables/Foo.generated.tsx'
+    )
+    expect(toModuleUrl('/repo', 'src', '@/tables/Foo.generated.tsx')).toBe(
+      '/@fs/repo/src/tables/Foo.generated.tsx'
+    )
+  })
+
+  it('returns a non-alias path unchanged (nothing to resolve)', () => {
+    expect(toModuleUrl('/repo', 'src', '/already/absolute.tsx')).toBe('/already/absolute.tsx')
   })
 })

--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -8,15 +8,35 @@ import { join } from 'node:path'
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value)
 
-/** One renderable preview: the generated module to mount + the subject behind it. */
+/** One renderable preview: the generated module to mount + the subject behind it.
+ *  `url` is the browser-fetchable module URL the iframe harness imports (see
+ *  `toModuleUrl`); `exportPath` is kept as the raw `@/…` alias for callers that
+ *  match against the manifest (e.g. the input matcher). */
 export type Preview = {
   name: string
-  module: { name: string; exportPath: string }
+  module: { name: string; exportPath: string; url: string }
   source: Record<string, unknown>
 }
 
 const manifestPath = (root: string, project: string): string =>
   join(root, '.skmtc', project, '.settings', 'manifest.json')
+
+// Resolve a preview's `@/…` export path to a browser-fetchable module URL.
+//
+// The iframe harness dynamically imports this against the CONSUMER's Vite dev
+// server, which serves modules relative to its OWN root. In a monorepo the Vite
+// root (the nested app, e.g. `apps/x`) differs from the skmtc root (the repo
+// root holding `.skmtc/`), so a `basePath`-rooted URL like `/apps/x/src/…` — the
+// path relative to the skmtc root — isn't servable and hits the SPA fallback
+// (`text/html`, rejected as a JS module). We instead resolve to the file's
+// ABSOLUTE path and address it via Vite's `/@fs/` prefix, which Vite serves
+// regardless of its root — sidestepping the root-relativity entirely. In a
+// single-package repo (Vite root === skmtc root) this resolves to the same file
+// the old `/${basePath}/…` URL did. `basePath` is the generated-output dir
+// relative to the skmtc root; a non-`@/` path is returned unchanged (nothing to
+// resolve). POSIX absolute paths only (the preview stack is a local dev tool).
+export const toModuleUrl = (root: string, basePath: string, exportPath: string): string =>
+  exportPath.startsWith('@/') ? `/@fs${join(root, basePath, exportPath.slice(2))}` : exportPath
 
 // Normalize an artifact path to a key comparable across the manifest's two
 // representations: `previews` use the `@/…` export-path alias, `files` entries
@@ -44,7 +64,11 @@ const emittedKey = (key: string, entry: unknown): string =>
  *  The generate manifest can list previews for subjects whose file the generator
  *  declined to write (e.g. a `<Model>SelectField` registered for a non-enum ref),
  *  so cross-reference `files` and drop the phantoms. */
-export async function readPreviews(root: string, project: string): Promise<Preview[]> {
+export async function readPreviews(
+  root: string,
+  project: string,
+  basePath: string
+): Promise<Preview[]> {
   let parsed: unknown
   try {
     parsed = JSON.parse(await readFile(manifestPath(root, project), 'utf8'))
@@ -66,7 +90,11 @@ export async function readPreviews(root: string, project: string): Promise<Previ
     // Drop previews whose module was never written (no backing file → 404 on
     // import). When the manifest carries no `files` map, keep all (can't tell).
     if (emitted && !emitted.has(artifactKey(exportPath))) continue
-    previews.push({ name, module: { name: moduleName, exportPath }, source: entry.source })
+    previews.push({
+      name,
+      module: { name: moduleName, exportPath, url: toModuleUrl(root, basePath, exportPath) },
+      source: entry.source
+    })
   }
   return previews
 }

--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -19,10 +19,21 @@ const manifestPath = (root: string, project: string): string =>
   join(root, '.skmtc', project, '.settings', 'manifest.json')
 
 // Normalize an artifact path to a key comparable across the manifest's two
-// representations: `previews` use the `@/…` export-path alias, `files` use the
-// `src/…` on-disk path. Strip the leading root so a preview can be matched to
-// the file that actually backs it.
+// representations: `previews` use the `@/…` export-path alias, `files` entries
+// carry a matching `@/…` `destinationPath`. Strip the leading root so a preview
+// can be matched to the file that actually backs it.
 const artifactKey = (path: string): string => path.replace(/^(?:@\/|src\/|\.\/)/, '')
+
+// The `@/…`-aliased path a `files` entry writes to, which is what previews
+// reference. Prefer `destinationPath` over the object key: the key is the raw
+// on-disk path, so in a monorepo (`basePath: apps/x/src`) it carries an
+// `apps/…` prefix `artifactKey` can't strip and never matches a preview's
+// `@/…` exportPath. `destinationPath` is `@/…` in both single-package and
+// monorepo layouts. Fall back to the key when an entry has no destinationPath.
+const emittedKey = (key: string, entry: unknown): string =>
+  artifactKey(
+    isRecord(entry) && typeof entry.destinationPath === 'string' ? entry.destinationPath : key
+  )
 
 /** Read the manifest's previews as a flat list. Returns `[]` when the project
  *  hasn't been generated yet (no manifest) or the file is malformed.
@@ -43,7 +54,7 @@ export async function readPreviews(root: string, project: string): Promise<Previ
   if (!isRecord(parsed) || !isRecord(parsed.previews)) return []
 
   const emitted = isRecord(parsed.files)
-    ? new Set(Object.keys(parsed.files).map(artifactKey))
+    ? new Set(Object.entries(parsed.files).map(([key, entry]) => emittedKey(key, entry)))
     : undefined
 
   const previews: Preview[] = []

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -385,7 +385,10 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       // The renderable previews from the last generate manifest (module + subject).
       const previewsHandler: Connect.NextHandleFunction = async (_request, response) => {
         try {
-          respondJson(response, 200, await readPreviews(root, options.project))
+          const clientJson = await readClientJson(root, options.project)
+          const basePath =
+            typeof clientJson.settings.basePath === 'string' ? clientJson.settings.basePath : 'src'
+          respondJson(response, 200, await readPreviews(root, options.project, basePath))
         } catch (error) {
           respondJson(response, 500, { error: messageOf(error) })
         }


### PR DESCRIPTION
## Problem

`@skmtc/vite` assumed the skmtc **project root** (dir holding `.skmtc/`), the **Vite dev-server root**, and the parent of `basePath` are the same directory. That holds for a single-package repo but breaks in a monorepo where the app is nested — skmtc project at the repo root, app at `apps/x/`, `basePath: apps/x/src`. Two user-visible symptoms in the desktop preview app, same root cause:

1. **Preview list empty** ("Filter 0 previews…") — every preview dropped as a phantom.
2. **Preview fails to render** — `text/html is not a valid JavaScript MIME type`.

Details: `notes/vite/monorepo.md`.

## Fixes

**Symptom 1 — `readPreviews` phantom filter.** The emitted-files set was built from the manifest `files` **object keys** (raw on-disk paths, `apps/x/src/…`) and compared to each preview's `@/…` `exportPath` via `artifactKey` (strips only `@/`/`src/`/`./`). In a monorepo the `apps/…` prefix can't be stripped, so nothing matched → all 146 previews dropped. Now the set is built from each entry's **`destinationPath`** (the `@/…`-aliased write path that previews actually reference), falling back to the key. Single-package output is unchanged.

**Symptom 2 — module URL is Vite-servable.** The harness imports the generated module against the consumer's Vite, which serves relative to its **own** root. A `basePath`-rooted URL (`/apps/x/src/…`) isn't servable → SPA fallback → `text/html`. `readPreviews` now resolves each preview to the file's absolute path via Vite's **`/@fs/`** prefix (`module.url`), which Vite serves regardless of its root. `previewsHandler` reads `basePath` from `client.json` and passes it through; `exportPath` is retained for callers that match against the manifest.

The desktop editor consumes `module.url` in a companion PR (skmtc-hub); it falls back to the old derivation for pre-0.2.3 plugins.

## Version

Bumps `@skmtc/vite` **0.2.2 → 0.2.3**. Merging to `main` publishes via CI (npm OIDC). This supersedes the consumer-side `pnpm patch` on `0.2.2` in `uk-lh` (drop it once `0.2.3` ships).

## Tests

Added to `manifest.test.ts`: a monorepo manifest (`files` keys `apps/x/src/…` + `destinationPath: @/…`) asserting previews survive and resolve to a `/@fs/` URL, plus `toModuleUrl` unit tests. Both new regression tests fail against the pre-fix code. Full `@skmtc/vite` suite green (76), typecheck clean.