### PR TITLE
fix(vite): root input-matcher probe at Vite root; bootstrap gen-map (§8, §9)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://skm.tc",

--- a/packages/vite/src/input-matcher.test.ts
+++ b/packages/vite/src/input-matcher.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import { join } from 'node:path'
 import ts from 'typescript'
 import {
   classify,
   renderProbe,
   rootModelNameForSchemaPath,
+  toRelativeSpecifier,
   type MatcherSubject,
   type ProbeLayout
 } from './input-matcher.ts'
@@ -167,6 +169,33 @@ describe('rootModelNameForSchemaPath', () => {
       }
     }
     expect(rootModelNameForSchemaPath(doc, operation('/x', 'post'), 'RequestBody')).toBeUndefined()
+  })
+})
+
+// The probe file lives at the Vite root; the model + candidate files are found
+// under the skmtc root. In a nested monorepo those differ, so the probe's import
+// specifiers are re-based from the on-disk (skmtc-rooted) path onto the Vite
+// root. Getting this wrong is how §8's picker broke.
+describe('toRelativeSpecifier', () => {
+  const skmtcRoot = '/repo'
+  const viteRoot = '/repo/apps/x'
+
+  it('re-bases a skmtc-rooted file onto the nested Vite root', () => {
+    expect(toRelativeSpecifier(viteRoot, join(skmtcRoot, 'apps/x/src/types/Model'))).toBe(
+      './src/types/Model'
+    )
+  })
+
+  it('reduces to the plain ./ form when the roots coincide (single-package app)', () => {
+    expect(toRelativeSpecifier(skmtcRoot, join(skmtcRoot, 'src/types/Model'))).toBe(
+      './src/types/Model'
+    )
+  })
+
+  it('steps out with ../ when the target sits outside the Vite root', () => {
+    expect(toRelativeSpecifier(viteRoot, join(skmtcRoot, 'packages/shared/src/Model'))).toBe(
+      '../../packages/shared/src/Model'
+    )
   })
 })
 

--- a/packages/vite/src/input-matcher.ts
+++ b/packages/vite/src/input-matcher.ts
@@ -11,7 +11,7 @@
 // that candidate unresolved; a candidate's cell → that candidate misfits.
 // There is no fallback list: every outcome is a named verdict (`MatchOutcome`).
 
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 import { match } from 'ts-pattern'
 import type * as TS from 'typescript'
 
