### PR TITLE
docs: correct insert* API shapes and the enrichment umbrella model

### DIFF
--- a/deno/docs/authoring/how-to/add-enrichment-options.md
+++ b/deno/docs/authoring/how-to/add-enrichment-options.md
@@ -20,68 +20,90 @@ configuration passed from `client.json` to the Projection.
 
 ### Edit `gen-x/src/enrichments.ts`
 
-The file declares a Valibot schema. The shape becomes the
-contract for what keys `client.json` can carry under this
-generator's ID.
+The file declares a Valibot schema via `toEnrichmentSchema`. The
+schema is the **three-scope enrichment umbrella** — an object with
+`subject`, `generator`, and `stack` keys — not a flat object of your
+fields. Your per-item options live under `subject`; the two
+run-constant scopes (`generator`, `stack`) are declared
+`v.undefined()` when you don't use them.
 
 ```ts
-// Stock gen-zod (minimal):
-import * as v from 'valibot'
-export const schema = v.optional(v.object({}))
-export type EnrichmentSchema = v.InferOutput<typeof schema>
-export const toEnrichmentSchema = () => schema
+// Stock gen-zod (no enrichments): re-exports core's empty umbrella.
+import { emptyEnrichmentSchema, type EmptyEnrichments } from '@skmtc/core'
+export const toEnrichmentSchema = () => emptyEnrichmentSchema
+export type EnrichmentSchema = EmptyEnrichments
 ```
 
-### Add Valibot fields
+`emptyEnrichmentSchema` is the umbrella with all three scopes
+`v.undefined()`. `toEnrichmentSchema` is a **required** field on both
+the entry config and the projection-base config — the derived static
+`toEnrichments` calls it to parse the umbrella, so it can never be
+omitted.
 
-Add the fields you want. Use `v.optional(...)` for fields that
-users can omit. The schema's *root* is what arrives at the lookup
-target, so put the fields directly on the root object — don't wrap
-them in an extra named object:
+### Add Valibot fields under `subject`
+
+Put the fields users can set per item under `subject`. Use
+`v.optional(...)` for fields they can omit. Keep `generator` and
+`stack` as `v.undefined()` unless you use those scopes:
 
 ```ts
 import * as v from 'valibot'
 
-export const schema = v.optional(
+// The per-item leaf — what a user writes for one model/operation.
+export const zodSubject = v.optional(
   v.object({
     description: v.optional(v.string()),
     strict: v.optional(v.boolean())
   })
 )
 
-export type EnrichmentSchema = v.InferOutput<typeof schema>
-export const toEnrichmentSchema = () => schema
+// The three-scope umbrella. This generator only reads `subject`.
+export const enrichmentSchema = v.object({
+  subject: zodSubject,
+  generator: v.undefined(),
+  stack: v.undefined()
+})
+
+export type EnrichmentSchema = v.InferOutput<typeof enrichmentSchema>
+export const toEnrichmentSchema = () => enrichmentSchema
 ```
 
-`gen-zod` is built on `toTsModelProjectionBase` (the
-lang-typescript veneer), so the routing
-path is `enrichments[generatorId][refName]`. Users supply
-enrichments like:
+`gen-zod` is built on `toTsModelProjectionBase`, so the subject
+routing path is `enrichments[generatorId][refName][variant]`. The
+trailing `variant` level is `'main'` by default and **must be present**
+whenever any variant is declared. Users write the subject leaf
+directly under the variant key:
 
 ```jsonc
 {
   "enrichments": {
     "@skmtc/gen-zod": {
-      "User": { "description": "A user account", "strict": true }
+      "User": {
+        "main": { "description": "A user account", "strict": true }
+      }
     }
   }
 }
 ```
 
-For OAS operation generators built on `toTsOasOperationProjectionBase`,
-the path would instead be `enrichments[generatorId][path][method]`;
-for GraphQL it's `enrichments[generatorId][rootKind][fieldName]`.
-See [enrichments shape](../../reference/settings/enrichments-shape.md)
+For OAS operation generators (`toTsOasOperationProjectionBase`) the
+subject path is `enrichments[generatorId][path][method][variant]`; for
+GraphQL (`toTsGqlOperationProjectionBase`) it's
+`enrichments[generatorId][rootKind][fieldName][variant]`. The two
+run-constant scopes, when used, live at `enrichments[generatorId]._generator`
+and the top-level `enrichments._stack`. See
+[enrichments shape](../../reference/settings/enrichments-shape.md)
 for the routing details.
 
