### PR TITLE
test(cli): pin monorepo root discovery + app-tsconfig resolution

### DIFF
--- a/deno/cli/lib/to-root-path.test.ts
+++ b/deno/cli/lib/to-root-path.test.ts
@@ -1,6 +1,21 @@
 import { assertEquals } from '@std/assert/equals'
 import { assertStringIncludes } from '@std/assert/string-includes'
+import { join } from '@std/path/join'
+import { resolve } from '@std/path/resolve'
+import { ensureDir } from '@std/fs/ensure-dir'
+import { homedir } from 'node:os'
 import { toRootPath, toAbsoluteRootPath, toRelativeRootPath } from '@/lib/to-root-path.ts'
+
+// Run `fn` with cwd temporarily changed to `dir`, restoring it afterwards.
+const withCwd = async (dir: string, fn: () => Promise<void> | void) => {
+  const prev = Deno.cwd()
+  Deno.chdir(dir)
+  try {
+    await fn()
+  } finally {
+    Deno.chdir(prev)
+  }
+}
 
 Deno.test('toRootPath - returns path ending with .skmtc', () => {
   const rootPath = toRootPath()
@@ -31,3 +46,72 @@ Deno.test('toRelativeRootPath - includes tilde for home directory', () => {
     assertStringIncludes(relativePath, '~')
   }
 })
+
+// --- monorepo root discovery --------------------------------------------------
+// The nested-monorepo case the `@skmtc/vite` plugin exposed: `.skmtc/` at the
+// repo root, the app dir nested under `apps/x`. `toRootPath` walks up from cwd,
+// so running from the nested app must still resolve the repo-root project.
+
+Deno.test('toRootPath - walks up from a nested dir to an ancestor .skmtc (monorepo)', async () => {
+  const repoRoot = await Deno.realPath(
+    await Deno.makeTempDir({ dir: homedir(), prefix: 'skmtc-root-mono-' })
+  )
+  try {
+    await ensureDir(join(repoRoot, '.skmtc'))
+    const appDir = join(repoRoot, 'apps', 'x')
+    await ensureDir(appDir)
+    await withCwd(appDir, () => {
+      assertEquals(resolve(toRootPath()), join(repoRoot, '.skmtc'))
+    })
+  } finally {
+    await Deno.remove(repoRoot, { recursive: true })
+  }
+})
+
+Deno.test('toRootPath - the nearest .skmtc wins when a nested project shadows the root', async () => {
+  const repoRoot = await Deno.realPath(
+    await Deno.makeTempDir({ dir: homedir(), prefix: 'skmtc-root-nest-' })
+  )
+  try {
+    await ensureDir(join(repoRoot, '.skmtc'))
+    const appDir = join(repoRoot, 'apps', 'x')
+    await ensureDir(join(appDir, '.skmtc'))
+    await withCwd(appDir, () => {
+      assertEquals(resolve(toRootPath()), join(appDir, '.skmtc'))
+    })
+  } finally {
+    await Deno.remove(repoRoot, { recursive: true })
+  }
+})
+
+Deno.test(
+  'toRootPath - does NOT walk up past the home-directory boundary (current limitation)',
+  async () => {
+    // Characterization test, not an endorsement: the walk-up loop only runs while
+    // inside $HOME, so a repo checked out OUTSIDE $HOME (common in CI, containers,
+    // /opt) never finds an ancestor `.skmtc` — it assumes one in cwd. This pins
+    // current behavior; if monorepo-outside-$HOME is to be supported, relax the
+    // boundary in `to-root-path.ts` and update this test deliberately.
+    const home = resolve(homedir())
+    const repoRoot = await Deno.realPath(
+      await Deno.makeTempDir({ prefix: 'skmtc-root-outside-home-' })
+    )
+    if (resolve(repoRoot).startsWith(home)) {
+      // The system temp dir happens to live under $HOME here, so the boundary
+      // can't be demonstrated — skip rather than assert a falsehood.
+      await Deno.remove(repoRoot, { recursive: true })
+      return
+    }
+    try {
+      await ensureDir(join(repoRoot, '.skmtc'))
+      const appDir = join(repoRoot, 'apps', 'x')
+      await ensureDir(appDir)
+      await withCwd(appDir, () => {
+        // Falls through to cwd/.skmtc rather than resolving the ancestor project.
+        assertEquals(resolve(toRootPath()), join(appDir, '.skmtc'))
+      })
+    } finally {
+      await Deno.remove(repoRoot, { recursive: true })
+    }
+  }
+)

--- a/deno/cli/lib/typecheck.test.ts
+++ b/deno/cli/lib/typecheck.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from '@std/assert'
+import { assertNotEquals } from '@std/assert/not-equals'
 import { join } from '@std/path/join'
 import { ensureDir } from '@std/fs/ensure-dir'
 import { homedir } from 'node:os'
@@ -49,6 +50,36 @@ Deno.test(
       })
 
       assertEquals(result.type, 'no-tsconfig')