@@ -113,6 +113,17 @@ export const rootModelNameForSchemaPath = (
 // --- The probe ----------------------------------------------------------------
 
 const stripExt = (path: string): string => path.replace(/\.(tsx?|jsx?)$/, '')
+
+// A relative-import specifier from `fromDir` to `toFile` (both absolute), posix,
+// always explicitly relative (`./…` or `../…`). The probe file lives at the Vite
+// root while the model + candidate files are found under the skmtc root, so
+// their absolute on-disk paths are re-based here onto the probe's location. In a
+// single-package app fromDir === skmtcRoot and this reduces to the old
+// `./<basePath-relative>` form.
+export const toRelativeSpecifier = (fromDir: string, toFile: string): string => {
+  const rel = relative(fromDir, toFile).split('\\').join('/')
+  return rel.startsWith('.') ? rel : `./${rel}`
+}
 
 // Segments are interpolated into single-quoted index strings.
 const escapeSegment = (segment: string): string =>
@@ -303,7 +314,12 @@ export type MatcherService = {
 }
 
 export type MatchArgs = {
-  root: string
+  /** Anchors the on-disk model/candidate paths (both stored relative to it) —
+   *  the repo root that holds `.skmtc/` in a monorepo. */
+  skmtcRoot: string
+  /** Anchors the probe's import specifiers — the Vite root where the probe file
+   *  lives and its imports resolve. Equals `skmtcRoot` in a single-package app. */
+  viteRoot: string
   basePath: string
   /** The OpenAPI / Swagger document (parsed). */
   schema: unknown
@@ -334,8 +350,8 @@ const toWire = ({ exportName, exportPath }: MatcherCandidateSource): MatcherCand
  * (and where does it break), does each candidate resolve, does each fit.
  */
 export const matchInputs = (args: MatchArgs): MatchOutcome => {
-  const { root, basePath, schema, subject, schemaPath, candidates, moduleType, modelImports } = args
-  const { service } = args
+  const { skmtcRoot, viteRoot, basePath, schema, subject, schemaPath, candidates, moduleType } = args
+  const { modelImports, service } = args
   if (!isRecord(schema)) {
     return { type: 'unavailable', reason: 'The schema document could not be read.' }
   }
@@ -368,11 +384,15 @@ export const matchInputs = (args: MatchArgs): MatchOutcome => {
           : `The gen-map has no import entry for ${modelName} — it was not emitted by the last generate. Regenerate the project.`
     }
   }
-  // The probe imports the RELATIVE on-disk path, never the consumer's `@/` alias.
+  // The model + candidate files live under the skmtc root (their paths are
+  // stored relative to it); the probe imports them by a specifier relative to
+  // its own location at the Vite root, never the consumer's `@/` alias. On-disk
+  // existence is checked at the skmtc-rooted absolute path; the import specifier
+  // is re-based onto the Vite root.
   const modelRelativePath = (alias.startsWith('@/') ? join(basePath, alias.slice(2)) : alias)
     .split('\\')
     .join('/')
-  const modelFileBase = join(root, modelRelativePath)
+  const modelFileBase = join(skmtcRoot, modelRelativePath)
   if (!service.fileExists(`${modelFileBase}.ts`) && !service.fileExists(`${modelFileBase}.tsx`)) {
     return {
       type: 'model-missing',
@@ -384,13 +404,13 @@ export const matchInputs = (args: MatchArgs): MatchOutcome => {
   const moduleTypePart = moduleTypeHeader(moduleType)
   const layout = renderProbe({
     modelName,
-    modelImportPath: `./${modelRelativePath}`,
+    modelImportPath: toRelativeSpecifier(viteRoot, modelFileBase),
     moduleTypeSource: moduleTypePart.source,
     moduleTypeName: moduleTypePart.name,
     segments,
     candidates: candidates.map((candidate) => ({
       exportName: candidate.exportName,
-      importPath: `./${stripExt(candidate.filePath)}`
+      importPath: stripExt(toRelativeSpecifier(viteRoot, join(skmtcRoot, candidate.filePath)))
     }))
   })
 
@@ -413,7 +433,7 @@ export const matchInputs = (args: MatchArgs): MatchOutcome => {
       { type: 'module-type-error' },
       (): MatchOutcome => ({
         type: 'unavailable',
-        reason: `The ${moduleTypePart.name} module-type contract failed to compile — a generator bug.`
+        reason: `The ${moduleTypePart.name} module-type contract did not type-check against this project — its declared contract has an error, or a type it imports (for example the lens library) is not installed or resolvable here.`
       })
     )
     .with(

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -5,7 +5,7 @@
 // and Vite HMR repaints it. No container, no R2, no flat config — the working
 // tree is the contract.
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import { join, resolve } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -91,10 +91,13 @@ type PreviewAuth = { token: string; tokenFile: string }
 /** Resolve the preview token — env (desktop-launched) → existing handshake file
  *  (stable across restarts) → freshly generated — and always (re)write the file
  *  so a connect-only desktop client can read it regardless of who launched the
- *  server. `node_modules/.cache` is universally gitignored, so the token never
- *  risks being committed and needs no consumer-side ignore rule. */
-const ensurePreviewToken = (root: string, project: string): PreviewAuth => {
-  const dir = join(root, 'node_modules', '.cache', 'skmtc-preview')
+ *  server. Anchored at the VITE root (the dev server's home, whose
+ *  `node_modules` always exists), not the skmtc root — in a monorepo the repo
+ *  root's `node_modules` is a coincidence of the workspace layout.
+ *  `node_modules/.cache` is universally gitignored, so the token never risks
+ *  being committed and needs no consumer-side ignore rule. */
+const ensurePreviewToken = (viteRoot: string, project: string): PreviewAuth => {
+  const dir = join(viteRoot, 'node_modules', '.cache', 'skmtc-preview')
   const tokenFile = join(dir, `${project}.token`)
   const fromEnv = process.env.SKMTC_PREVIEW_TOKEN?.trim()
   const fromFile = ((): string | null => {
@@ -244,7 +247,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       // be tunnelled to the public web. The desktop app obtains the token
       // automatically over `/__skmtc/handshake` (loopback-only); the token is
       // also logged for the env-var and handshake-file fallbacks.
-      const auth = ensurePreviewToken(root, options.project)
+      const auth = ensurePreviewToken(viteRoot, options.project)
       server.config.logger.info(
         `\n  skmtc preview auth enabled\n  token: ${auth.token}\n  handshake file: ${auth.tokenFile}\n`
       )
@@ -253,7 +256,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       // snapshot, candidates, gen-map, match memo). The matcher's contract for
       // a field comes off the generator's moduleSelect declaration, read from
       // the (cached) describe descriptors.
-      const state = new SourceState(root, options.project, {
+      const state = new SourceState(root, viteRoot, options.project, {
         resolveModuleType: async (generator) => {
           if (generator === undefined) return undefined
           const result = await describe()
@@ -267,6 +270,18 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       server.watcher.add(bundlePath)
       server.watcher.add(HARNESS_SOURCE_PATH)
       server.watcher.add(clientJsonFile)
+
+      // The gen-map (`.maps/_map.ndjson`) resolves a model name to its generated
+      // file for the input matcher; only `--anchors` generates emit it. The
+      // regenerate path always anchors, but edit/filters don't (the map is heavy
+      // and stable across enrichment edits) — so a project only ever generated
+      // without `--anchors` (a repo `generate` script that omits it, or an
+      // edit-only session) has NO map, and every field picker reports
+      // `model-missing`. Bootstrap it exactly once, when it's absent, on any
+      // generate path and lazily before the first match — then the fast no-anchor
+      // path takes over.
+      const genMapPath = join(root, '.skmtc', options.project, '.maps', '_map.ndjson')
+      const genMapMissing = (): boolean => !existsSync(genMapPath)
 
       // describe is a function of the bundle AND the schema, so also invalidate
       // it when the local schema file changes (a URL source can't be watched).
@@ -351,7 +366,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
         const generate = await enqueue(async () => {
           const next = applyEditToClientJson(await readClientJson(root, options.project), edit)
           await writeClientJson(root, options.project, next)
-          return runGenerate(root, options.project)
+          return runGenerate(root, options.project, genMapMissing())
         }).catch((error): CliResult => ({ ok: false, code: 1, message: messageOf(error) }))
         // The generate rewrote the source the matcher type-checks against —
         // bump the state's file versions + drop its generate-derived caches.
@@ -379,6 +394,15 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
         } catch (error) {
           respondJson(response, 400, { error: `invalid request: ${messageOf(error)}` })
           return
+        }
+        // The matcher needs the gen-map to resolve a model's import. If the
+        // project was only ever generated without `--anchors`, bootstrap it once
+        // now — lazily, on genuine picker use — so the field editor works from
+        // first open without the user first hitting Regenerate. A plain
+        // `vite dev` user who never opens the editor never triggers this.
+        if (genMapMissing()) {
+          const generate = await enqueue(() => runGenerate(root, options.project, true))
+          if (generate.ok) state.onGenerateSuccess()
         }
         try {
           respondJson(response, 200, await state.match(body))
@@ -509,7 +533,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
               skip: toFilterEntries(filters.skip)
             }
           })
-          return runGenerate(root, options.project)
+          return runGenerate(root, options.project, genMapMissing())
         }).catch((error): CliResult => ({ ok: false, code: 1, message: messageOf(error) }))
         if (generate.ok) state.onGenerateSuccess()
         respondJson(response, generate.ok ? 200 : 500, { generate })

--- a/packages/vite/src/source-state.test.ts
+++ b/packages/vite/src/source-state.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { SourceState } from './source-state.ts'
+
+// The §8 regression, exercised end-to-end through a real TypeScript service in
+// the layout that broke: a nested monorepo where the skmtc root (holding
+// `.skmtc/`) is the repo root, but `typescript`, the app `tsconfig`, the
+// `@hookform/lenses` contract dep, and the generated code all live under the
+// nested Vite root (`apps/x`). The probe MUST root at the Vite root — rooting it
+// at the skmtc root (the pre-fix behavior) can't load `typescript` or resolve
+// the lens contract, and every field returns `unavailable`.
+describe('SourceState.match in a nested monorepo', () => {
+  const project = 'app'
+  let skmtcRoot: string
+  let viteRoot: string
+
+  const write = async (path: string, content: string): Promise<void> => {
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, content)
+  }
+
+  beforeAll(async () => {
+    skmtcRoot = await mkdtemp(join(tmpdir(), 'skmtc-source-state-'))
+    viteRoot = join(skmtcRoot, 'apps', 'x')
+
+    // .skmtc/ lives at the repo root. client.json points basePath + inputDirs at
+    // the nested app (repo-root-relative), the way a monorepo project is wired.
+    await write(
+      join(skmtcRoot, '.skmtc', project, '.settings', 'client.json'),
+      JSON.stringify({
+        source: 'schema.json',
+        settings: { basePath: 'apps/x/src', inputDirs: ['apps/x/src/inputs'] }
+      })
+    )
+    // The gen-map (only emitted by `generate --anchors`) resolves the model name.
+    await write(
+      join(skmtcRoot, '.skmtc', project, '.maps', '_map.ndjson'),
+      JSON.stringify({ name: 'CreateThingModel', f: '@/types/CreateThingModel' }) + '\n'
+    )
+    // Minimal schema: the matcher only reads the model NAME off the operation.
+    await write(
+      join(skmtcRoot, 'schema.json'),
+      JSON.stringify({
+        paths: {
+          '/things': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': { schema: { $ref: '#/components/schemas/CreateThingModel' } }
+                }
+              }
+            }
+          }
+        },
+        components: { schemas: { CreateThingModel: { type: 'object' } } }
+      })
+    )
+
+    // The nested Vite app: typescript + the lens contract are APP deps (not at
+    // the repo root), the app owns the tsconfig, and the generated code lives
+    // here. `typescript` is symlinked from this package's own install.
+    const tsPackageDir = dirname(
+      createRequire(import.meta.url).resolve('typescript/package.json')
+    )
+    await mkdir(join(viteRoot, 'node_modules'), { recursive: true })
+    await symlink(tsPackageDir, join(viteRoot, 'node_modules', 'typescript'), 'dir')
+    await write(join(viteRoot, 'package.json'), JSON.stringify({ name: 'x' }))
+    // A stub for the contract's `@hookform/lenses` import — resolvable ONLY from
+    // the Vite root, so the test fails if the probe is rooted anywhere else.
+    await write(
+      join(viteRoot, 'node_modules', '@hookform', 'lenses', 'package.json'),
+      JSON.stringify({ name: '@hookform/lenses', types: 'index.d.ts' })
+    )
+    await write(
+      join(viteRoot, 'node_modules', '@hookform', 'lenses', 'index.d.ts'),
+      'export type Lens<T> = { readonly __lens: T }\n'
+    )
+    await write(
+      join(viteRoot, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          moduleResolution: 'bundler',
+          module: 'esnext',
+          target: 'es2020',
+          strict: true,
+          jsx: 'preserve',
+          baseUrl: '.',
+          paths: { '@/*': ['src/*'] }
+        }
+      })
+    )
+    // The generated model and two candidate inputs.
+    await write(
+      join(viteRoot, 'src', 'types', 'CreateThingModel.ts'),
+      'export type CreateThingModel = { forename: string; officeIds: string[] }\n'
+    )
+    await write(
+      join(viteRoot, 'src', 'inputs', 'OfficeSelect.tsx'),
+      `import type { Lens } from '@hookform/lenses'\nexport const OfficeSelect = (props: { lens: Lens<string[]> }) => props\n`
+    )
+    await write(
+      join(viteRoot, 'src', 'inputs', 'TextInput.tsx'),
+      `import type { Lens } from '@hookform/lenses'\nexport const TextInput = (props: { lens: Lens<string> }) => props\n`
+    )
+  })
+
+  afterAll(async () => {
+    await rm(skmtcRoot, { recursive: true, force: true })
+  })
+
+  const request = {
+    subject: { type: 'operation' as const, path: '/things', method: 'post' },
+    schemaPath: ['RequestBody', 'officeIds']
+  }
+
+  it('adjudicates the builtin lens contract against a string[] field', async () => {
+    const state = new SourceState(skmtcRoot, viteRoot, project)
+    const outcome = await state.match(request)
+    // The probe loaded the app's TypeScript, resolved @hookform/lenses + the
+    // re-based model/candidate imports, and type-checked the field.
+    expect(outcome.type).toBe('fits')
+    if (outcome.type !== 'fits') return
+    expect(outcome.fieldType).toContain('string[]')
+    expect(outcome.fits.map((c) => c.exportName)).toEqual(['OfficeSelect'])
+    expect(outcome.misfits.map((c) => c.exportName)).toEqual(['TextInput'])
+  })
+
+  it('rooting the probe at the skmtc root (the pre-fix bug) makes it unavailable', async () => {
+    // Both roots = skmtc root: typescript is not resolvable there, so the
+    // service never loads — exactly the failure §8 fixed.
+    const state = new SourceState(skmtcRoot, skmtcRoot, project)
+    const outcome = await state.match(request)
+    expect(outcome.type).toBe('unavailable')
+  })
+})

--- a/packages/vite/src/source-state.ts
+++ b/packages/vite/src/source-state.ts
@@ -59,7 +59,15 @@ const readCompilerOptions = (ts: typeof TS, root: string): TS.CompilerOptions =>
 }
 
 export class SourceState {
-  #root: string
+  // TWO roots, deliberately distinct (they coincide only in a single-package
+  // app). `#skmtcRoot` anchors every `.skmtc/…` read — client.json, manifest,
+  // gen-map, schema, the inputDir walk — all stored relative to it. `#viteRoot`
+  // anchors the TypeScript probe: the app's `typescript`, `tsconfig`,
+  // `node_modules`, and `@/*` aliases live there, NOT at the repo root in a
+  // monorepo. Using the skmtc root for the probe was the §8 bug: `typescript`
+  // and contract deps like `@hookform/lenses` don't resolve from the repo root.
+  #skmtcRoot: string
+  #viteRoot: string
   #project: string
 
   // File freshness for the language service: versions bumped by watcher events;
@@ -79,28 +87,34 @@ export class SourceState {
 
   #resolveModuleType: SourceStateOptions['resolveModuleType']
 
-  constructor(root: string, project: string, options: SourceStateOptions = {}) {
-    this.#root = root
+  constructor(
+    skmtcRoot: string,
+    viteRoot: string,
+    project: string,
+    options: SourceStateOptions = {}
+  ) {
+    this.#skmtcRoot = skmtcRoot
+    this.#viteRoot = viteRoot
     this.#project = project
     this.#resolveModuleType = options.resolveModuleType
   }
 
   get #clientJsonPath(): string {
-    return join(this.#root, '.skmtc', this.#project, '.settings', 'client.json')
+    return join(this.#skmtcRoot, '.skmtc', this.#project, '.settings', 'client.json')
   }
   get #mapsPath(): string {
-    return join(this.#root, '.skmtc', this.#project, '.maps', '_map.ndjson')
+    return join(this.#skmtcRoot, '.skmtc', this.#project, '.maps', '_map.ndjson')
   }
 
   /** Subscribe to the dev server's watcher; also watch the project's own
    *  `.skmtc/<project>` tree (manifest, gen-map, client.json). */
   attach(watcher: WatcherLike): void {
-    watcher.add(join(this.#root, '.skmtc', this.#project))
+    watcher.add(join(this.#skmtcRoot, '.skmtc', this.#project))
     watcher.on('all', (_eventName, file) => this.#onFileEvent(file))
   }
 
   #onFileEvent(file: string): void {
-    if (!file.startsWith(this.#root + sep)) return
+    if (!file.startsWith(this.#skmtcRoot + sep)) return
     if (file.includes(`${sep}node_modules${sep}`) || file.includes(`${sep}.git${sep}`)) return
     this.#fileVersions.set(file, (this.#fileVersions.get(file) ?? 0) + 1)
     this.#memo.clear()
@@ -129,8 +143,8 @@ export class SourceState {
    *  generate succeeds (or, for a local file, until the file itself changes). */
   schemaDoc(source: string): Promise<unknown> {
     if (this.#schemaCache?.source === source) return this.#schemaCache.value
-    this.#schemaFile = /^https?:\/\//.test(source) ? null : join(this.#root, source)
-    const value = readSchema(this.#root, source)
+    this.#schemaFile = /^https?:\/\//.test(source) ? null : join(this.#skmtcRoot, source)
+    const value = readSchema(this.#skmtcRoot, source)
     this.#schemaCache = { source, value }
     return value
   }
@@ -139,15 +153,15 @@ export class SourceState {
    *  (inputDirs + basePath), invalidated by watcher events under any inputDir. */
   candidates(inputDirs: string[], basePath: string): Promise<Candidate[]> {
     const key = JSON.stringify([inputDirs, basePath])
-    this.#inputDirPrefixes = inputDirs.map((dir) => join(this.#root, dir) + sep)
+    this.#inputDirPrefixes = inputDirs.map((dir) => join(this.#skmtcRoot, dir) + sep)
     if (this.#candidatesCache?.key === key) return this.#candidatesCache.value
-    const value = readCandidates(this.#root, inputDirs, basePath)
+    const value = readCandidates(this.#skmtcRoot, inputDirs, basePath)
     this.#candidatesCache = { key, value }
     return value
   }
 
   modelImports(): Promise<Map<string, string>> {
-    this.#modelImportsCache ??= readModelImports(this.#root, this.#project)
+    this.#modelImportsCache ??= readModelImports(this.#skmtcRoot, this.#project)
     return this.#modelImportsCache
   }
 
@@ -166,7 +180,12 @@ export class SourceState {
   }
 
   #createService(): MatcherService {
-    const root = this.#root
+    // The probe is the app's TypeScript, run in the app's directory: load `ts`,
+    // read `tsconfig`, place the probe file, and resolve its imports all at the
+    // VITE root. In a monorepo that's `apps/x`, where `typescript`, the app's
+    // tsconfig (its `moduleResolution`/`jsx`/`@/*` paths), and `node_modules`
+    // live — not the repo root that holds `.skmtc/`.
+    const root = this.#viteRoot
     const ts = loadTs(root)
     const options: TS.CompilerOptions = {
       ...readCompilerOptions(ts, root),
@@ -228,7 +247,7 @@ export class SourceState {
     const memoized = this.#memo.get(key)
     if (memoized) return memoized
 
-    const clientJson = await readClientJson(this.#root, this.#project)
+    const clientJson = await readClientJson(this.#skmtcRoot, this.#project)
     const source = clientJson.source
     if (typeof source !== 'string') {
       return { type: 'unavailable', reason: 'client.json has no `source` schema reference.' }
@@ -248,7 +267,8 @@ export class SourceState {
         this.modelImports()
       ])
       outcome = matchInputs({
-        root: this.#root,
+        skmtcRoot: this.#skmtcRoot,
+        viteRoot: this.#viteRoot,
         basePath,
         schema,
         subject: request.subject,


### PR DESCRIPTION
Follow-up to #41 (0.3.0). Sweeps the same `skmtcRoot ≠ viteRoot` bug class through the input matcher and closes the two open issues from `notes/vite/monorepo2.md`, plus two hardening items the sweep surfaced.

## The bug class

Every monorepo issue in this package is one fault: a path anchored at the wrong root because the plugin was built assuming `skmtcRoot == viteRoot == parent-of-basePath`. 0.3.0 fixed the browser-facing and optimizer paths. This PR fixes the last column — the **TypeScript probe** — and confirms (by sweeping all ~40 path sites) that no other category remains.

## §8 — input-matcher probe rooted at the wrong dir

`/__skmtc/input-matches` ran the project's TypeScript rooted at the **skmtc root**. In a nested monorepo that's the repo root, where `typescript`, the app tsconfig, `node_modules`, and `@/*` aliases don't resolve — so every field picker returned `unavailable`.

Split the two conflated roots. `SourceState` now holds:
- **skmtcRoot** — every `.skmtc/…` read (client.json, manifest, gen-map, schema, inputDir walk), all stored relative to it.
- **viteRoot** — the probe: load `typescript`, read tsconfig, place the probe file, resolve its imports.

`matchInputs` takes both anchors: on-disk existence is checked at the skmtc-rooted absolute path; the probe's model + candidate import specifiers are **re-based** onto the Vite root where the probe file lives (`toRelativeSpecifier`). Single-package apps (roots coincide) reduce to prior behavior. Imports stay alias-free (the deliberate "consumer `@` config can't break resolution" decision is preserved).

## §9 — gen-map never bootstrapped

Only `--anchors` generates emit the map the matcher needs; the edit/filters paths skipped it (heavy + stable across edits), so a project generated without `--anchors` had no map and every field was `model-missing` until a manual Regenerate. The desktop editor's mount sequence doesn't call regenerate, so the picker was dead on first open. Bootstrap the map once when absent — on the edit/filters paths, and lazily on the first `input-matches` (genuine picker use only; a plain `vite dev` user never triggers it) — then the fast no-anchor path resumes.

## Hardening (surfaced by the sweep)

- **Token cache** anchored at the Vite root (the dev server's home, whose `node_modules` always exists) instead of the skmtc root, where a repo-root `node_modules` is a workspace coincidence. Live-confirmed the token now lands at `apps/x/node_modules/.cache/`.
- **`#seenFiles`** anchor follows the probe to the Vite root.
- **Message fix**: the module-type-error no longer says "a generator bug" — it names the real causes (contract error, or an unresolvable/uninstalled contract dep).

## Verification

- **Hermetic integration test** (`source-state.test.ts`): runs a real TypeScript service in the nested-monorepo layout (`typescript` + `@hookform/lenses` app-only), asserts a builtin-`InputModule` field returns `fits: [OfficeSelect]` / `misfits: [TextInput]`, **and** that the pre-fix skmtc-rooted construction returns `unavailable` (proves the fixture depends on correct rooting).
- **Unit tests** for the import re-basing (monorepo, single-package identity, `../` step-out).
- **Live end-to-end**: POST `/__skmtc/input-matches` against a real monorepo dev server running this plugin → `{type:fits, fieldType:"string[]", fits:[OfficeSelect], misfits:[TextInput]}`. Confirms the plugin's `SourceState(skmtcRoot, viteRoot, …)` wiring order — the one thing types can't catch.

96 tests pass; `tsc --noEmit` clean. No wire-contract change — desktop app unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)