-### Consume in the Projection constructor
+### Consume in the Projection
 
-The validated enrichment is at `this.settings.enrichments`:
+`this.settings.enrichments` is the parsed umbrella. Read your per-item
+options off its `subject` scope:
 
 ```ts
 // In ZodProjection.ts
 override toString(): string {
-  const { description, strict } = this.settings.enrichments ?? {}
+  const { description, strict } = this.settings.enrichments.subject ?? {}
 
   const objectCall = strict ? 'z.strictObject' : 'z.object'
   const jsdoc = description ? `/** ${description} */\n` : ''
@@ -90,7 +112,9 @@ override toString(): string {
 }
 ```
 
-Default to a sensible fallback when the enrichment is absent.
+Default to a sensible fallback when the enrichment is absent. (The
+`generator` and `stack` scopes, if you declared them, read the same
+way — `this.settings.enrichments.generator` / `.stack`.)
 
 ### Document for users
 
@@ -111,14 +135,17 @@ verify the output reflects them.
 
 ## Verification
 
-Set an enrichment in `.skmtc/<project>/.settings/client.json`:
+Set an enrichment in `.skmtc/<project>/.settings/client.json` (the
+subject leaf under the `main` variant):
 
 ```jsonc
 {
   "settings": {
     "enrichments": {
       "@skmtc/gen-zod": {
-        "User": { "description": "test description" }
+        "User": {
+          "main": { "description": "test description" }
+        }
       }
     }
   }
@@ -131,8 +158,10 @@ appear above the declaration.
 ## Troubleshooting
 
 - **Enrichment silently ignored** — Unknown keys are stripped by
-  Valibot. Most common cause: schema-key typo, or `toEnrichmentSchema`
-  not properly wired in the Entry.
+  Valibot. Most common causes: schema-key typo; the fields declared on
+  the umbrella root instead of under `subject`; or the `main` variant
+  key omitted in `client.json` (the value must sit under
+  `[…][variant]`, not directly under the item key).
 - **Valibot validation throws** — A required field is missing or a
   type doesn't match. Use `v.optional(...)` for everything that
   can reasonably default.

--- a/deno/docs/authoring/how-to/change-export-paths.md
+++ b/deno/docs/authoring/how-to/change-export-paths.md
@@ -54,16 +54,22 @@ breaks because the cache key includes `exportPath`.
 For per-operation path control, add an enrichment field:
 
 ```ts
