### PR TITLE
chore(deno): move nodeModulesDir to the workspace root

### DIFF
--- a/deno/core/deno.json
+++ b/deno/core/deno.json
@@ -2,7 +2,6 @@
   "name": "@skmtc/core",
   "version": "0.26.0",
   "license": "Apache-2.0",
-  "nodeModulesDir": "auto",
   "imports": {
     "@/": "./",
     "@std/assert": "jsr:@std/assert@^1.0.10",

--- a/deno/deno.json
+++ b/deno/deno.json
@@ -16,6 +16,7 @@
     "tiny-invariant": "npm:tiny-invariant@1.3.3",
     "valibot": "npm:valibot@1.1.0"
   },
+  "nodeModulesDir": "auto",
   "unstable": [
     "kv",
     "worker-options"


### PR DESCRIPTION
Silences the `"nodeModulesDir" field can only be specified in the workspace root deno.json file` warning that printed on **every** `deno` command.

## What

`deno/core/deno.json` (the `@skmtc/core` member) declared `"nodeModulesDir": "auto"`. Deno 2 only honors that field in the **workspace root**; in a member it is ignored and warns. So the setting did nothing in-workspace and just produced noise. It's a leftover from when `core` was developed standalone (where its deno.json *is* the root and the field is valid).

Moved it to `deno/deno.json` (the workspace root), where it applies uniformly to every member.

## Verification

- `deno check` no longer prints the warning; npm deps now materialize from the root node_modules as expected.
- Existing `to-root-path` tests pass unchanged.

## Notes

- No version bump: the field was ignored in-workspace, so removing it from `core/deno.json` changes nothing functional there, and the root addition takes effect for local dev on merge. The only surface that loses the field is a *standalone* `@skmtc/core` checkout developed outside this workspace — not a workflow used here. If that matters, say so and I'll restore it there too (the warning is the tradeoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)