+    })
+  }
+)
+
+Deno.test(
+  'runTypecheck - discovers the nested app tsconfig by walking up from a monorepo basePath',
+  async () => {
+    // The nested-monorepo layout: the skmtc root (tempRoot) has NO tsconfig; the
+    // app under apps/x owns it, and basePath points at the app's src. Discovery
+    // walks up from basePath, so it must find the app's tsconfig — the app root,
+    // not the skmtc root, is where the consumer's TypeScript lives.
+    await withTempCwd(async tempRoot => {
+      const appDir = join(tempRoot, 'apps', 'x')
+      await ensureDir(join(appDir, 'src'))
+      await Deno.writeTextFile(
+        join(appDir, 'tsconfig.json'),
+        JSON.stringify({ compilerOptions: { noEmit: true, skipLibCheck: true } })
+      )
+      await Deno.writeTextFile(join(appDir, 'src', 'thing.ts'), 'export const thing = 1\n')
+
+      const result = await runTypecheck({
+        filePaths: ['apps/x/src/thing.ts'],
+        basePathAbs: join(appDir, 'src')
+      })
+
+      // Reaching past tsconfig-discovery (anything but `no-tsconfig`) proves the
+      // search walked up from basePath into the nested app and found the app's
+      // tsconfig — the only one in the tree. Whether tsc then runs depends on the
+      // environment; discovery succeeding is the monorepo behavior under test.
+      assertNotEquals(result.type, 'no-tsconfig')
     })
   }
 )


### PR DESCRIPTION
Follow-up to the `@skmtc/vite` monorepo work (#41, #43). Adds CLI-side regression coverage for the same `skmtcRoot != appRoot` split, and documents one real limitation the sweep surfaced.

Context: I swept the deno CLI for the `wrong-root` bug class that bit the vite plugin. The good news — the CLI is largely monorepo-correct already (`toRootPath()` walks up from cwd to find `.skmtc/`; `runTypecheck` walks up from the absolute basePath to the app's tsconfig). But those behaviors had **no** monorepo test coverage, so this pins them.

## What's covered

- **`toRootPath` walk-up** — from a nested dir (`apps/x`) resolves the ancestor repo-root `.skmtc`; a nested project's `.skmtc` shadows the root (nearest wins). This behavior was previously untested entirely.
- **`toRootPath` home-directory boundary** — a *characterization* test documenting a genuine limitation: the walk-up loop only runs while inside `$HOME`, so a repo checked out **outside $HOME** (CI runners, containers, `/opt`) never walks up — it assumes `.skmtc` in cwd. The test pins current behavior so relaxing the boundary becomes a deliberate, test-visible decision.
- **`runTypecheck` app-tsconfig discovery** — in a monorepo (skmtc root has no tsconfig; the app under `apps/x` owns it), discovery walks up from basePath and finds the app's tsconfig, not the skmtc root.

## Notes / follow-ups (not in this PR)

- The **home-directory boundary** is a real monorepo-outside-$HOME limitation (now documented by a test). Whether to relax it — e.g. walk to a git root or filesystem root — is a design call worth making deliberately.
- `cli/lib/ignore-file.ts` (+ its test) is **confirmed dead** — no callers; the live `.skmtcignore` path is `source-upload.ts`. It also carries a latent `Deno.cwd()` assumption. Candidate for deletion in a separate change.

10 tests pass (2 tsc-gated ones remain environment-`ignore`d); `deno check` + `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)