-// In enrichments.ts
-export const schema = v.optional(
+// In enrichments.ts — the per-operation override lives under `subject`.
+export const pathsSubject = v.optional(
   v.object({
     paths: v.optional(v.object({ override: v.optional(v.string()) }))
   })
 )
+export const enrichmentSchema = v.object({
+  subject: pathsSubject,
+  generator: v.undefined(),
+  stack: v.undefined()
+})
+export const toEnrichmentSchema = () => enrichmentSchema
 
-// In base.ts
+// In base.ts — toExportPath receives the parsed umbrella; read `subject`.
 toExportPath: ({ operation, enrichments }) => {
-  const override = enrichments?.paths?.override
+  const override = enrichments?.subject?.paths?.override
   if (override) return override
   return `/api/${toEndpointName(operation)}.ts`
 }

--- a/deno/docs/authoring/how-to/compose-with-another-generator.md
+++ b/deno/docs/authoring/how-to/compose-with-another-generator.md
@@ -61,8 +61,9 @@ class TanstackQuery extends TanstackQueryBase {
 
 `this.insertNormalizedModel` is the canonical entry point for
 "materialize this schema as a Zod definition" (or any peer
-Projection). The engine returns an `Inserted` describing the
-existing or newly-created definition.
+Projection). It returns the peer's `Definition` — read its name off
+`.identifier.name`. (`insertModel` and `insertOperation` instead
+return an `Inserted`, whose `.toName()` gives the same string.)
 
 For model-by-refName composition, use `insertModel`:
 
@@ -75,14 +76,14 @@ projection-base methods (`this.x`) that wrap the underlying
 `GenerateContext` methods (`this.context.x`). The projection-base
 versions auto-fill `destinationPath` from `this.settings`.
 
-### Use the returned `Inserted` to get the identifier name
+### Use the returned `Definition` to get the identifier name
 
 ```ts
-const zodName = this.requestZod.toName()
+const zodName = this.requestZod.identifier.name
 // → e.g., "createUserBody"
 ```
 
-`toName()` returns the name string the peer Projection's
+`identifier.name` is the name string the peer Projection's
 `toIdentifierName` produced.
 
 ### Reference the name in your template
@@ -93,7 +94,7 @@ override toString(): string {
     export const useCreateUser = () => useMutation({
       mutationFn: (body) => fetch('/users', {
         method: 'POST',
-        body: JSON.stringify(${this.requestZod.toName()}.parse(body))
+        body: JSON.stringify(${this.requestZod.identifier.name}.parse(body))
       }).then(r => r.json())
     })
   `
@@ -138,16 +139,15 @@ two ways:
    consumer carries its own copy.
 
 By-name composition sidesteps both. You declare the peer
-contribution (via `insertNormalizedModel`), receive an
-`Inserted`-handle to the peer's identifier, and reference the
-identifier in your template. The engine handles the file
-materialization and import injection.
+contribution (via `insertNormalizedModel`), receive the peer's
+`Definition`, and reference its `identifier.name` in your template.
+The engine handles the file materialization and import injection.
 
 See [how idempotency works](../../explanation/how-idempotency-works.md).
 
 ## Troubleshooting
 
-- **`toName()` returns undefined** — The peer Projection wasn't
+- **`identifier.name` is undefined** — The peer Projection wasn't
   created. Check the peer's `isSupported` filter — your call may
   have been gated out.
 - **Import line not in output** — Confirm the

--- a/deno/docs/authoring/recipes/composing-multi-generator-stacks.md
+++ b/deno/docs/authoring/recipes/composing-multi-generator-stacks.md
@@ -498,7 +498,7 @@ they produced output — verify the `files` map).
 
 - **Operation generator depending on multiple model generators.**
   Pull in each via `insertNormalizedModel(MyModelProjection,
-  schema, fallbackName)`. The pattern scales —
+  { schema, fallbackName })`. The pattern scales —
   `gen-shadcn-form` pulls in three TS types (request body, props,
   path params) plus a Zod validator.
 - **Model generator depending on another model generator.**

--- a/deno/docs/authoring/recipes/composing-multi-generator-stacks.md
+++ b/deno/docs/authoring/recipes/composing-multi-generator-stacks.md
@@ -260,7 +260,7 @@ template:
 
 ```ts
 override toString(): string {
-  const { title, description, submitLabel } = this.settings.enrichments ?? {}
+  const { title, description, submitLabel } = this.settings.enrichments.subject ?? {}
   return `(${this.parameter}) => {
     const form = useForm<Required<${this.tsRequestBodyName}>>({
       resolver: zodResolver(${this.zodRequestBodyName}.required()),
@@ -388,9 +388,14 @@ via enrichments, not via `insert*`. A user can supply a
     "@skmtc/gen-shadcn-form": {
       "/contacts": {
         "post": {
-          "fields": [
-            { "id": "officeIds", "references": "GetOffices" }
-          ]
+          "main": {
+            "fields": [
+              {
+                "moduleSelect": { "schemaPath": ["officeIds"] },
+                "references": "GetOffices"
+              }
+            ]
+          }
         }
       }
     }

--- a/deno/docs/authoring/recipes/design-system-across-many-apis.md
+++ b/deno/docs/authoring/recipes/design-system-across-many-apis.md
@@ -126,7 +126,9 @@ fields:
     "enrichments": {
       "@local/gen-shadcn-form": {
         "/users": {
-          "post": { "title": "Sign up" }
+          "post": {
+            "main": { "title": "Sign up" }
+          }
         }
       }
     }

--- a/deno/docs/authoring/tutorials/02-authoring-a-model-generator.md
+++ b/deno/docs/authoring/tutorials/02-authoring-a-model-generator.md
@@ -174,12 +174,13 @@ something close to:
 
 ```ts
 // src/mod.ts
-import { toModelEntry } from '@skmtc/core'
+import { emptyEnrichmentSchema, toModelEntry } from '@skmtc/core'
 import { SchemaMetaProjection } from './SchemaMetaProjection.ts'
 import denoJson from '../deno.json' with { type: 'json' }
 
 const schemaMetaEntry = toModelEntry({
   id: denoJson.name,
+  toEnrichmentSchema: () => emptyEnrichmentSchema,
   transform({ context, refName }) {
     context.insertModel(SchemaMetaProjection, refName)
   }
@@ -217,9 +218,11 @@ filter inside `transform` — but `isSupported` makes the capability
 explicit, surfaces the refName as `notSupported` rather than a silent
 no-op, and lets peers probe it via `insertModel`.
 
-If you later need user-facing options, add `toEnrichmentSchema` to
-the Entry config and pass the typed enrichment through. The full
-config surface — including `toPreviewModule`, `toMappingModule`,
+`toEnrichmentSchema` is **required** — the scaffold wires it to core's
+`emptyEnrichmentSchema` (no user options). When you need user-facing
+options, replace it with your own three-scope umbrella schema; see
+[how to add enrichment options](../how-to/add-enrichment-options.md).
+The rest of the config surface — `toPreviewModule`, `toMappingModule`,
 and the rarely-used `toEnrichmentRequest` — is documented in the
 [entry-factories reference](../../reference/api/entry-factories.md).
 

--- a/deno/docs/authoring/tutorials/03-authoring-an-operation-generator.md
+++ b/deno/docs/authoring/tutorials/03-authoring-an-operation-generator.md
@@ -204,40 +204,52 @@ implicitly. See [projections-and-snippets concept](../../concepts/projections-an
 ## Step 6: Wire enrichments
 
 The scaffold does not create `src/enrichments.ts`. Add it
-yourself when you need user-configurable behavior. The Valibot
-schema's root **is** the enrichment payload — don't wrap it in
-an extra named object:
+yourself when you need user-configurable behavior. The schema is
+the **three-scope umbrella** — `v.object({ subject, generator, stack })`.
+Your per-operation options go under `subject`; leave the run-constant
+scopes `v.undefined()` when unused:
 
 ```ts
 // src/enrichments.ts
 import * as v from 'valibot'
 
-export const curlSchema = v.optional(
+// The per-operation leaf.
+export const curlSubject = v.optional(
   v.object({
     baseUrl: v.optional(v.string())
   })
 )
 
-export type EnrichmentSchema = v.InferOutput<typeof curlSchema>
-export const toEnrichmentSchema = () => curlSchema
+export const enrichmentSchema = v.object({
+  subject: curlSubject,
+  generator: v.undefined(),
+  stack: v.undefined()
+})
+
+export type EnrichmentSchema = v.InferOutput<typeof enrichmentSchema>
+export const toEnrichmentSchema = () => enrichmentSchema
 ```
 
 Wire it through the entry config and projection-base config (both
-take a `toEnrichmentSchema` field), then read in the Projection:
+take the required `toEnrichmentSchema` field), then read the `subject`
+scope in the Projection:
 
 ```ts
-const baseUrl = this.settings.enrichments?.baseUrl ?? 'https://api.example.com'
+const baseUrl = this.settings.enrichments.subject?.baseUrl ?? 'https://api.example.com'
 ```
 
 Users set `baseUrl` per operation in `client.json` under the OAS
-operation routing path `enrichments[generatorId][path][method]`:
+operation routing path `enrichments[generatorId][path][method][variant]`
+— the subject leaf sits under the variant key (`main` by default):
 
 ```jsonc
 {
   "enrichments": {
     "@local/curl-cmd": {
       "/users": {
-        "get": { "baseUrl": "https://staging.example.com" }
+        "get": {
+          "main": { "baseUrl": "https://staging.example.com" }
+        }
       }
     }
   }

--- a/deno/docs/concepts/cross-generator-coordination.md
+++ b/deno/docs/concepts/cross-generator-coordination.md
@@ -113,8 +113,9 @@ calls out the purity requirement.
 
 ## The Driver flow
 
-When code calls `context.insertOperation(MyProjection, op)` (or the
-projection-base wrapper that auto-fills `destinationPath`):
+When code calls `context.insertOperation({ projection: MyProjection, operation })`
+(or the positional projection-base wrapper `this.insertOperation(MyProjection, operation)`
+that auto-fills `destinationPath`):
 
 1. **Compute settings.** Driver calls `MyProjection.toIdentifierName(...)`
    and `MyProjection.toExportPath(...)` to produce the cache key

--- a/deno/docs/concepts/enrichments.md
+++ b/deno/docs/concepts/enrichments.md
@@ -293,8 +293,8 @@ Specifically:
 - **Model generators** route by `(refName, variant)` — the component name as it
   appears under `components.schemas`, plus variant name.
 - **GraphQL operation generators** route by `(rootKind, fieldName, variant)` —
-  `"Query" | "Mutation" | "Subscription"`, the operation field, and variant
-  name.
+  `"query" | "mutation" | "subscription"` (lowercase), the operation field, and
+  variant name.
 
 The trailing `variant` level defaults to `'main'` when the consumer declares no
 variants. Whenever any variant is declared, `'main'` MUST be present (the engine
@@ -316,12 +316,12 @@ member describes the leaf at that scope; unused scopes are declared
 ```ts
 // gen-shadcn-form/src/enrichments.ts
 import * as v from "valibot";
-import { moduleExport } from "@skmtc/core";
+import { lensInputModuleType, moduleSelect } from "@skmtc/core";
 
 export const formFieldItem = v.object({
-  id: v.string(),
-  accessorPath: v.optional(v.array(v.string())),
-  input: v.optional(moduleExport),
+  // `moduleSelect` is the field binding: `schemaPath` (the join key) plus an
+  // optional consumer component bound to the field's lens.
+  moduleSelect: v.pipe(moduleSelect(lensInputModuleType), v.title("Input")),
   label: v.optional(v.string()),
   placeholder: v.optional(v.string()),
   references: v.optional(v.string()),

--- a/deno/docs/concepts/the-three-phases.md
+++ b/deno/docs/concepts/the-three-phases.md
@@ -265,7 +265,7 @@ returns `void`). Instead, the transform calls
 
 ### The Driver lifecycle
 
-When `transform` calls `context.insertOperation(TanstackQuery, operation)`:
+When `transform` calls `context.insertOperation({ projection: TanstackQuery, operation })`:
 
 1. `new OasOperationDriver(...)` runs
    (`core/dsl/operation/oas/OasOperationDriver.ts`).

--- a/deno/docs/reference/api/content-settings.md
+++ b/deno/docs/reference/api/content-settings.md
@@ -169,7 +169,7 @@ Inside the Projection, the settings are available as `this.settings`:
 
 class ShadcnForm extends ShadcnFormBase {
   override toString(): string {
-    const { title, submitLabel } = this.settings.enrichments ?? {}
+    const { title, submitLabel } = this.settings.enrichments.subject ?? {}
 
     return `
       <Form>
@@ -265,7 +265,7 @@ const settings = new ContentSettings<EnrichmentSchema>({
 
 class ShadcnForm extends ShadcnFormBase {
   override toString(): string {
-    const { title, submitLabel } = this.settings.enrichments ?? {}
+    const { title, submitLabel } = this.settings.enrichments.subject ?? {}
     return `<Form><h2>${title}</h2>...<Button>${submitLabel}</Button></Form>`
   }
 }

--- a/deno/docs/reference/settings/enrichments-shape.md
+++ b/deno/docs/reference/settings/enrichments-shape.md
@@ -230,7 +230,7 @@ The validated, routed payload is available at `this.settings.enrichments`:
 ```ts
 // gen-shadcn-form/src/ShadcnForm.ts
 override toString(): string {
-  const { title, description, submitLabel } = this.settings.enrichments ?? {}
+  const { title, description, submitLabel } = this.settings.enrichments.subject ?? {}
 
   return `(${this.parameter}) => {
     return (
@@ -294,7 +294,8 @@ values via constructor arguments:
 new MyFieldSnippet({
   context,
   name,
-  label: parent.settings.enrichments?.fields?.find(f => f.id === name)?.label,
+  label: parent.settings.enrichments.subject?.fields
+    ?.find(f => f.moduleSelect.schemaPath.at(-1) === name)?.label,
   destinationPath
 })
 ```

--- a/deno/docs/skills/skmtc-architecture/SKILL.md
+++ b/deno/docs/skills/skmtc-architecture/SKILL.md
@@ -245,7 +245,7 @@ dependency graph and no topological sort.** Coordination is
 **memoization**:
 
 - A generator that needs a peer's output calls
-  `context.insertOperation(PeerProjection, op)` (or `insertModel` /
+  `this.insertOperation(PeerProjection, op)` (or `insertModel` /
   `insertNormalizedModel`).
 - A **Driver** (`OasOperationDriver`, `GqlOperationDriver`,
   `ModelDriver`) computes a cache key `(identifier.name, exportPath)`

--- a/deno/docs/skills/skmtc-generator/SKILL.md
+++ b/deno/docs/skills/skmtc-generator/SKILL.md
@@ -731,7 +731,7 @@ operational details — committing this table to memory saves time:
 | `transform` return | `void` — the `acc` accumulator is removed (F11) | same | same |
 | `isSupported` field | optional, default `() => true` | optional, default `() => true` | optional, default `() => true` (predicate gets `refName`, no schema) |
 | Enrichment routing | `enrichments.<id>.<path>.<method>.<variant>` | `enrichments.<id>.<rootKind>.<fieldName>.<variant>` | `enrichments.<id>.<refName>.<variant>` |
-| Compose with | `context.insertOperation(P, op, { variant? })` | `context.insertOperation(P, op, { variant? })` | `context.insertModel(P, refName, { variant? })` |
+| Compose with | `this.insertOperation(P, op, { variant? })` | `this.insertOperation(P, op, { variant? })` | `this.insertModel(P, refName, { variant? })` |
 | Companion base factory (from `@skmtc/lang-typescript`) | `toTsOasOperationProjectionBase` | `toTsGqlOperationProjectionBase` | `toTsModelProjectionBase` |
 | `GeneratorKey` shape | `id\|path\|method\|variant` | `id\|rootKind\|fieldName\|variant` | `id\|refName\|variant` |
 

--- a/deno/docs/using/tutorials/03-customize-with-enrichments.md
+++ b/deno/docs/using/tutorials/03-customize-with-enrichments.md
@@ -118,7 +118,7 @@ generator's Valibot schema. The validated value lands on the
 Projection as `this.settings.enrichments`:
 
 ```ts
-const { title, submitLabel } = this.settings.enrichments ?? {}
+const { title, submitLabel } = this.settings.enrichments.subject ?? {}
 return `<Form><h2>${title ?? defaultTitle}</h2>...<Button>${submitLabel ?? 'Submit'}</Button></Form>`
 ```
 


### PR DESCRIPTION
Two verified clusters from the 2026-07-07 docs-vs-source audit, combined
because they share a file (`composing-multi-generator-stacks.md`).

## Cluster A — insert* arg shapes / return types

Two distinct `insertOperation` methods were conflated, and
`insertNormalizedModel`'s return type was wrong. Verified against source:

| Call | Shape | Returns |
|---|---|---|
| `context.insertOperation({ projection, operation })` | object | `Inserted` (`.toName()`) |
| `this.insertOperation(projection, operation, opts?)` | positional (base convenience) | `Inserted` (`.toName()`) |
| `insertModel(projection, refName, opts?)` | positional | `Inserted` (`.toName()`) |
| `insertNormalizedModel(projection, { schema, fallbackName })` | object opts | **`Definition`** (`.identifier.name`) |

Most docs already used the positional `this.` form correctly — only the
`context.`-receiver calls and `insertNormalizedModel().toName()` were wrong.

## Cluster B — enrichment umbrella model

The concept page and skill were already correct; the authoring how-tos,
tutorials, and recipes still taught the pre-0.8 flat model. Corrected to:

- `toEnrichmentSchema` (required) returns `v.object({ subject, generator, stack })`;
  per-item leaf under `subject`; unused scopes `v.undefined()`; no-config →
  `emptyEnrichmentSchema`.
- Projection reads `this.settings.enrichments.subject?.<field>`.
- `client.json` nests the subject leaf under `[variant]` (`main`, required).

Plus two concept-page detail bugs: GQL rootKind is lowercase;
`formFieldItem` uses `moduleSelect`, not `id`/`accessorPath`/`input`.

A tree-wide sweep (not just the audited pages) caught flat reads on
`enrichments-shape`, `content-settings`, and `using/tutorials/03` — pages
the partial audit never reached. Doc gate green.