### PR TITLE
docs: add remediation tracker for the docs cleanup

### DIFF
--- a/deno/docs/friction-log/docs-remediation-reaudit-findings.json
+++ b/deno/docs/friction-log/docs-remediation-reaudit-findings.json
@@ -1,0 +1,1987 @@
+{
+  "auditDate": "2026-07-07",
+  "kind": "re-audit (audit-only) of the 90 pages the first pass never reached",
+  "caveat": "Audit-only run \u2014 NO adversarial verify phase. Every discrepancy is UNVERIFIED. Verify each against current source before acting (the first audit was wrong on several counts).",
+  "pagesAudited": 90,
+  "bySeverity": {
+    "error": 59,
+    "major": 81,
+    "minor": 80
+  },
+  "discrepancies": [
+    {
+      "page": "concepts/generators-as-packages.md",
+      "claim": "Model entries differ from operation entries by having no `isSupported` \u2014 \"there's no capability gate at the Entry level. Filter inside `transform` if needed.\"",
+      "docLocation": "concepts/generators-as-packages.md:126,139-141",
+      "evidence": "core/dsl/model/toModelEntry.ts:17 declares `isSupported?: (args: IsSupportedModelArgs) => boolean` on the entry config, :124 defaults it to `() => true`, and the JSDoc at :66-69 documents it as an \"Optional capability gate; a model whose predicate returns `false` is recorded `notSupported` and its `transform` is skipped.\" Model entries DO have an entry-level capability gate \u2014 symmetric with operation entries \u2014 contradicting the doc's claim that they don't and that filtering must happen inside `transform`.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'isSupported?: (args: IsSupportedModelArgs) => boolean' core/dsl/model/toModelEntry.ts"
+    },
+    {
+      "page": "concepts/vocabulary-cheat-sheet.md",
+      "claim": "The `client.json#settings` block \"Carries `basePath`, `source`, `enrichments`, `include`, `skip`.\"",
+      "docLocation": "concepts/vocabulary-cheat-sheet.md:65",
+      "evidence": "In core/types/Settings.ts the `clientSettings` schema (lines 227-236) has `basePath`, `schemaSource`, `packages`, `enrichments`, `include`, `skip`, `anchors`, `inputDirs` \u2014 there is no `source` field inside settings. `source` is a field of `skmtcClientConfig` at the client.json ROOT (line 578), a sibling of `settings`, not a member of it. The settings-level equivalent is named `schemaSource` (line 229), not `source`.",
+      "severity": "major",
+      "verificationCommand": "sed -n '227,236p' core/types/Settings.ts | grep -q 'schemaSource:' && ! sed -n '227,236p' core/types/Settings.ts | grep -qw 'source:'"
+    },
+    {
+      "page": "concepts/vocabulary-cheat-sheet.md",
+      "claim": "`basePath` is \"Required, relative.\"",
+      "docLocation": "concepts/vocabulary-cheat-sheet.md:67",
+      "evidence": "In core/types/Settings.ts:228 the `clientSettings` schema declares `basePath: v.optional(v.string())` \u2014 the field is optional in the config schema, contradicting the \"Required\" wording.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'basePath: v.optional(v.string())' core/types/Settings.ts"
+    },
+    {
+      "page": "explanation/design-philosophy.md",
+      "claim": "The _oasIssueTypeDriftCheck binding (OasIssueType TS union vs oasIssueType Valibot schema) is at core/context/generateTypes.ts:208-209",
+      "docLocation": "explanation/design-philosophy.md:133 (and repeated at :145)",
+      "evidence": "The binding `const _oasIssueTypeDriftCheck: v.GenericSchema<OasIssueType> = oasIssueType` / `void _oasIssueTypeDriftCheck` is actually at generateTypes.ts:264-265. Lines 208-209 contain a JSDoc comment ('The TS type and the valibot schema below stay in sync via the'). The quoted code content is correct; only the line citation drifted.",
+      "severity": "minor",
+      "verificationCommand": "cd core && test \"$(grep -n '_oasIssueTypeDriftCheck: v.GenericSchema' context/generateTypes.ts | cut -d: -f1)\" = 264 && ! sed -n '208,209p' context/generateTypes.ts | grep -q _oasIssueTypeDriftCheck"
+    },
+    {
+      "page": "explanation/design-philosophy.md",
+      "claim": "The GqlIssueType TS-union / gqlIssueType Valibot-schema drift-check pairing is at ParseIssue.ts:72-73",
+      "docLocation": "explanation/design-philosophy.md:146",
+      "evidence": "The drift-check binding `const _gqlIssueTypeDriftCheck: v.GenericSchema<GqlIssueType> = gqlIssueType` is at core/context/ParseIssue.ts:80-81. Lines 72-73 are union literal members (`v.literal('UNKNOWN_TYPE_KIND')`, `v.literal('DROPPED_DIRECTIVE')`) inside the gqlIssueType schema, not the drift-check binding.",
+      "severity": "minor",
+      "verificationCommand": "cd core && test \"$(grep -n '_gqlIssueTypeDriftCheck: v.GenericSchema' context/ParseIssue.ts | cut -d: -f1)\" = 80 && ! sed -n '72,73p' context/ParseIssue.ts | grep -q _gqlIssueTypeDriftCheck"
+    },
+    {
+      "page": "explanation/how-idempotency-works.md",
+      "claim": "The `Registered definition mismatch` throw via `affirmDefinition` is cited at `OasOperationDriver.ts:129`, `GqlOperationDriver.ts:129`, and `model/ModelDriver.ts:137`.",
+      "docLocation": "explanation/how-idempotency-works.md:206-208",
+      "evidence": "Cited lines do not contain affirmDefinition or the throw: OasOperationDriver.ts:129 and GqlOperationDriver.ts:129 are blank lines; ModelDriver.ts:137 is `exportPath` (an arg to findDefinition). The actual `affirmDefinition` call sites are at OasOperationDriver.ts:139, GqlOperationDriver.ts:139, ModelDriver.ts:140, and the `Registered definition mismatch` throw is at OasOperationDriver.ts:181, GqlOperationDriver.ts:181, ModelDriver.ts:184. The mechanism the doc describes is real; only the line numbers have drifted.",
+      "severity": "minor",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && ! sed -n '129p' core/dsl/operation/oas/OasOperationDriver.ts | grep -q affirmDefinition && ! sed -n '137p' core/dsl/model/ModelDriver.ts | grep -q affirmDefinition && grep -q 'Registered definition mismatch' <(sed -n '181p' core/dsl/operation/oas/OasOperationDriver.ts) && grep -q 'Registered definition mismatch' <(sed -n '184p' core/dsl/model/ModelDriver.ts)"
+    },
+    {
+      "page": "explanation/status-and-roadmap.md",
+      "claim": "`bundle --json` itself returns only `{ kind, projectName, bundlePath }`",
+      "docLocation": "explanation/status-and-roadmap.md:209-210",
+      "evidence": "The bundle result type is `{ type: 'bundled'; projectName: string; bundlePath: string }` (cli/lib/bundle-headless.ts:27-31) and the JSON output is a bare `JSON.stringify(result)` (cli/commands/bundle.tsx:86). The discriminator field is `type` (value `'bundled'`), not `kind` \u2014 bundle.tsx:77-78 even documents `jq -e '.type == \"bundled\"'`. A reader scripting on `.kind` gets null. The load-bearing `.bundlePath` is correct.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"type: 'bundled'\" cli/lib/bundle-headless.ts && ! grep -q 'kind' cli/lib/bundle-headless.ts"
+    },
+    {
+      "page": "explanation/status-and-roadmap.md",
+      "claim": "The collision is loud... see `affirmDefinition` in the three Drivers.",
+      "docLocation": "explanation/status-and-roadmap.md:176-177",
+      "evidence": "Four Drivers define `private affirmDefinition` with the identical 'Registered definition mismatch' throw: OasOperationDriver.ts, GqlOperationDriver.ts, ModelDriver.ts, and WebhookDriver.ts \u2014 not three.",
+      "severity": "minor",
+      "verificationCommand": "[ \"$(grep -rl 'private affirmDefinition' core | grep -c '\\.ts$')\" -eq 4 ]"
+    },
+    {
+      "page": "explanation/the-graphql-asymmetry.md",
+      "claim": "The page's entire thesis: OAS Parse runs host-side and the *parsed document* is postMessage'd into the Worker, whereas GraphQL parses inside the Worker \u2014 presented as a structural OAS-vs-GraphQL asymmetry in WHERE parsing happens.",
+      "docLocation": "docs/explanation/the-graphql-asymmetry.md:11-13 (also 25-27, 174 diagram, 169-181)",
+      "evidence": "In current source BOTH protocols parse worker-side inside the pipeline. cli/lib/document-input.ts:29-31 posts OAS as `{ type: 'oas', value: documentObject }` where documentObject is the RAW OpenAPIV3.Document produced by @skmtc/convert (`toV3Document(stringToSchema(...))`) \u2014 a normalization to 3.0, NOT a parse into the internal model. worker/mod.ts:66-68 states 'toArtifacts runs the protocol-specific parse step inside the pipeline based on document.type'. core/context/ParseContext.ts:127-134 shows OAS parse (`new OasDocument()` + `.parse()` walk over `input.value`) runs inside toArtifacts, i.e. worker-side. There is no host-side OAS *parse*; the WHERE-parsing-happens asymmetry the page is built on does not exist.",
+      "verificationCommand": "grep -q 'Parse runs host-side' docs/explanation/the-graphql-asymmetry.md && grep -q 'value: documentObject' cli/lib/document-input.ts",
+      "severity": "error"
+    },
+    {
+      "page": "explanation/the-graphql-asymmetry.md",
+      "claim": "'The OAS pre-parse step is host-side... The Worker receives a fully-typed OasDocument-shaped value.'",
+      "docLocation": "docs/explanation/the-graphql-asymmetry.md:179-181",
+      "evidence": "The worker receives a raw OpenAPIV3.Document, not an OasDocument. core/context/ParseContext.ts:127-133 constructs `oasDocument: new OasDocument()` and later `parse()` walks `documentObject` (input.value) \u2014 the OasDocument is built INSIDE the worker/pipeline, not received across the boundary. worker/types.ts:52-54 confirms the GENERATE payload's OAS variant carries 'the OpenAPI v3 document (already converted to 3.0 host-side via @skmtc/convert)', i.e. the raw document, then 'The worker hands the union straight to toArtifacts, which runs the protocol-specific parser inside the pipeline.'",
+      "verificationCommand": "grep -q 'receives a fully-typed' docs/explanation/the-graphql-asymmetry.md && grep -q 'oasDocument: new OasDocument()' core/context/ParseContext.ts",
+      "severity": "error"
+    },
+    {
+      "page": "explanation/the-graphql-asymmetry.md",
+      "claim": "'Why OAS can cross the boundary as parsed JSON' \u2014 the OAS parser produces a tree of plain objects with oasType discriminators, this cloneable parsed model crosses the boundary, and only GraphQL's parsed model is class instances.",
+      "docLocation": "docs/explanation/the-graphql-asymmetry.md:76-108 (also 20-23)",
+      "evidence": "The oasType-tagged OAS model is itself a graph of CLASS instances, not plain objects, and it does not cross the boundary. core/oas/document/Document.ts:152-154 `export class OasDocument { oasType: 'openapi' }` and core/oas/operation/Operation.ts:68-70 `export class OasOperation extends OasBase { oasType: 'operation' }` (carrying methods). What actually crosses the boundary for OAS is the raw OpenAPIV3.Document (cli/lib/document-input.ts:30-31); the class-instance OasDocument model is built worker-side by ParseContext. So the OAS-cloneable-vs-GraphQL-class-instances contrast the section draws is false \u2014 both internal models are non-clone-safe class graphs, and the raw form is what crosses in both cases.",
+      "verificationCommand": "grep -q 'Why OAS can cross the boundary as parsed JSON' docs/explanation/the-graphql-asymmetry.md && grep -q \"oasType: 'operation'\" core/oas/operation/Operation.ts",
+      "severity": "major"
+    },
+    {
+      "page": "explanation/the-graphql-asymmetry.md",
+      "claim": "'The Worker's first action is to call graphql.parse(sdl), producing an AST inside its own process' (also 'GraphQL's AST produced by graphql-js's parse function').",
+      "docLocation": "docs/explanation/the-graphql-asymmetry.md:184 (also 112)",
+      "evidence": "The worker-side GraphQL entry point is `buildSchema`, not `parse`, and it produces a `GraphQLSchema`, not a raw AST. core/context/ParseContext.ts:24 imports `{ buildSchema }` from 'graphql' and line 136-137 does `typeof input.value === 'string' ? buildSchema(input.value) : input.value`. core/types/SkmtcDocument.ts:76 documents 'Strings are run through buildSchema inside the pipeline'. The page's named function (graphql.parse) and produced artifact (AST) are both wrong.",
+      "verificationCommand": "grep -q 'graphql.parse(sdl)' docs/explanation/the-graphql-asymmetry.md && grep -q 'buildSchema(input.value)' core/context/ParseContext.ts",
+      "severity": "major"
+    },
+    {
+      "page": "explanation/why-three-phases.md",
+      "claim": "For OAS, the parsed model is produced host-side (in the CLI process) and then crossed into the Worker via structuredClone; the boundary sits after Parse completes, and crossing is one postMessage of a stable model. GraphQL is contrasted as the one that 'parses worker-side'.",
+      "docLocation": "explanation/why-three-phases.md:155-171",
+      "evidence": "cli/lib/document-input.ts:20-38 shows the host sends a raw OpenAPIV3.Document (JSON) for OAS \u2014 it runs only Swagger2/3.1\u21923.0 normalization via @skmtc/convert, not the Parse phase. worker/mod.ts:65-66 states 'toArtifacts runs the protocol-specific parse step inside the pipeline', i.e. the Parse phase (producing OasDocument/OasOperation/OasSchema) runs worker-side for OAS just like GraphQL. The structuredClone boundary is therefore BEFORE Parse, not 'at Generate's start' / 'after Parse completes'. The doc's OAS-vs-GraphQL asymmetry (OAS host-side / GraphQL worker-side) is wrong: both parse worker-side; the real asymmetry is that OAS gets host-side format conversion while GraphQL posts raw SDL.",
+      "severity": "error",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && grep -q 'protocol-specific parse step inside the pipeline' worker/mod.ts && grep -q \"type: 'oas', value: documentObject\" cli/lib/document-input.ts"
+    },
+    {
+      "page": "explanation/why-three-phases.md",
+      "claim": "The parsed OasDocument is a tree of plain objects with discriminators \u2014 JSON-cloneable \u2014 which is what makes the structuredClone crossing work.",
+      "docLocation": "explanation/why-three-phases.md:158-160",
+      "evidence": "OasDocument is a class instance with a private #fields store (core/oas/document/Document.ts:152, 156), and the model contains OasOperation (class OasOperation extends OasBase, core/oas/operation/Operation.ts:68) and OasRef back-refs (class OasRef extends OasBase, core/oas/ref/Ref.ts:158). cli/lib/document-input.ts:13-15 explicitly notes that a pre-parsed document 'would carry class instances and OasRef back-refs that don't survive structured clone' \u2014 the exact opposite of the doc's 'plain objects \u2026 JSON-cloneable' claim. The parsed model is not what crosses the boundary; the raw JSON document is.",
+      "severity": "error",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && grep -q 'class OasDocument' core/oas/document/Document.ts && grep -q '#fields' core/oas/document/Document.ts && grep -q \"don't survive structured clone\" cli/lib/document-input.ts"
+    },
+    {
+      "page": "llms.md",
+      "claim": "Per-model skip filter is written as `{ \"@skmtc/gen-zod\": [\"UserModel\"] }` (a generatorId mapping to an array of model names).",
+      "docLocation": "docs/llms.md:355",
+      "evidence": "In core/types/Settings.ts the `skip` union is `[skipOperations, skipModels, v.string()]`. `skipModels = v.record(v.string(), skipModelRefs)` (line 154) and `skipModelRefs = v.record(v.string(), v.array(v.string()))` (line 143). So a per-model skip must be `{ \"@skmtc/gen-zod\": { \"UserModel\": [] } }` (generatorId -> refName -> variant[]). The doc's `{ \"@skmtc/gen-zod\": [\"UserModel\"] }` maps a generatorId to a bare array, which matches no arm of the union and fails Valibot validation.",
+      "severity": "error",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && grep -A3 'export const skipModels' core/types/Settings.ts | grep -q skipModelRefs && grep -A3 'export const skipModelRefs' core/types/Settings.ts | grep -q 'v.array(v.string())'"
+    },
+    {
+      "page": "llms.md",
+      "claim": "The DSL source-map lists the Identifier primitive at file path `core/dsl/Identifier.ts`.",
+      "docLocation": "docs/llms.md:393",
+      "evidence": "core/dsl/Identifier.ts does not exist; the neutral base class now lives at core/dsl/IdentifierBase.ts (there is also core/dsl/IdentifierType.ts). A reader following the source-map path finds no file. The doc elsewhere (fact 6 line 74, glossary line 621) also calls it `Identifier`, but the core class is `IdentifierBase`.",
+      "severity": "minor",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && test ! -e core/dsl/Identifier.ts && test -e core/dsl/IdentifierBase.ts"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "Import example imports `Identifier` from `@skmtc/core`, and the DSL classes table lists `Identifier` as a core export (Name + entity-type marker).",
+      "docLocation": "reference/api/core-overview.md:26 and :70",
+      "evidence": "Core does not export any symbol named `Identifier`. `core/dsl/IdentifierBase.ts:35` exports `IdentifierBase`; the concrete `Identifier` class is `TsIdentifier` in `lang-typescript/src/TsIdentifier.ts:28`. Copying the import example (`import { ... Identifier ... } from '@skmtc/core'`) fails to resolve.",
+      "verificationCommand": "! grep -rqE \"export (class|const|type|interface|function) Identifier\\b\" core/",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "DSL classes table lists `Definition` as a core export that 'Wraps a Projection's value into export const NAME ='.",
+      "docLocation": "reference/api/core-overview.md:69",
+      "evidence": "Core exports the neutral base `DefinitionBase` (abstract) at core/dsl/Definition.ts:35, not `Definition`. The concrete class is `TsDefinition` in lang-typescript/src/TsDefinition.ts:30.",
+      "verificationCommand": "grep -rq \"export abstract class DefinitionBase\" core/dsl/Definition.ts && ! grep -rqE \"export (class|abstract class) Definition\\b\" core/dsl/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "DSL classes table lists `Import` as a core export ('Rendered import { X } from ... statement').",
+      "docLocation": "reference/api/core-overview.md:71",
+      "evidence": "Core exports the neutral base `ImportBase` (core/dsl/ImportBase.ts), not `Import`. The concrete class is `TsImport` in lang-typescript/src/TsImport.ts:67.",
+      "verificationCommand": "grep -rq \"export abstract class ImportBase\" core/dsl/ImportBase.ts && ! grep -rqE \"export class Import\\b\" core/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "DSL classes table lists `File` (and `JsonFile` as 'Variant of File') as core exports; `File` = 'Output file with imports, definitions, and metadata'.",
+      "docLocation": "reference/api/core-overview.md:73",
+      "evidence": "Core exports neutral bases `FileBase` (core/dsl/FileBase.ts:22) and `CodeFileBase` (core/dsl/CodeFileBase.ts:66), not `File`. The concrete class is `TsFile` in lang-typescript/src/TsFile.ts:28. (`JsonFile` at core/dsl/JsonFile.ts:45 does exist and extends FileBase, not a class named `File`.)",
+      "verificationCommand": "grep -rq \"export abstract class FileBase\" core/dsl/FileBase.ts && ! grep -rqE \"export (class|abstract class) File\\b\" core/dsl/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "Type system helpers table lists `ImportNameArg` (`string | { name, alias?, type? }`) as an `@skmtc/core` export \u2014 input to `register({ imports })`.",
+      "docLocation": "reference/api/core-overview.md:142",
+      "evidence": "`ImportNameArg` is declared and exported only from lang-typescript/src/TsImport.ts:14 (re-exported by lang-typescript/mod.ts:57), not from core. Its actual shape is a three-way union `string | { [name: string]: string } | { name; alias?; type? }` \u2014 the doc omits the middle `{ [name]: string }` form.",
+      "verificationCommand": "! grep -rqE \"export type ImportNameArg\" core/ && grep -rq \"export type ImportNameArg\" lang-typescript/src/TsImport.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "GraphQL object model table lists `GqlType` (union) as a core export \u2014 'Set of GraphQL types (object, scalar, enum, etc.)'.",
+      "docLocation": "reference/api/core-overview.md:129",
+      "evidence": "No `GqlType` symbol exists anywhere in core (source-wide grep finds nothing). The GraphQL exports are GqlDocument, GqlRegistry, GqlOperation, GqlArgument, GqlRootTypes.",
+      "verificationCommand": "! grep -rqE \"export (type|class) GqlType\\b\" core/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "Naming/identifier helpers table lists `isIdentifierName(s)` \u2014 'Check if a string is a valid JS identifier'.",
+      "docLocation": "reference/api/core-overview.md:158",
+      "evidence": "No `isIdentifierName` export (or any occurrence) exists in core source; the helper does not exist.",
+      "verificationCommand": "! grep -rqE \"export (const|function) isIdentifierName\" core/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "Parsing helpers table gives `tryParseAt(ctx, key, valibotSchema, value)` \u2014 a positional-arg lenient parse taking a valibot schema and value.",
+      "docLocation": "reference/api/core-overview.md:164",
+      "evidence": "core/context/tryParseAt.ts:72 defines `tryParseAt` as a single object-arg function `<T>({ stackTrail, key, context, type, parent, refKey, fn })` that runs `fn` inside a stack trace and returns undefined on throw. There is no `valibotSchema`/`value` parameter and it is not positional.",
+      "verificationCommand": "grep -qE \"export const tryParseAt = <T>\\(\\{\" core/context/tryParseAt.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "claim": "Parsing helpers table lists `removeErroredItems` as an importable helper alongside `tryParseAt`.",
+      "docLocation": "reference/api/core-overview.md:165",
+      "evidence": "`removeErroredItems` is a method on ParseContext (core/context/ParseContext.ts:306, `removeErroredItems(): void`), not a standalone exported helper function.",
+      "verificationCommand": "grep -q \"removeErroredItems(): void\" core/context/ParseContext.ts && ! grep -rqE \"export (const|function) removeErroredItems\" core/",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/dsl-custom-value.md",
+      "claim": "The Class block and Properties section declare the discriminator as `readonly type: 'custom'`.",
+      "docLocation": "reference/api/dsl-custom-value.md:18",
+      "evidence": "Source declares `type = 'custom' as const` (a writable field, no `readonly` modifier) in core/dsl/CustomValue.ts:32.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"readonly type: 'custom'\" docs/reference/api/dsl-custom-value.md && grep -q \"type = 'custom' as const\" core/dsl/CustomValue.ts && ! grep -q 'readonly type' core/dsl/CustomValue.ts"
+    },
+    {
+      "page": "reference/api/dsl-definition.md",
+      "claim": "The DefinitionBase class signature is shown with field/constructor arg typed `identifier: Identifier`.",
+      "docLocation": "reference/api/dsl-definition.md:24",
+      "evidence": "Source types the field and constructor arg as `IdentifierBase`, not `Identifier`. core/dsl/Definition.ts:39 declares `identifier: IdentifierBase` and :44 destructures `IdentifierBaseArgs`. Core's mod.ts exports `IdentifierBase` (core/mod.ts:88); there is no exported bare `Identifier` type. The sibling page dsl-identifier.md:133 explicitly flags 'Identifier class in core' as wrong, canonicalizing `IdentifierBase`.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'identifier: Identifier' docs/reference/api/dsl-definition.md && grep -q 'identifier: IdentifierBase' core/dsl/Definition.ts"
+    },
+    {
+      "page": "reference/api/dsl-definition.md",
+      "claim": "toString() derives the declaration keyword from 'the identifier's `kind`' (toTsKeyword: 'variable' \u2192 const, 'type' \u2192 type).",
+      "docLocation": "reference/api/dsl-definition.md:67",
+      "evidence": "The identifier field is named `type`, not `kind`. TsDefinition.toString destructures `const { type, name, typeName } = this.identifier` (lang-typescript/src/TsDefinition.ts:57) and TsIdentifier declares `type: TsEntityType` (lang-typescript/src/TsIdentifier.ts:30). No `kind` field exists on the identifier.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"identifier's \\`kind\\`\" docs/reference/api/dsl-definition.md && grep -q 'const { type, name, typeName } = this.identifier' lang-typescript/src/TsDefinition.ts"
+    },
+    {
+      "page": "reference/api/dsl-definition.md",
+      "claim": "toString() step 5 always emits '`=`, the value ..., `;\\n`' after the keyword+name \u2014 i.e. every definition renders as `export <kw> Name = value;`.",
+      "docLocation": "reference/api/dsl-definition.md:71",
+      "evidence": "Block-form types (class / interface / namespace) render WITHOUT `= value` and WITHOUT a trailing `;`. TsDefinition.toString branches on `isBlockType(type)` (lang-typescript/src/TsDefinition.ts:71-78) emitting `${keyword} ${name} ${this.value}` for class/interface/namespace. The doc's universal step list and the two-entry keyword enumeration ('variable'\u2192const, 'type'\u2192type) omit this entire branch.",
+      "severity": "minor",
+      "verificationCommand": "! grep -q 'isBlockType\\|block-form\\|class / interface' docs/reference/api/dsl-definition.md && grep -q 'isBlockType' lang-typescript/src/TsDefinition.ts"
+    },
+    {
+      "page": "reference/api/dsl-definition.md",
+      "claim": "First-write-wins: '`addDefinition` ignores a duplicate name'.",
+      "docLocation": "reference/api/dsl-definition.md:149",
+      "evidence": "addDefinition dedups on `declarationKey()` (name folded with declaration type), not bare name. lang-typescript/src/TsFile.ts:67 keys on `definition.identifier.declarationKey()`; the class doc (TsFile.ts:60-64) and test (TsFile.test.ts:202) confirm a same-name/different-type pair (e.g. `class Foo` + `declare namespace Foo`) occupies different slots and BOTH render \u2014 a duplicate name is not necessarily ignored.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'ignores a duplicate name' docs/reference/api/dsl-definition.md && grep -q 'definition.identifier.declarationKey()' lang-typescript/src/TsFile.ts"
+    },
+    {
+      "page": "reference/api/dsl-import.md",
+      "claim": "Rendered import statements are shown with spaces inside the braces, e.g. `import { z } from 'zod'`, `import { useMutation, type UseMutationResult } from '@tanstack/react-query'`, and the statement-level `import type { A, B } from './types'`.",
+      "docLocation": "reference/api/dsl-import.md:121 (also 88, 90, 122-124)",
+      "evidence": "TsImport.toString() renders named specifiers via List.toObject, which wraps with no inner-brace padding (`{${joined}}` in List.ts:207), and the statement-level branch produces `import type {${names.join(', ')}}` (TsImport.ts:128). Running the renderer yields `import {z} from 'zod'`, `import {useMutation, type UseMutationResult} from '@tanstack/react-query'`, and `import type {A, B} from './types'` \u2014 no spaces inside the braces. No formatter runs in-pipeline, so this is the literal output.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"import { z } from 'zod'\" docs/reference/api/dsl-import.md && grep -qF '`{${joined}}`' lang-typescript/src/List.ts && grep -qF \"import type {${names.join(', ')}}\" lang-typescript/src/TsImport.ts"
+    },
+    {
+      "page": "reference/api/dsl-import.md",
+      "claim": "`static fromIdentifier(module: string, identifier: Identifier): TsImport` \u2014 the second parameter is typed `Identifier`.",
+      "docLocation": "reference/api/dsl-import.md:53",
+      "evidence": "Source signature is `static fromIdentifier(module: string, identifier: TsIdentifier): TsImport` (TsImport.ts:88). The concrete type is `TsIdentifier` (exported from lang-typescript/src/TsIdentifier.ts:28); there is no exported type or class named `Identifier`.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'identifier: Identifier)' docs/reference/api/dsl-import.md && grep -q 'identifier: TsIdentifier' lang-typescript/src/TsImport.ts"
+    },
+    {
+      "page": "reference/api/dsl-inserted.md",
+      "claim": "The Inserted class is declared with a default on its second type parameter: `class Inserted<V extends GeneratedValue, EnrichmentType = undefined>`, and the Generic parameters table states EnrichmentType 'Defaults to undefined for Projections without enrichments.'",
+      "docLocation": "docs/reference/api/dsl-inserted.md:22,49",
+      "evidence": "Source declares no default on the class: `export class Inserted<V extends GeneratedValue, EnrichmentType>` (core/dsl/Inserted.ts:68). The `= undefined` default exists only on the insertOperation/insertModel call-site methods (GenerateContext.ts:1188), not on the Inserted class itself.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"EnrichmentType = undefined\" docs/reference/api/dsl-inserted.md && grep -q \"export class Inserted<V extends GeneratedValue, EnrichmentType>\" core/dsl/Inserted.ts"
+    },
+    {
+      "page": "reference/api/dsl-inserted.md",
+      "claim": "In the 'Does Inserted participate in caching?' answer: 'The cache lives in `File.definitions: Map<name, Definition>`.'",
+      "docLocation": "docs/reference/api/dsl-inserted.md:202",
+      "evidence": "There is no `File` class in core/ or lang-typescript/ (the legacy core File class was deleted). The cache read seam is the neutral `CodeFileBase.findDefinitions` (core/dsl/CodeFileBase.ts:94), and concrete storage is `TsFile.definitions: Map<string, TsDefinition>` (lang-typescript/src/TsFile.ts:41) \u2014 keyed by `string` with `TsDefinition` values, not `Map<name, Definition>` on a `File` class.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'File.definitions: Map<name, Definition>' docs/reference/api/dsl-inserted.md && ! grep -rqE '(export )?class File\\b' core/ lang-typescript/"
+    },
+    {
+      "page": "reference/api/dsl-snippet-base.md",
+      "claim": "The 'Related types' block declares `type GeneratorKey = string & { __brand: 'GeneratorKey' }` \u2014 a single branded string with a `__brand` field literal 'GeneratorKey'.",
+      "docLocation": "reference/api/dsl-snippet-base.md:315",
+      "evidence": "core/dsl/GeneratorKeys.ts:216-221 defines `GeneratorKey` as a UNION of five branded types (OasOperationGeneratorKey | WebhookGeneratorKey | GqlOperationGeneratorKey | ModelGeneratorKey | GeneratorOnlyKey), not a single type. The brand mechanism (core/types/Brand.ts:52,119) is `Brand<T, TBrand> = T & { [brand]: TBrand }` using a unique symbol \u2014 there is no `__brand` property and no brand literal 'GeneratorKey' anywhere (grep for `__brand` in core/ returns nothing).",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && sed -n '216,222p' core/dsl/GeneratorKeys.ts | grep -q 'OasOperationGeneratorKey' && ! grep -rq '__brand' core/",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/entry-factories.md",
+      "claim": "The page lists toEnrichmentDefaults under \"Common config fields ... These appear on all three factories\" (line 53, header at line 115) and states the returned GqlOperationEntry is of \"identical structure\" to OasOperationEntry (line 247), implying the GQL factory accepts/returns toEnrichmentDefaults.",
+      "docLocation": "reference/api/entry-factories.md:53,115,247",
+      "evidence": "core/dsl/operation/gql/toGqlOperationEntry.ts has NO toEnrichmentDefaults: ToGqlOperationConfigArgs (lines 20-34) and GqlOperationEntry (lines 36-47) omit it entirely, and the factory (lines 60-78) never wires it. Only the OAS entry (toOasOperationEntry.ts lines 43-47,61-65) and model entry (toModelEntry.ts lines 27-31,45-49) have toEnrichmentDefaults. So it is NOT common to all three; a GQL author adding toEnrichmentDefaults hits a TypeScript excess-property error. (The page's own table at line 404 right-column already concedes 'yes (model and OAS)' for the projection base, contradicting the 'all three' entry claim.)",
+      "verificationCommand": "! grep -q toEnrichmentDefaults core/dsl/operation/gql/toGqlOperationEntry.ts && grep -q 'These appear on all three factories' docs/reference/api/entry-factories.md && grep -q 'toEnrichmentDefaults' docs/reference/api/entry-factories.md",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/generate-context.md",
+      "claim": "The RegisterJsonArgs type is documented with `json: unknown`.",
+      "docLocation": "reference/api/generate-context.md:174",
+      "evidence": "Source defines `json: Record<string, unknown>` (generateTypes.ts:282), not `unknown`. A reader following the doc who passes a top-level array/string/number JSON value would pass type-check per the doc but fail against the real (narrower) signature.",
+      "verificationCommand": "grep -q 'json: Record<string, unknown>' core/context/generateTypes.ts && grep -q 'json: unknown' docs/reference/api/generate-context.md",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "GqlRegistry.createRef takes only a refName: createRef(refName: RefName): OasRef<'schema'>",
+      "docLocation": "reference/api/gql-document.md:96, :123-127",
+      "evidence": "core/gql/registry/GqlRegistry.ts:79 \u2014 createRef(refName: RefName, context: ParseContextType): OasRef<'schema'>. The context argument is required; call sites pass it (e.g. core/gql/field/toFieldSchema.ts:100 `context.registry.createRef(named.name as RefName, context)`). Following the doc's one-arg call fails to compile.",
+      "verificationCommand": "grep -q 'createRef(refName: RefName, context: ParseContextType)' core/gql/registry/GqlRegistry.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "GqlArgument exposes the argument's schema via `get type(): OasSchema | OasRef<'schema'>`.",
+      "docLocation": "reference/api/gql-document.md:205",
+      "evidence": "core/gql/argument/GqlArgument.ts:48 \u2014 the field is `readonly schema: OasSchema | OasRef<'schema'>`; there is no `type` member. `argument.type` is undefined; the real accessor is `argument.schema` (used by core/gql/operation/synthesizeArgsObject.ts).",
+      "verificationCommand": "grep -q 'readonly schema:' core/gql/argument/GqlArgument.ts && ! grep -q 'readonly type' core/gql/argument/GqlArgument.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "GqlOperation.identifier is a computed `Identifier` (e.g. createType('Query_getUser')).",
+      "docLocation": "reference/api/gql-document.md:153, :185-189",
+      "evidence": "core/gql/operation/GqlOperation.ts:76-78 \u2014 `get identifier(): string { return `${this.rootKind}_${this.fieldName}` }`. It returns a plain string, not an Identifier, and rootKind is lowercase ('query'|'mutation'|'subscription'), so the value is `query_getUser`, not `Query_getUser`.",
+      "verificationCommand": "grep -q 'get identifier(): string' core/gql/operation/GqlOperation.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "The SDL parser lives at core/parsers/graphql/toGqlDocument.ts, exposed via sub-export `@skmtc/core/parsers/graphql`.",
+      "docLocation": "reference/api/gql-document.md:263-268",
+      "evidence": "The file is at core/gql/document/toGqlDocument.ts (core/parsers/graphql/ does not exist). core/deno.json exports (lines 20-49) contain no `./parsers/graphql` entry, so importing `@skmtc/core/parsers/graphql` fails to resolve.",
+      "verificationCommand": "test -f core/gql/document/toGqlDocument.ts && ! test -d core/parsers/graphql && ! grep -q 'parsers/graphql' core/deno.json",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "For running the full pipeline against GraphQL, use `toArtifactsFromGraphQL` (sibling to `toArtifacts`).",
+      "docLocation": "reference/api/gql-document.md:270-271",
+      "evidence": "No such function is defined anywhere in core (only stale mentions in a test comment and CLAUDE.md). The GraphQL pipeline runs through the unified toArtifacts, whose `document` param is a `SkmtcDocumentInput` discriminated union accepting `{ type: 'gql', value }` (core/run/toArtifacts.ts:38-45).",
+      "verificationCommand": "! grep -rEq '(const|function) toArtifactsFromGraphQL' core && grep -q 'document: SkmtcDocumentInput' core/run/toArtifacts.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "GqlRegistry resolves refs via a private OasDocument mirror whose components.schemas is the same Record instance as registry.schemas.",
+      "docLocation": "reference/api/gql-document.md:107-120",
+      "evidence": "core/gql/registry/GqlRegistry.ts:27-28 explicitly states the opposite: refs resolve through the parent GqlDocument via SkmtcParsedDocument's GQL variant \u2014 'no fake OasDocument mirror needed'. createRef (line 79-84) constructs an OasRef pointing at the context's parsedDocument, not an internal OasDocument mirror. (The advice 'do not construct OasRef directly, use createRef' remains valid, but the mechanism explanation is wrong.)",
+      "verificationCommand": "grep -q 'no fake' core/gql/registry/GqlRegistry.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "GqlRegistryFields.schemas is required and the constructor is `constructor(fields: GqlRegistryFields)`.",
+      "docLocation": "reference/api/gql-document.md:94, :100-102",
+      "evidence": "core/gql/registry/GqlRegistry.ts:15 declares `schemas?:` (optional) and line 37 gives the constructor a default `constructor(fields: GqlRegistryFields = {})`, so both fields and schemas may be omitted.",
+      "verificationCommand": "grep -q 'schemas?:' core/gql/registry/GqlRegistry.ts && grep -q 'GqlRegistryFields = {}' core/gql/registry/GqlRegistry.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "GqlOperationFields.returnTypeString is required (`returnTypeString: string`).",
+      "docLocation": "reference/api/gql-document.md:160",
+      "evidence": "core/gql/operation/GqlOperation.ts:28 declares `returnTypeString?: string` (optional, falls back to '' at line 65).",
+      "verificationCommand": "grep -q 'returnTypeString?:' core/gql/operation/GqlOperation.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "claim": "GqlRootTypes fields are `string` (query?: string, mutation?: string, subscription?: string).",
+      "docLocation": "reference/api/gql-document.md:221-225",
+      "evidence": "core/gql/rootType/GqlRootTypes.ts:12-14 types each field as `RefName` (a branded string), not plain `string`.",
+      "verificationCommand": "grep -q 'query?: RefName' core/gql/rootType/GqlRootTypes.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "OasComponents has a `pathItems: Record<string, OasPathItem> | undefined` property.",
+      "docLocation": "reference/api/oas-document-model.md:424",
+      "evidence": "core/oas/components/Components.ts has no `pathItems` field or getter. The source class exposes `links` (getter at Components.ts:348), which the doc's class listing omits entirely. A generator accessing `document.components.pathItems` gets undefined.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"pathItems\" docs/reference/api/oas-document-model.md && ! grep -q \"pathItems\" core/oas/components/Components.ts"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "OasComponents dictionaries are typed `Record<string, OasSchema>` / `Record<string, OasResponse>` etc. \u2014 values are 'always resolved at parse time \u2014 they're never refs themselves.'",
+      "docLocation": "reference/api/oas-document-model.md:414-434",
+      "evidence": "Every component dictionary in source is a ref-union, e.g. Components.ts:31 `schemas?: Record<RefName, OasSchema | OasRef<'schema'>>` (same for responses/parameters/examples/requestBodies/headers/links). The class's own JSDoc example (Components.ts:189) calls `schema.isRef()` on a component schema. Generator code following the doc would omit isRef() handling the source type says is required.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"schemas: Record<string, OasSchema> | undefined\" docs/reference/api/oas-document-model.md && grep -q \"schemas?: Record<RefName, OasSchema | OasRef<'schema'>>\" core/oas/components/Components.ts"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "OasParameter has an `example: unknown` property.",
+      "docLocation": "reference/api/oas-document-model.md:334",
+      "evidence": "core/oas/parameter/Parameter.ts has no singular `example` field; it has `examples?: Record<string, OasExample | OasRef<'example'>>` (Parameter.ts:210). Reading `parameter.example` yields undefined.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"example: unknown\" docs/reference/api/oas-document-model.md && ! grep -qE \"^  example\\b\" core/oas/parameter/Parameter.ts && grep -q \"examples?: Record\" core/oas/parameter/Parameter.ts"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "The `toRequestBody` mapper receives `{ schema, requestBody, mediaType }`.",
+      "docLocation": "reference/api/oas-document-model.md:183",
+      "evidence": "The mapper arg type `ToRequestBodyMapArgs` (Operation.ts:63-66) is only `{ schema, requestBody }` \u2014 no `mediaType`. A caller destructuring `mediaType` in the mapper gets undefined.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"schema, requestBody, mediaType\" docs/reference/api/oas-document-model.md && ! grep -A4 \"ToRequestBodyMapArgs = {\" core/oas/operation/Operation.ts | grep -q mediaType"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "The `toRequestBody` mapper argument type is `ToRequestBodyArgs`.",
+      "docLocation": "reference/api/oas-document-model.md:125",
+      "evidence": "Source names the type `ToRequestBodyMapArgs` (Operation.ts:63); `ToRequestBodyArgs` does not exist.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"ToRequestBodyArgs)\" docs/reference/api/oas-document-model.md && ! grep -q \"ToRequestBodyArgs\" core/oas/operation/Operation.ts"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "OasResponse.description is typed `string` and 'required by OAS spec'.",
+      "docLocation": "reference/api/oas-document-model.md:307",
+      "evidence": "core/oas/response/Response.ts:212 declares `description: string | undefined` and the constructor field is optional (ResponseFields.description?, Response.ts:15). Code reading `response.description` may get undefined despite the doc.",
+      "severity": "minor",
+      "verificationCommand": "grep -qE \"description: string +// required by OAS spec\" docs/reference/api/oas-document-model.md && grep -q \"description: string | undefined\" core/oas/response/Response.ts"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "The `OasComponentType` union is OasSchema | OasResponse | OasParameter | OasExample | OasRequestBody | OasHeader | OasSecurityScheme.",
+      "docLocation": "reference/api/oas-document-model.md:515-522",
+      "evidence": "Source `OasComponentType` (core/oas/ref/Ref.ts:392-400) includes an eighth member `OasLink`, which the doc's listing omits.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"OasLink\" core/oas/ref/Ref.ts && ! sed -n '515,523p' docs/reference/api/oas-document-model.md | grep -q OasLink"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "OasParameter.toSchema() takes no args and returns `OasSchema | OasRef<'schema'> | undefined`.",
+      "docLocation": "reference/api/oas-document-model.md:340",
+      "evidence": "Source signature is `toSchema(mediaType: string = 'application/json'): OasSchema | OasRef<'schema'>` (Parameter.ts:278) \u2014 it accepts a mediaType and never returns undefined; it throws `Schema not found for media type ...` when absent.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"toSchema(): OasSchema | OasRef<'schema'> | undefined\" docs/reference/api/oas-document-model.md && grep -q \"toSchema(mediaType: string = 'application/json'): OasSchema | OasRef<'schema'>\" core/oas/parameter/Parameter.ts"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "claim": "OasMediaType.encoding is typed `Record<string, OasEncoding>`.",
+      "docLocation": "reference/api/oas-document-model.md:382",
+      "evidence": "Source declares `encoding?: Record<string, unknown>` (MediaType.ts:114); there is no `OasEncoding` type anywhere in core.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"encoding: Record<string, OasEncoding>\" docs/reference/api/oas-document-model.md && grep -q \"encoding?: Record<string, unknown>\" core/oas/mediaType/MediaType.ts"
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "claim": "The OasRef constructor's second parameter is `document: SkmtcParsedDocument` (stated in the class signature and the Constructor section, which says the document is held by reference).",
+      "docLocation": "reference/api/oas-ref.md:18 (also 63-68, 71-74)",
+      "evidence": "Source constructor is `constructor(fields: RefFields<T>, context: ParseContextType)` and derives the document internally via `this.#document = context.parsedDocument`. The second argument is a ParseContext, not a SkmtcParsedDocument \u2014 `new OasRef({...}, document)` (as shown in the doc's examples) would not type-check.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'constructor(fields: RefFields<T>, context: ParseContextType)' core/oas/ref/Ref.ts && ! grep -q 'context.parsedDocument  // \u2190 reference' /dev/null; grep -q 'constructor(fields: RefFields<T>, context: ParseContextType)' core/oas/ref/Ref.ts"
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "claim": "Forward-reference handling: `toRefV31` at `core/oas/ref/toRefV31.ts:26-34` calls `return new OasRef({ refType, $ref }, context.parsedDocument)`.",
+      "docLocation": "reference/api/oas-ref.md:221-228",
+      "evidence": "No file exists at `core/oas/ref/toRefV31.ts`; the real file is `core/parse/v3-1/ref/toRefV31.ts` (and v3-0). Its actual call is `new OasRef({ refType, $ref, nullable }, context)` wrapped in `context.withStackTrail(...)` \u2014 it passes `context`, not `context.parsedDocument`, and includes a `nullable` field.",
+      "severity": "major",
+      "verificationCommand": "test ! -f core/oas/ref/toRefV31.ts && grep -q 'new OasRef({ refType, \\$ref, nullable }, context)' core/parse/v3-1/ref/toRefV31.ts"
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "claim": "The type parameter T (the ref category) is 'One of' exactly seven values: schema, requestBody, parameter, response, example, header, securityScheme.",
+      "docLocation": "reference/api/oas-ref.md:39-47",
+      "evidence": "`OasRefData['refType']` includes an eighth value `'link'` (OasLinkRefData in ref-types.ts:195-201), which OasRef.resolveOnce handles (refTypeToPluralPath \u2192 'links'). The enumeration presented as complete is missing 'link'.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"refType: 'link'\" core/oas/ref/ref-types.ts"
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "claim": "The `OasComponentType` union (Related types) is: OasSchema | OasResponse | OasParameter | OasExample | OasRequestBody | OasHeader | OasSecurityScheme.",
+      "docLocation": "reference/api/oas-ref.md:245-252",
+      "evidence": "Source `OasComponentType` includes a trailing `| OasLink` member (Ref.ts:400) which the doc's reproduction omits.",
+      "severity": "minor",
+      "verificationCommand": "grep -q '| OasLink' core/oas/ref/Ref.ts"
+    },
+    {
+      "page": "reference/api/oas-schema-variants.md",
+      "claim": "OasUnion exposes its member schemas via a field named `variants` (`variants: (OasSchema | OasRef<'schema'>)[]`), and generators read `schema.variants.length`.",
+      "docLocation": "reference/api/oas-schema-variants.md:50,161,287",
+      "evidence": "core/oas/union/Union.ts:181 declares the field as `members: (OasSchema | OasRef<'schema'>)[]` (set from `fields.members` at line 201). There is no `variants` field on OasUnion. A generator accessing `schema.variants` gets `undefined` and `schema.variants.length` throws.",
+      "verificationCommand": "grep -q 'members: (OasSchema | OasRef' core/oas/union/Union.ts && ! grep -q 'variants' core/oas/union/Union.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/oas-schema-variants.md",
+      "claim": "OasUnknown carries the original OAS schema object in a `value: OpenAPIV3.SchemaObject` field for inspection.",
+      "docLocation": "reference/api/oas-schema-variants.md:226,233",
+      "evidence": "core/oas/unknown/Unknown.ts:24-56 shows OasUnknown's only fields are title, description, extensionFields, example, nullable (plus stackTrail from OasBase). There is no `value` field and the original schema object is not retained. `schema.value` would be `undefined`.",
+      "verificationCommand": "! grep -qE '^\\s*value' core/oas/unknown/Unknown.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/api/oas-schema-variants.md",
+      "claim": "The eight schema variant classes have no shared parent \u2014 'Each is a top-level class (no shared parent)', 'not a class hierarchy', narrowing works 'via duck typing, not via inheritance'.",
+      "docLocation": "reference/api/oas-schema-variants.md:6,32-34",
+      "evidence": "Every variant extends OasBase (core/oas/object/Object.ts:154, array/Array.ts:45, union/Union.ts:148, string/String.ts:45, integer/Integer.ts:48, number/Number.ts:49, boolean/Boolean.ts:36, unknown/Unknown.ts:24). core/types/OasBase.ts:30 defines the shared parent (it adds only the `stackTrail` slot, no schema methods, but it is nonetheless a shared parent). The literal 'no shared parent' / 'not a class hierarchy' claim is contradicted by source.",
+      "verificationCommand": "grep -q 'extends OasBase' core/oas/object/Object.ts && grep -q 'extends OasBase' core/oas/union/Union.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/oas-schema-variants.md",
+      "claim": "OasObject.addProperty is a 'builder; returns mutated this' \u2014 it mutates the object in place and returns the same instance.",
+      "docLocation": "reference/api/oas-schema-variants.md:127",
+      "evidence": "core/oas/object/Object.ts:341-358: addProperty returns `new OasObject({...})` with the merged properties/required \u2014 it is immutable and returns a fresh instance, not a mutated `this`. Code that calls `obj.addProperty(...)` and keeps using `obj` (discarding the return) will not see the new property.",
+      "verificationCommand": "grep -q 'return new OasObject' core/oas/object/Object.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/api/oas-schema-variants.md",
+      "claim": "The OasComponentType union has seven members: OasSchema, OasResponse, OasParameter, OasExample, OasRequestBody, OasHeader, OasSecurityScheme.",
+      "docLocation": "reference/api/oas-schema-variants.md:402-410",
+      "evidence": "core/oas/ref/Ref.ts:392-400 defines OasComponentType with eight members \u2014 the seven listed plus `OasLink`. The doc's Related-types block omits OasLink.",
+      "verificationCommand": "grep -A9 'export type OasComponentType' core/oas/ref/Ref.ts | grep -q OasLink",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/oas-schema-variants.md",
+      "claim": "OasString.enums is typed `(string | number | boolean | null)[]`.",
+      "docLocation": "reference/api/oas-schema-variants.md:176",
+      "evidence": "core/oas/string/String.ts:70 types enums as `Nullable extends true ? (string | null)[] | undefined : string[] | undefined` \u2014 string-only, never number or boolean.",
+      "verificationCommand": "grep -q 'enums: Nullable extends true ? (string | null)' core/oas/string/String.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/oas-schema-variants.md",
+      "claim": "`OasSchemaOrRef` and `OasSchemaOrRefOrVoid` are named types (shown in the Related-types block alongside real exported types OasSchema and OasComponentType).",
+      "docLocation": "reference/api/oas-schema-variants.md:396,399",
+      "evidence": "Neither `OasSchemaOrRef` nor `OasSchemaOrRefOrVoid` is defined or exported anywhere in core/. The underlying inline unions (`OasSchema | OasRef<'schema'>` etc.) are used, but not under these alias names \u2014 a reader importing them would fail.",
+      "verificationCommand": "! grep -rq 'OasSchemaOrRef' core/",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/api/parse-context.md",
+      "claim": "The published ParseIssue type declares `level: 'error' | 'warning'`, asserting only two severity levels.",
+      "docLocation": "reference/api/parse-context.md:92",
+      "evidence": "core/context/ParseIssue.ts defines a THIRD severity `debug`: ParseIssue has `oas`+`gql` `level: 'debug'` variants (lines 99-105, 121-127), and the module header (lines 12-17) explicitly documents 'Three severities: error, warning, and debug'. The class's logIssueNoKey (ParseContext.ts:496-508) also handles a `debug` case. The doc omits debug entirely from its ParseIssue enumeration.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"level: 'error' | 'warning'\" docs/reference/api/parse-context.md && grep -q \"level: 'debug'\" core/context/ParseIssue.ts"
+    },
+    {
+      "page": "reference/api/parse-context.md",
+      "claim": "LogIssueAtArgs is enumerated with four variants (oas error/warning, gql error/warning) \u2014 no debug variant.",
+      "docLocation": "reference/api/parse-context.md:212",
+      "evidence": "core/context/parseTypes.ts LogIssueAtArgs (lines 160-204) has SIX variants, including `oas`/`gql` `level: 'debug'` (lines 176-182, 198-204). The doc block at lines 212-217 lists only error/warning.",
+      "severity": "minor",
+      "verificationCommand": "! sed -n '211,217p' docs/reference/api/parse-context.md | grep -q debug && grep -q \"level: 'debug'\" core/context/parseTypes.ts"
+    },
+    {
+      "page": "reference/api/parse-context.md",
+      "claim": "GqlParseOptions has shape `{ includeIntrospection?: boolean; /* ... */ }`.",
+      "docLocation": "reference/api/parse-context.md:442",
+      "evidence": "core/context/parseTypes.ts:210-213 defines `GqlParseOptions = { interfaceUnionSuffix?: string; synthesizeInterfaceUnions?: boolean }`. There is no `includeIntrospection` key anywhere in core; a reader passing `options.gql.includeIntrospection` would find it silently ignored.",
+      "severity": "major",
+      "verificationCommand": "grep -q includeIntrospection docs/reference/api/parse-context.md && ! grep -rq includeIntrospection core && grep -q interfaceUnionSuffix core/context/parseTypes.ts"
+    },
+    {
+      "page": "reference/api/parse-context.md",
+      "claim": "The registerRef call site and toRefV31 example live at `core/oas/ref/toRefV31.ts` (line 26).",
+      "docLocation": "reference/api/parse-context.md:189",
+      "evidence": "No such file exists. The real files are core/parse/v3-1/ref/toRefV31.ts and core/parse/v3-0/ref/toRefV31.ts, and the `context.registerRef(stackTrail.clone(), $ref)` call is at line 33, not 26. core/oas/ref/ contains only Ref.ts / ref-types.ts. The same wrong path is repeated at doc line 351.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'core/oas/ref/toRefV31.ts' docs/reference/api/parse-context.md && ! test -f core/oas/ref/toRefV31.ts && test -f core/parse/v3-1/ref/toRefV31.ts"
+    },
+    {
+      "page": "reference/api/render-context.md",
+      "claim": "The `collate` return type `FilesRenderResult` is documented as `{ artifacts: Record<string,string>; files: Record<string, FileMetadata> }`, referencing a type named `FileMetadata`.",
+      "docLocation": "reference/api/render-context.md:133-137",
+      "evidence": "core/context/generateTypes.ts:148-153 defines `FilesRenderResult.files` as `Record<string, ManifestEntry>` (ManifestEntry from core/types/Manifest.ts:139 = `{ lines; characters; destinationPath }`). No type named `FileMetadata` exists anywhere in core/ (grep returns nothing). The metadata shape the doc lists is correct in content, but the type name is fabricated.",
+      "severity": "minor",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && grep -q 'files: Record<string, ManifestEntry>' core/context/generateTypes.ts && ! grep -rq 'FileMetadata' core/"
+    },
+    {
+      "page": "reference/api/stack-trail.md",
+      "claim": "toStackRef's recognized buckets are described as 'exactly those in Components.componentsKeys' and then enumerated as schemas, parameters, responses, requestBodies, headers, examples, securitySchemes (7 items).",
+      "docLocation": "reference/api/stack-trail.md:199-201",
+      "evidence": "core/oas/components/Components.ts:15-24 defines componentsKeys with 8 entries including 'links'. A trail ['components','links','X'] therefore yields '#/components/links/X' from toStackRef (StackTrail.ts:233 uses componentsKeys.includes), contradicting the doc's 'exactly' enumeration which omits links.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"'links'\" core/oas/components/Components.ts && ! grep -qi 'links' docs/reference/api/stack-trail.md"
+    },
+    {
+      "page": "reference/api/stack-trail.md",
+      "claim": "The clone snapshot call site and example cite the source file as core/oas/ref/toRefV31.ts:26.",
+      "docLocation": "reference/api/stack-trail.md:150,247",
+      "evidence": "No file exists at core/oas/ref/toRefV31.ts. The actual registerRef(stackTrail.clone(), $ref) call lives at core/parse/v3-1/ref/toRefV31.ts:33 (and core/parse/v3-0/ref/toRefV31.ts:33). Both the directory and line number are wrong.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'core/oas/ref/toRefV31.ts' docs/reference/api/stack-trail.md && ! test -f core/oas/ref/toRefV31.ts && test -f core/parse/v3-1/ref/toRefV31.ts"
+    },
+    {
+      "page": "reference/api/stack-trail.md",
+      "claim": "removeItem handles only 'paths' and 'components' first frames; 'Anything else \u2192 throws Unexpected stack trail', and the gotcha table repeats that any trail not starting with paths or components throws.",
+      "docLocation": "reference/api/stack-trail.md:292,306",
+      "evidence": "core/oas/document/Document.ts:222-240 has a case 'webhooks' branch that matches on (name, method) and returns the removed webhook without throwing. A trail starting with 'webhooks' is handled, not thrown, contradicting 'Anything else \u2192 throws'.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"case 'webhooks'\" core/oas/document/Document.ts && ! grep -qi webhook docs/reference/api/stack-trail.md"
+    },
+    {
+      "page": "reference/api/stack-trail.md",
+      "claim": "For a ['components','<bucket>','<name>'] trail, removeItem 'removes the named component from the bucket'.",
+      "docLocation": "reference/api/stack-trail.md:291",
+      "evidence": "core/oas/document/Document.ts:242-247 ignores the bucket frame (second) entirely and always calls components.removeSchema(third). So ['components','responses','Foo'] attempts to remove a *schema* named Foo, not a response \u2014 the operation is schema-only, not bucket-parameterized as the doc states.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'removeSchema(third' core/oas/document/Document.ts && grep -q 'removes the named component from the bucket' docs/reference/api/stack-trail.md"
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "claim": "toArtifacts is `export async function toArtifacts<E = undefined>(args): Promise<{artifacts, manifest}>` and the page has a whole \"Why async if the phases are synchronous?\" section, `await toArtifacts(...)` examples, and a \"Can I run multiple toArtifacts invocations in parallel?\" section.",
+      "docLocation": "docs/reference/api/to-artifacts.md:20-25,201-320",
+      "evidence": "Source: `export const toArtifacts = ({...}: TransformArgs): { artifacts; manifest; sidecars?; generationMap?; inspection? } => {...}` \u2014 a synchronous arrow function returning a plain object, not async, not `Promise`. No `await` inside; `context.toArtifacts(...)` is called synchronously.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'async function toArtifacts' docs/reference/api/to-artifacts.md && grep -q 'export const toArtifacts =' core/run/toArtifacts.ts"
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "claim": "ManifestContent is `{ files: Record<string, ManifestFileEntry>; durationMs: number; diagnostics: DiagnosticItem[] }`, and examples read `result.manifest.durationMs`.",
+      "docLocation": "docs/reference/api/to-artifacts.md:160-167,174,225,333-337",
+      "evidence": "Source ManifestContent (core/types/Manifest.ts:161-178) has fields `deploymentId, traceId, spanId, region?, files, previews, results, parseIssues, startAt, endAt`. There is no `durationMs` field (elapsed is `endAt - startAt`) and no `diagnostics` field (parse issues live in `parseIssues`). `DiagnosticItem` does not exist anywhere in core.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'DiagnosticItem' docs/reference/api/to-artifacts.md && ! grep -rq 'DiagnosticItem' core/ && grep -q 'durationMs' docs/reference/api/to-artifacts.md && ! grep -q 'durationMs' core/types/Manifest.ts"
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "claim": "`GeneratorsMapContainer<E> = { generators: Record<string, GeneratorConfigInput<E>> }`, and factory examples return `() => ({ generators: { zod: ZodEntry } })`.",
+      "docLocation": "docs/reference/api/to-artifacts.md:93-98,258,329-331",
+      "evidence": "Source (core/types/GeneratorType.ts:70-73): `export type GeneratorsMapContainer<EnrichmentType = undefined> = Record<string, GeneratorConfig<EnrichmentType>>` \u2014 a bare record with no `generators` wrapper key, and the value type is `GeneratorConfig`, not `GeneratorConfigInput`. A factory returning `{ generators: {...} }` does not match the type.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'generators: Record<string' docs/reference/api/to-artifacts.md && grep -q 'GeneratorsMapContainer<EnrichmentType = undefined> = Record' core/types/GeneratorType.ts"
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "claim": "settings carries `paths` (per-operation path overrides) and `exclude` (components to exclude).",
+      "docLocation": "docs/reference/api/to-artifacts.md:81-84",
+      "evidence": "ClientSettings (core/types/Settings.ts:227-236) has: basePath, schemaSource, packages, enrichments, include, skip, anchors, inputDirs. There is no `paths` field and no `exclude` field; the filter opposite of `skip` is `include`.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'components to exclude' docs/reference/api/to-artifacts.md && ! grep -qE '(exclude|paths): v\\.' core/types/Settings.ts"
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "claim": "`toArtifacts<E = undefined>` and `TransformArgs<E>` are generic in the enrichment type.",
+      "docLocation": "docs/reference/api/to-artifacts.md:20-27",
+      "evidence": "Source: `type TransformArgs = {...}` is not generic and `toArtifacts` is not generic. The enrichment generic lives only on the field: `toGeneratorConfigMap: <EnrichmentType = undefined>() => GeneratorsMapContainer<EnrichmentType>` (core/run/toArtifacts.ts:30,49,136).",
+      "severity": "major",
+      "verificationCommand": "grep -q 'toArtifacts<E = undefined>' docs/reference/api/to-artifacts.md && grep -q '^type TransformArgs = {' core/run/toArtifacts.ts"
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "claim": "Manifest per-artifact metadata type is `ManifestFileEntry`.",
+      "docLocation": "docs/reference/api/to-artifacts.md:161,334",
+      "evidence": "Source names the type `ManifestEntry` (core/types/Manifest.ts:139); there is no `ManifestFileEntry` in core.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'ManifestFileEntry' docs/reference/api/to-artifacts.md && ! grep -rq 'ManifestFileEntry' core/"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "The complete output shape is {command, workspace, projects, anomalies, verifyWith}.",
+      "docLocation": "reference/cli/agent-context.md:143-149",
+      "evidence": "The actual AgentContext type has keys {cliVersion, skmtcRootPath, globalStateDir, jsrUrl, projects, commands}. None of 'command', 'workspace', 'anomalies', or 'verifyWith' exist in source (cli/lib/agent-context-headless.ts:45-55); grep finds them nowhere in the command or headless files.",
+      "verificationCommand": "grep -q 'skmtcRootPath' cli/lib/agent-context-headless.ts && ! grep -rqE 'anomalies|verifyWith|\"command\"' cli/lib/agent-context-headless.ts cli/commands/agent-context.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "A top-level `workspace` key holds {root, denoVersion, cliVersion, corePin}.",
+      "docLocation": "reference/cli/agent-context.md:42-60",
+      "evidence": "There is no `workspace` key. The root path is top-level as `skmtcRootPath`; `cliVersion` is top-level; `denoVersion` and `corePin` do not exist anywhere in source (AgentContext at cli/lib/agent-context-headless.ts:45-55).",
+      "verificationCommand": "! grep -rqE 'denoVersion|corePin' cli/lib/agent-context-headless.ts cli/commands/agent-context.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "Each project has a `schema` object with `url` and `lastFetched`.",
+      "docLocation": "reference/cli/agent-context.md:70-74",
+      "evidence": "ProjectSnapshot (cli/lib/agent-context-headless.ts:33-43) is {name, basePath, schemaSource, generators}. There is no `schema` object; the schema source is a flat string field `schemaSource` (string|null) read from client.json#source. No `lastFetched` exists.",
+      "verificationCommand": "grep -q 'schemaSource' cli/lib/agent-context-headless.ts && ! grep -rq 'lastFetched' cli/lib/agent-context-headless.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "`generators` is an array of objects with fields name/source/version/path.",
+      "docLocation": "reference/cli/agent-context.md:75-86",
+      "evidence": "generators is an object {remote: string[], local: string[]} of import ids, not an array of descriptor objects (cli/lib/agent-context-headless.ts:37-42, readGenerators lines 108-140). There are no per-generator `source`, `version`, or `path` fields.",
+      "verificationCommand": "grep -q 'remote: string\\[\\]' cli/lib/agent-context-headless.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "Each project includes a `bundle` object {present, path, mtime}.",
+      "docLocation": "reference/cli/agent-context.md:87-91",
+      "evidence": "ProjectSnapshot has no `bundle` field (cli/lib/agent-context-headless.ts:33-43); snapshotProject never inspects bundle.js (lines 92-106).",
+      "verificationCommand": "! grep -rq 'bundle' cli/lib/agent-context-headless.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "Each project includes a `lastGenerate` object {timestamp, durationMs, artifactCount, diagnostics}.",
+      "docLocation": "reference/cli/agent-context.md:92-100",
+      "evidence": "No `lastGenerate`, `artifactCount`, `durationMs`, or `diagnostics` exist in ProjectSnapshot or anywhere in the headless module (cli/lib/agent-context-headless.ts).",
+      "verificationCommand": "! grep -rqE 'lastGenerate|artifactCount|durationMs' cli/lib/agent-context-headless.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "Each project includes a `settings` object {basePath, enrichmentsConfigured, skipCount, excludeCount}.",
+      "docLocation": "reference/cli/agent-context.md:101-106",
+      "evidence": "There is no per-project `settings` object; `basePath` is a flat top-level project field, and enrichmentsConfigured/skipCount/excludeCount do not exist (cli/lib/agent-context-headless.ts:33-43, readClientJson 142-167 reads only basePath and source).",
+      "verificationCommand": "! grep -rqE 'enrichmentsConfigured|skipCount|excludeCount' cli/lib/agent-context-headless.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "Output includes an `anomalies` array (e.g. stale-bundle, missing-operationId), consumed via .anomalies[].kind.",
+      "docLocation": "reference/cli/agent-context.md:112-136,177",
+      "evidence": "No anomaly detection exists; `anomalies` appears nowhere in source. runAgentContext returns a static snapshot with no analysis (cli/lib/agent-context-headless.ts:61-75). The jq examples selecting .anomalies[].kind operate on a nonexistent field.",
+      "verificationCommand": "! grep -rq 'anomal' cli/lib/agent-context-headless.ts cli/commands/agent-context.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "Exit code 1 means 'Internal error gathering context'; and running outside a workspace prints 'Error: not in a SKMTC workspace (no deno.json found)'.",
+      "docLocation": "reference/cli/agent-context.md:213-230",
+      "evidence": "renderAgentContext always calls Deno.exit(0) (cli/commands/agent-context.ts:21-25) and never throws a workspace error. toRootPath (cli/lib/to-root-path.ts:7-19) never throws \u2014 it falls back to cwd/.skmtc; collectProjects returns [] when the path is absent (headless lines 77-90). There is no 'not in a SKMTC workspace' message.",
+      "verificationCommand": "grep -q 'Deno.exit(0)' cli/commands/agent-context.ts && ! grep -rq 'not in a SKMTC workspace' cli/",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "claim": "The Synopsis and Options say the command only defines `--json`.",
+      "docLocation": "reference/cli/agent-context.md:17-34",
+      "evidence": "This part is correct \u2014 the Cliffy command registers only .option('--json', ...) (cli/mod.ts:430-436). Flagging as verified-correct; the surrounding descriptions of what --json produces (JSON shape) are wrong per the other findings.",
+      "verificationCommand": "grep -q \"agentContextCommand = new Command\" cli/mod.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/bundle.md",
+      "claim": "The \"Verify success\" example pipes to `jq '.kind'` and expects the output `\"bundled\"`.",
+      "docLocation": "reference/cli/bundle.md:131-133",
+      "evidence": "The JSON result object has no `kind` field. `BundleHeadlessResult` in cli/lib/bundle-headless.ts:27-31 is `{ type: 'bundled'; projectName; bundlePath }`. printBundleResult (cli/commands/bundle.tsx:78) even documents the correct filter as `jq -e '.type == \"bundled\"'`. Running the doc's example returns `null`, not `\"bundled\"`. The doc's own JSON example (line 103) correctly uses `type`, so line 131 is internally inconsistent.",
+      "verificationCommand": "grep -q \"jq '.kind'\" docs/reference/cli/bundle.md && grep -q \"type: 'bundled'\" cli/lib/bundle-headless.ts",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/bundle.md",
+      "claim": "The successful-bundle JSON shows `\"bundlePath\": \".skmtc/my-api/bundle.js\"` \u2014 a project-relative path.",
+      "docLocation": "reference/cli/bundle.md:106",
+      "evidence": "`bundleHeadless` returns the value from `createBundle`, which returns `toBundlePath(project.toPath())`. `toBundlePath` (cli/lib/to-bundle-path.ts:12-14) is `file://${join(projectPath, 'bundle.js')}`, and `project.toPath()` -> `toProjectPath` -> `resolve(toRootPath(), name)` (cli/lib/to-project-path.ts:7, cli/lib/to-root-path.ts:7-18) is an absolute path. The real value is an absolute `file://` URL like `file:///Users/.../.skmtc/my-api/bundle.js`, not a bare relative path. An agent reading `.bundlePath` as a filesystem path gets a `file://` URL.",
+      "verificationCommand": "grep -q '\"bundlePath\": \".skmtc/my-api/bundle.js\"' docs/reference/cli/bundle.md && grep -q 'file://' cli/lib/to-bundle-path.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/bundle.md",
+      "claim": "The intro states the CLI runs `deno bundle worker.ts -o bundle.js`.",
+      "docLocation": "reference/cli/bundle.md:6",
+      "evidence": "The actual subprocess args (cli/lib/create-bundle.ts:32) are `['bundle', '-o', fileName, 'worker.ts']`, i.e. `deno bundle -o bundle.js worker.ts` \u2014 flag before the entry file. The doc's Behavior section (line 66) quotes the correct order, so the intro is internally inconsistent. Functionally equivalent, so cosmetic.",
+      "verificationCommand": "grep -q 'deno bundle worker.ts -o bundle.js' docs/reference/cli/bundle.md && grep -q \"'bundle', '-o', fileName, 'worker.ts'\" cli/lib/create-bundle.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/clone.md",
+      "claim": "The rebundle JSON reports bundle.bundlePath as the relative path \".skmtc/my-api/bundle.js\" (shown in both the post-clone rebundle example and the JSON-output example).",
+      "docLocation": "docs/reference/cli/clone.md:137 and :159",
+      "evidence": "bundle-headless.ts sets bundlePath = createBundle(...) \u2192 create-bundle.ts:26 returns toBundlePath(project.toPath()), and to-bundle-path.ts:12-14 returns `file://${join(projectPath,'bundle.js')}` \u2014 an absolute file:// URL (e.g. file:///Users/.../.skmtc/my-api/bundle.js), not the relative string the doc shows. printCloneResult (clone.tsx:129) passes this value straight through to JSON and text output.",
+      "verificationCommand": "grep -q 'file://' cli/lib/to-bundle-path.ts && grep -q '\"bundlePath\": \".skmtc/my-api/bundle.js\"' docs/reference/cli/clone.md",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/clone.md",
+      "claim": "For transitive peers @skmtc/core, @std/path, valibot, tiny-invariant, \"the CLI does not overwrite them.\"",
+      "docLocation": "docs/reference/cli/clone.md:120",
+      "evidence": "generator.ts:232-241 loops over every import specifier found in the cloned source (extract-import-paths captures bare specifiers like @skmtc/core) and, whenever the package's own deno.json pins that specifier, calls denoJson.addImport(importModule, source). root-deno-json.ts:105-110 addImport does `imports: { ...this.contents.imports, [key]: value }`, which overwrites an existing key. There is no exclusion for @skmtc/core/@std/valibot/tiny-invariant, so a cloned generator that imports @skmtc/core (all do) and pins it in its package deno.json will overwrite the project's existing core pin.",
+      "verificationCommand": "grep -q 'does not overwrite them' docs/reference/cli/clone.md && grep -q '\\[key\\]: value' cli/lib/root-deno-json.ts && grep -q 'denoJson.addImport(importModule, source)' cli/lib/generator.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/create.md",
+      "claim": "\"Post-create rebundle\" \u2014 \"After scaffolding, the CLI rebuilds the project's bundle.js so the new generator is reachable by the next generate invocation.\" (also asserted in the exit-code table row \"Success \u2014 generator scaffolded and project rebundled\" and the \"Bundle compile failure\" failure mode.)",
+      "docLocation": "reference/cli/create.md:143-147, 202, 224-229",
+      "evidence": "The create flow renders App -> AddGeneratorView -> AddGeneratorTask, which calls project.addGenerator({moduleName,type}) and then dispatches to the 'project' view. project.addGenerator (cli/lib/project.ts:310-331) calls generator.add(), which writes files and updates deno.json (generator.ts:100-119) and never bundles. There is no 'bundle' reference anywhere in cli/components/AddGeneratorView.tsx or cli/commands/create.tsx. No bundle.js is rebuilt by create; the 'rebundled'/'bundle compile failure' behavior described does not occur.",
+      "verificationCommand": "! grep -riq 'bundle' cli/components/AddGeneratorView.tsx cli/commands/create.tsx && grep -q 'addGenerator' cli/components/AddGeneratorView.tsx",
+      "severity": "error"
+    },
+    {
+      "page": "reference/cli/create.md",
+      "claim": "The scaffolded base.ts uses factory `toModelProjectionBase` (model) / `toOasOperationProjectionBase` (operation), presented as the projection-base factory wired into the scaffold (table + file-tree comments).",
+      "docLocation": "reference/cli/create.md:59-60, 86, 99",
+      "evidence": "The scaffold's base.ts emits `toTsModelProjectionBase` (cli/lib/model-generator.ts:46,50) and `toTsOasOperationProjectionBase` (cli/lib/operation-generator.ts:49,53), both imported from '@skmtc/lang-typescript' \u2014 not the core-named `toModelProjectionBase`/`toOasOperationProjectionBase`. A reader grepping the generated scaffold for the documented factory names would not find them.",
+      "verificationCommand": "grep -q 'toTsModelProjectionBase({' cli/lib/model-generator.ts && grep -q 'toTsOasOperationProjectionBase({' cli/lib/operation-generator.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/create.md",
+      "claim": "Failure mode \"Generator name collides\" produces `Error: generator 'my-zod-schema' already exists in project 'my-api'` when the directory already exists.",
+      "docLocation": "reference/cli/create.md:207-214",
+      "evidence": "createFiles calls `Deno.mkdir(generatorPath, { recursive: true })` (cli/lib/generator.ts:122), which succeeds silently on an existing directory \u2014 there is no collision check and no such error is raised. The string 'already exists in project' does not exist anywhere in cli/. addGenerator swallows any error and dispatches only the generic message `Failed to add generator \"<name>\"` (AddGeneratorView.tsx:84). The documented collision error is fabricated.",
+      "verificationCommand": "grep -q 'recursive: true' cli/lib/generator.ts && ! grep -rq 'already exists in project' cli/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/create.md",
+      "claim": "Failure mode \"Project doesn't exist\" emits `Error: project 'my-api' not found`.",
+      "docLocation": "reference/cli/create.md:218-220",
+      "evidence": "The real path throws via tiny-invariant in SkmtcRoot.findProject: `invariant(project, \\`Project \"${projectName}\" not found\\`)` (cli/lib/skmtc-root.ts:55), which surfaces at runtime as `Invariant failed: Project \"my-api\" not found` \u2014 capital P, double quotes, no `Error:` prefix. The lowercase single-quoted `project '...' not found` form in the doc does not exist in cli/.",
+      "verificationCommand": "grep -q 'Project \"${projectName}\" not found' cli/lib/skmtc-root.ts && ! grep -rq \"project '.*' not found\" cli/",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/create.md",
+      "claim": "\"The scope falls back through `Project.addGenerator` in `cli/lib/project.ts:340\u2013349`.\"",
+      "docLocation": "reference/cli/create.md:127",
+      "evidence": "The scope fallback lives at cli/lib/project.ts:316 (`scopeName: scopeName ?? (username ? \\`@${username}\\` : undefined) ?? 'jsr-user'`) inside addGenerator (lines 310-331). Lines 340-349 are now the body of the static `open()` method (Manifest.open / SchemaFile.openFromProject / `new Project({...})`) and contain no scope-fallback logic.",
+      "verificationCommand": "sed -n '316p' cli/lib/project.ts | grep -q 'jsr-user' && ! sed -n '340,349p' cli/lib/project.ts | grep -q 'jsr-user'",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/create.md",
+      "claim": "\"The scaffold itself wraps these canonical args with optional `destinationPath` and `rootRef?` fields exposed to user code.\"",
+      "docLocation": "reference/cli/create.md:65-66",
+      "evidence": "For the model scaffold, `destinationPath: string` is a required (non-optional) field, not optional (cli/lib/model-generator.ts:79); only `rootRef?` is optional (line 82). For the operation scaffold there is NO such wrapper at all \u2014 its constructor uses core's `OasOperationProjectionConstructorArgs` directly with `{ context, operation, settings }` and neither destinationPath nor rootRef (cli/lib/operation-generator.ts:77,81).",
+      "verificationCommand": "grep -q 'destinationPath: string' cli/lib/model-generator.ts && grep -q 'OasOperationProjectionConstructorArgs' cli/lib/operation-generator.ts && ! grep -q 'destinationPath' cli/lib/operation-generator.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/describe.md",
+      "claim": "The `--json` option \"Implies `--no-input`.\"",
+      "docLocation": "reference/cli/describe.md:41",
+      "evidence": "describe has no `--no-input` flag and no interactive/input-mode resolution. Its command definition registers only `.option('--json', ...)` (cli/mod.ts:274) and cli-schema.ts:143 lists `flags: [{ flag: '--json', ... }]` only. renderDescribe calls only resolveOutputFormat({jsonFlag}) (cli/commands/describe.ts:104), never an input-mode resolver \u2014 describe always runs headless regardless of --json, so --json implies nothing about --no-input.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'Implies .--no-input' docs/reference/cli/describe.md && ! grep -A6 \"name: 'describe'\" cli/lib/cli-schema.ts | grep -q 'no-input'"
+    },
+    {
+      "page": "reference/cli/dev.md",
+      "claim": "Schema source resolution has a third fallback: an interactive prompt (TTY only), the same three-step chain generate uses.",
+      "docLocation": "reference/cli/dev.md:90 (also 26-27)",
+      "evidence": "cli/commands/dev.ts:45-49 resolves the schema as `schemaSourceString ?? project.clientJson.contents?.source` and then `invariant(typeof schemaSource === 'string' && schemaSource.length > 0, 'No schema source \u2014 pass <schema> as an argument or set \"source\" in client.json')`. There is no prompt fallback and no TTY check anywhere in the command; a missing schema always throws the invariant.",
+      "verificationCommand": "! grep -qi prompt cli/commands/dev.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/dev.md",
+      "claim": "In strict mode (no TTY), a missing schema fails with the same recipe error generate produces.",
+      "docLocation": "reference/cli/dev.md:30-31",
+      "evidence": "cli/commands/dev.ts has no strict-mode, TTY, or recipe-error handling. A missing schema throws a plain tiny-invariant Error (dev.ts:46-49) that propagates uncaught to the top level (mod.ts:585 `.parse` has no wrapping try/catch), exiting 1 with a raw message, not a structured recipe error.",
+      "verificationCommand": "! grep -qiE 'recipe|no-input|strict' cli/commands/dev.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/dev.md",
+      "claim": "Exit code 1 means the initial bundle failed and the watch loop never started.",
+      "docLocation": "reference/cli/dev.md:166",
+      "evidence": "cli/commands/dev.ts:60-92: `createBundle` and the generate step run inside runOnce's try block whose catch (dev.ts:81-82) only logs `error: ...` and does not rethrow. After `await runOnce()` (dev.ts:94) the watcher is unconditionally started (dev.ts:96-118). An initial bundle failure is therefore swallowed and the loop DOES start. Exit code 1 actually results from the pre-loop invariants (non-local project dev.ts:39, missing schema dev.ts:46) or the registry check, not from a bundle failure.",
+      "verificationCommand": "grep -q 'await runOnce()' cli/commands/dev.ts && grep -Eq 'catch \\(error\\)' cli/commands/dev.ts && grep -q 'await createBundle' cli/commands/dev.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/dev.md",
+      "claim": "The watched directories are specifically each generator's `<gen-name>/src/` and `<gen-name>/mod.ts`.",
+      "docLocation": "reference/cli/dev.md:50-52",
+      "evidence": "cli/commands/dev.ts:100-104 calls `chokidar.watch(projectPath, { ignored: shouldIgnore, ... })`, watching the entire project tree. shouldIgnore (dev.ts:26-34) excludes only /.settings/, bundle.js, worker.ts, node_modules and .git \u2014 so every other file (e.g. deno.json, any non-src file) is watched, not just src/ and mod.ts. The page's own boundaries table (line 105, deno.json edit triggers) contradicts this narrowed list.",
+      "verificationCommand": "grep -q 'chokidar.watch(projectPath' cli/commands/dev.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "claim": "There are exactly SIX check IDs, and 'the full surface is enumerated in cli/lib/doctor-headless.ts \u2014 every id: literal'. The tables list install-lockfile, deno-version, hub-auth, project-deno-json, project-base-path, project-core-pin, project-bundle, project-manifest.",
+      "docLocation": "reference/cli/doctor.md:39-64",
+      "evidence": "Source emits at least 12 distinct check IDs. doctor-headless.ts alone has install-lockfile, deno-version, hub-auth, project-deno-json, project-base-path, project-core-pin, project-bundle, project-worker-pin (line 565), project-manifest \u2014 9 literals, not 6. Three more (anchors-config, anchors-coverage, anchors-staleness) come from doctor-anchors.ts (pushed at doctor-headless.ts:262-264), so they are NOT enumerated in doctor-headless.ts as the doc claims.",
+      "severity": "error",
+      "verificationCommand": "grep -q \"project-worker-pin\" cli/lib/doctor-headless.ts && grep -q \"anchors-config\" cli/lib/doctor-anchors.ts && test $(grep -rhoE \"id: .[a-z-]+\" cli/lib/doctor-headless.ts cli/lib/doctor-anchors.ts | sort -u | wc -l) -gt 6"
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "claim": "project-bundle: 'If the project has at least one *local* generator import, bundle.js exists. Pure JSR projects return ok with hasLocalGenerator: false (no bundle needed).' JSON example shows message 'has local generators but no bundle.js' and data { hasLocalGenerator: true, bundlePath }. 'Bundle missing' failure mode says 'Remote-only projects report ok here \u2014 no bundle needed when every generator is on JSR.'",
+      "docLocation": "reference/cli/doctor.md:60,116-118,254-258",
+      "evidence": "checkProjectBundle does NOT inspect generator imports and has no hasLocalGenerator field. Comment at doctor-headless.ts:529-530: 'Every project \u2014 remote-only included \u2014 generates from its local bundle.js, so its absence is always actionable.' Missing bundle.js is always a warning regardless of JSR-vs-local; message is 'Project \"X\" has no bundle.js at <path>.' with data { bundlePath } only (lines 531-539).",
+      "severity": "error",
+      "verificationCommand": "grep -q \"remote-only included \u2014 generates from its local\" cli/lib/doctor-headless.ts && ! grep -q \"hasLocalGenerator\" cli/lib/doctor-headless.ts"
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "claim": "Human-readable output uses \u2713/\u2717/\u25cb symbols, per-check 'OK'/'FAIL'/'WARN' tags, 'Workspace:' and 'Project:' group headers, and a trailing 'Summary: 4 OK, 1 WARN, 1 FAIL' line.",
+      "docLocation": "reference/cli/doctor.md:70-87",
+      "evidence": "printDoctorResult (cli/commands/doctor.ts:47-60) prints 'SKMTC doctor \u2014 summary: <status>', then CLI version / SKMTC root / Global state dir / Projects lines, then one line per check formatted by printCheckLine as '[ok]/[warn]/[error]/[skip] [<id>] <message>' with an indented 'hint:' line. There are no \u2713 symbols, no Workspace/Project headers, and no 'Summary: N OK...' line.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"SKMTC doctor \u2014 summary:\" cli/commands/doctor.ts && grep -q \"\\[ok\\]\" cli/commands/doctor.ts && ! grep -q \"Summary:\" cli/commands/doctor.ts"
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "claim": "install-lockfile is shown as a FAIL failure mode: '\u2717 install-lockfile FAIL / The installed CLI's deno.lock not found', implying a missing lockfile is an error-severity check.",
+      "docLocation": "reference/cli/doctor.md:47,214-222",
+      "evidence": "checkInstallLockfile returns status 'skipped' (not error/FAIL) when the lockfile is absent, with message 'No install lockfile at <path> \u2014 not a deno-install setup.' (doctor-headless.ts:130-136). When present it always returns 'ok'; a read error returns 'warning'. It never returns 'error'.",
+      "severity": "major",
+      "verificationCommand": "awk '/id: .install-lockfile/{f=1} f&&/status:/{print;exit}' cli/lib/doctor-headless.ts | grep -q skipped"
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "claim": "project-core-pin mismatch is an error: JSON example shows status \"error\" with top-level summary \"error\"; the human-readable example marks it '\u2717 ... FAIL' contributing to a '1 FAIL' summary and exit 1.",
+      "docLocation": "reference/cli/doctor.md:79,108-110,126",
+      "evidence": "checkProjectCorePin returns status 'warning' for a major.minor mismatch (doctor-headless.ts:400-411: message ends 'Major.minor mismatch.'), and warning for missing/non-JSR pins. It never returns 'error', so a core-pin mismatch alone yields summary 'warning' and exit 0 \u2014 contradicting the doc's error/exit-1 framing and its CI example.",
+      "severity": "major",
+      "verificationCommand": "grep -B4 \"Major.minor mismatch\" cli/lib/doctor-headless.ts | grep -q \"status: 'warning'\""
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "claim": "'Remediation hints' section: 'Each non-OK check includes a `remediation` string.'",
+      "docLocation": "reference/cli/doctor.md:152-154",
+      "evidence": "The Check type has no 'remediation' field; remediation text lives in the optional 'hint' field (doctor-headless.ts:32-44, 'hint?: string'). 'remediation' appears in source only inside a doc comment (line 40), never as a field. The doc itself contradicts this at line 130-131 ('There is no separate ... remediation field \u2014 remediation text lives in hint'). Also not every non-OK check carries a hint (e.g. the base-path 'unreadable' error at lines 497-503 has none).",
+      "severity": "major",
+      "verificationCommand": "grep -q \"hint?: string\" cli/lib/doctor-headless.ts && ! grep -qE \"^\\s+remediation:\" cli/lib/doctor-headless.ts"
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "claim": "project-base-path reads 'client.json#settings.basePath' with client.json at the project root (`<project>/client.json`).",
+      "docLocation": "reference/cli/doctor.md:58,243",
+      "evidence": "checkProjectBasePath reads join(projectPath, '.settings', 'client.json') (doctor-headless.ts:249) \u2014 the file lives at `<project>/.settings/client.json`, not `<project>/client.json`.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"'.settings', 'client.json'\" cli/lib/doctor-headless.ts"
+    },
+    {
+      "page": "reference/cli/generate.md",
+      "claim": "The typecheck result's failed outcome is identified by a `kind` field: \"Only `kind: \"failed\"` causes exit 1\" (line 273) and the exit-code table \"`--typecheck` returned `kind: \"failed\"`\" (line 320).",
+      "docLocation": "reference/cli/generate.md:273 and :320",
+      "evidence": "The typecheck result is discriminated on `type`, not `kind`. `cli/lib/typecheck.ts:39,223` define `type: 'failed'` and the exit decision reads `typecheckResult?.type === 'failed'` (cli/commands/generate-switch.ts:160). There is no `kind` field anywhere in TypecheckResult. The doc's own JSON examples (line 236 \"Discriminated on `type`\", lines 240/250/264/267/270) correctly use `type`, so the two `kind` mentions are internally inconsistent and would make a `jq '.typecheck.kind==\"failed\"'` recipe silently never match \u2014 the exact silent-null failure the page warns about.",
+      "verificationCommand": "grep -q 'kind: \"failed\"' docs/reference/cli/generate.md && grep -q \"type: 'failed'\" cli/lib/typecheck.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/init.md",
+      "claim": "Rejecting an absolute basePath prints `Error: basePath must be relative, got \"/tmp/foo\"` followed by `Usage: skmtc init <projectName> <basePath>` and `Example: skmtc init my-api ./src`.",
+      "docLocation": "docs/reference/cli/init.md:109-115",
+      "evidence": "The absolute-basePath path throws InvalidBasePathError which commands/init.tsx catches and routes through failWithRecipe({arg:'<basePath>', ...discover: error.message}). formatMissingArgError (cli/lib/strict-mode.ts:86-108) emits a first line of `Error: missing required argument: <basePath>`, an Example of `skmtc init my-api ./web/app/src` (init.tsx:71), and puts the real text (`basePath must be relative to the SKMTC root ... Got an absolute path: <path>`, init-headless.ts:54) under a trailing `Discover valid values:` line. init.test.tsx:209 asserts the output contains `missing required argument: <basePath>`. The doc's quoted error block and example do not match actual output.",
+      "evidenceCommand": "grep -q 'basePath must be relative, got' docs/reference/cli/init.md && grep -q 'missing required argument' cli/lib/strict-mode.ts",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && grep -q 'basePath must be relative, got' docs/reference/cli/init.md && grep -q 'missing required argument' cli/lib/strict-mode.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/init.md",
+      "claim": "Re-running on an existing project returns `kind: \"existed\"` in JSON mode.",
+      "docLocation": "docs/reference/cli/init.md:7",
+      "evidence": "The result discriminator field is `type`, not `kind`: InitHeadlessResult is `{ type: 'existed'; projectName }` (cli/lib/init-headless.ts:28-30) and the JSON payload is `{ type: 'existed', projectName, nextStep: null }` (printInitResult, init.tsx:106-116; test init.test.tsx:142-144). The doc's own full JSON examples (lines 99, 138) correctly use `\"type\": \"existed\"`, so line 7's `kind:` is drift.",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && grep -q 'kind: \"existed\"' docs/reference/cli/init.md && grep -q \"type: 'existed'\" cli/lib/init-headless.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/cli/install.md",
+      "claim": "Opening summary: install \"writes default settings to `client.json`\".",
+      "docLocation": "reference/cli/install.md:5-7",
+      "evidence": "Generator.install only runs denoJson.addImport (cli/lib/generator.ts:96-98); installHeadless (cli/lib/install-headless.ts) and installGenerator (cli/lib/project.ts:226-256) never touch client.json. The page's own body contradicts the summary at line 60 (\"Install does not modify client.json\").",
+      "severity": "major",
+      "verificationCommand": "grep -q 'writes default settings to `client.json`' docs/reference/cli/install.md && ! grep -qi 'clientjson\\|client.json' cli/lib/install-headless.ts && sed -n '96,98p' cli/lib/generator.ts | grep -q 'addImport(this.toModuleName'"
+    },
+    {
+      "page": "reference/cli/install.md",
+      "claim": "Opening summary: \"Transitive peer dependencies resolve automatically.\"",
+      "docLocation": "reference/cli/install.md:7",
+      "evidence": "install adds only the single requested import (cli/lib/generator.ts:97); no peer-dependency resolution exists in the install path. The page's own body at line 138 states the CLI \"does not add transitive peer deps automatically\", directly contradicting the summary.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'Transitive peer dependencies resolve automatically' docs/reference/cli/install.md && grep -q 'does \\*\\*not\\*\\* add transitive peer deps automatically' docs/reference/cli/install.md"
+    },
+    {
+      "page": "reference/cli/install.md",
+      "claim": "Verification section: \"the CLI reads back `deno.json` to confirm the import actually landed\" (and \"With the read-back verification, write failures now surface\").",
+      "docLocation": "reference/cli/install.md:80-84",
+      "evidence": "RootDenoJson.write() only writes via writeFileSafeDir with no readback (cli/lib/root-deno-json.ts:119-125); installGenerator does not re-read deno.json (cli/lib/project.ts:226-256). The only post-mutation readback in the install path is bundle.js file existence in cli/lib/bundle-headless.ts:50 \u2014 not a deno.json import readback.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'reads back `deno.json`' docs/reference/cli/install.md && sed -n '119,125p' cli/lib/root-deno-json.ts | grep -q writeFileSafeDir && ! sed -n '119,125p' cli/lib/root-deno-json.ts | grep -q readTextFile"
+    },
+    {
+      "page": "reference/cli/install.md",
+      "claim": "deno.json#imports update step 3: \"Updates the Deno lockfile to pin the exact resolved version.\"",
+      "docLocation": "reference/cli/install.md:58",
+      "evidence": "No lockfile handling exists in the install path: installGenerator (cli/lib/project.ts:226-256) does addImport + write only; bundle-headless.ts and create-bundle.ts perform no lock management (deno bundle is invoked with args ['bundle','-o',fileName,'worker.ts'], no --lock \u2014 cli/lib/create-bundle.ts:31).",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'Updates the Deno lockfile' docs/reference/cli/install.md && ! grep -qi 'lock' cli/lib/install-headless.ts cli/lib/create-bundle.ts"
+    },
+    {
+      "page": "reference/cli/install.md",
+      "claim": "deno.json#imports update step 1: \"Resolves the latest version satisfying the user's semver constraint\".",
+      "docLocation": "reference/cli/install.md:52",
+      "evidence": "When a version/constraint is supplied it is written verbatim, not resolved: installGenerator uses `version ?? (await Jsr.getLatestMeta(...)).latest` (cli/lib/project.ts:237) so a truthy constraint short-circuits registry resolution, and toFullName() emits `jsr:<name>@<constraint>` unchanged (cli/lib/generator.ts:263-265). Only the no-constraint case resolves to an exact latest.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'Resolves the latest version satisfying' docs/reference/cli/install.md && grep -q 'version ?? (await Jsr.getLatestMeta' cli/lib/project.ts"
+    },
+    {
+      "page": "reference/cli/install.md",
+      "claim": "Failure-mode error strings: `Error: jsr:@skmtc/gen-xyz not found in registry` and `Error: jsr:@skmtc/gen-zod@^99.0.0 not found`.",
+      "docLocation": "reference/cli/install.md:158-169",
+      "evidence": "Actual thrown messages are `Failed to get latest meta for jsr:${scopeName}/${packageName}` (cli/lib/jsr.ts:65) and `Failed to find package for jsr:${scopeName}/${packageName} with version matching ${semver}` (cli/lib/jsr.ts:85-87); the documented strings do not appear in source.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'not found in registry' docs/reference/cli/install.md && grep -q 'Failed to get latest meta for jsr' cli/lib/jsr.ts && grep -q 'Failed to find package for jsr' cli/lib/jsr.ts"
+    },
+    {
+      "page": "reference/cli/list.md",
+      "claim": "list reports \"the import keys from <project>/deno.json#imports, nothing more\" / \"every key under deno.json#imports\" as a flat array, and the example output includes @dgrabov/my-form (a non-gen-named key).",
+      "docLocation": "reference/cli/list.md:3-4, 45-47, 57, 65-66, 90",
+      "evidence": "list -> project.toGeneratorIds() -> RootDenoJson.toGeneratorIds() FILTERS the import keys: `Object.keys(this.contents.imports ?? {}).filter(item => parseModuleName(item).packageName.startsWith('gen-'))` (cli/lib/root-deno-json.ts:42-46). Only keys whose package name starts with `gen-` appear. The doc's example `@dgrabov/my-form` parses to packageName `my-form`, which fails the filter and would NOT be listed. So list does NOT show 'every key' \u2014 it shows only gen-* keys.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"startsWith('gen-')\" cli/lib/root-deno-json.ts && grep -q 'my-form' docs/reference/cli/list.md"
+    },
+    {
+      "page": "reference/cli/list.md",
+      "claim": "When [project] is unset and not in strict mode, the CLI infers the project from the workspace if there's exactly one, and multi-project workspaces prompt for selection; the missing-arg exit code 2 only applies 'in strict mode'.",
+      "docLocation": "reference/cli/list.md:29-31, 138",
+      "evidence": "renderList() unconditionally errors when projectName is undefined: `if (projectName === undefined) { ... return failWithRecipe({command:'list', arg:'<project>', ...}) }` (cli/commands/list.tsx:34-51), which prints a recipe error and `Deno.exit(2)` (cli/lib/strict-mode.ts). This happens BEFORE the mode check, in both interactive and strict mode. There is no single-project inference and no selection prompt \u2014 the code comment states 'list has no Ink view for picking a project ... the recipe error is appropriate in both modes'.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'return failWithRecipe' cli/commands/list.tsx && ! grep -q 'ListGeneratorsView' cli/commands/list.tsx"
+    },
+    {
+      "page": "reference/cli/list.md",
+      "claim": "Project-not-found prints `Error: project 'my-api' not found`.",
+      "docLocation": "reference/cli/list.md:147-149",
+      "evidence": "findProject uses `invariant(project, `Project \"${projectName}\" not found`)` (cli/lib/skmtc-root.ts:55) via tiny-invariant \u2014 the message is `Project \"my-api\" not found` (capital P, double quotes), thrown as an uncaught error (Deno prints `error: Uncaught ... Invariant failed: Project \"my-api\" not found` with a stack trace), not the clean `Error: project 'my-api' not found` shown in the doc.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'Project \"${projectName}\" not found' cli/lib/skmtc-root.ts && ! grep -rq \"project 'my-api' not found\" cli/"
+    },
+    {
+      "page": "reference/cli/list.md",
+      "claim": "Malformed deno.json prints `Error: parsing .skmtc/my-api/deno.json: <reason>`.",
+      "docLocation": "reference/cli/list.md:156-158",
+      "evidence": "No such message exists in source. Schema-invalid deno.json throws a ConfigValidationError with context string `deno.json at <absolute path>` (cli/lib/root-deno-json.ts:59-63 -> cli/lib/parse-or-explain.ts:47-49); invalid JSON throws a raw SyntaxError from JSON.parse. Neither produces the `parsing .skmtc/...` prefix the doc shows.",
+      "severity": "minor",
+      "verificationCommand": "! grep -rq 'parsing .skmtc' cli/ && grep -q 'deno.json at ' cli/lib/root-deno-json.ts"
+    },
+    {
+      "page": "reference/cli/list.md",
+      "claim": "An empty/absent workspace prints `Error: workspace has no projects (looked under .skmtc/)`.",
+      "docLocation": "reference/cli/list.md:165-167",
+      "evidence": "No such message exists in source. When no .skmtc root exists, SkmtcRoot.open returns `new SkmtcRoot([], manager)` with no error (cli/lib/skmtc-root.ts:81-83); a subsequent findProject then fails with the 'Project \"...\" not found' invariant. There is no 'workspace has no projects' string anywhere in the CLI.",
+      "severity": "minor",
+      "verificationCommand": "! grep -rq 'workspace has no projects' cli/"
+    },
+    {
+      "page": "reference/cli/login.md",
+      "claim": "\"Every hub-token consumer (`publish`, `push`) resolves the credential through one helper\" \u2014 states the token consumers are publish and push.",
+      "docLocation": "reference/cli/login.md:74",
+      "evidence": "resolveHubAuth (the shared resolution helper) is imported and used by four hub commands, not two: cli/commands/publish.tsx:60, cli/commands/push.ts:84, cli/commands/pull.ts:51, and cli/commands/project.ts:75 (twice). The word \"Every\" with a two-item parenthetical is factually incomplete \u2014 `pull` and `project` also resolve the stored token.",
+      "severity": "minor",
+      "verificationCommand": "grep -q resolveHubAuth cli/commands/pull.ts && grep -q resolveHubAuth cli/commands/project.ts && ! grep -qiE 'pull|project' docs/reference/cli/login.md"
+    },
+    {
+      "page": "reference/cli/overview.md",
+      "claim": "Every command writes structured JSON output behind `--json` so agents can consume it programmatically.",
+      "docLocation": "reference/cli/overview.md:8",
+      "evidence": "In cli/mod.ts the `create` command (createCommand) and `dev` command (devCommand) define no `--json` option (nor `--no-input`). createCommand only chains .description/.type/.arguments/.action; devCommand only .description/.arguments/.action. Passing `--json` to either yields a Cliffy unknown-option error (exit 2), not JSON. The universal 'Every command' framing is false.",
+      "verificationCommand": "! awk '/const createCommand =/,/const cloneCommand =/' cli/mod.ts | grep -q -- '--json'",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/publish.md",
+      "claim": "The source-tree upload filter excludes 'Dotfiles (with the single exception of .settings/, which holds client.json)'.",
+      "docLocation": "reference/cli/publish.md:188",
+      "evidence": "cli/lib/source-upload.ts does NOT skip dotfiles wholesale. Its DEFAULT_IGNORE list (lines 48-81) only excludes specific dotfiles: .git/, .DS_Store, .env, .env.* \u2014 every other dotfile uploads. The code comment at lines 44-46 states explicitly: 'unlike the old hand-rolled filter, dotfiles are NOT skipped wholesale \u2014 a stack may legitimately want to ship one. Known-unwanted dotfiles are listed explicitly; anything else uploads.' .settings/ is not a special-cased exception; it uploads simply because dotfiles aren't excluded. The doc's inverted framing materially misleads about which files (including secret-bearing dotfiles beyond .env*) get uploaded.",
+      "evidence2": "",
+      "severity": "error",
+      "verificationCommand": "grep -q \"Dotfiles (with the single exception\" docs/reference/cli/publish.md && grep -q \"dotfiles are NOT skipped wholesale\" cli/lib/source-upload.ts"
+    },
+    {
+      "page": "reference/cli/pull.md",
+      "claim": "When neither --project nor client.json#project supplies a destination, the resolution falls through to \"a recipe error\" (implying failWithRecipe: exit 2 with a recipe printed to stderr).",
+      "docLocation": "reference/cli/pull.md:45",
+      "evidence": "pull.ts only calls failWithRecipe for the missing <project> arg (line 42) and the missing --token (line 57). The missing-destination case is handled in pull-headless.ts, which returns { type: \"failed\", stage: \"destination\" } (lines 138-146). renderPull exits 1 for any failed result (pull.ts:101 `result.type === \"failed\" ? 1 : 0`), not 2. The doc's own stage table (line 162) correctly describes this as stage `destination`, contradicting the prose at line 45.",
+      "verificationCommand": "cd /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno && grep -q 'stage: \"destination\"' cli/lib/pull-headless.ts && ! grep -q 'destination' <(grep -A3 'no hub destination' cli/commands/pull.ts) && grep -q 'Otherwise a recipe error' docs/reference/cli/pull.md",
+      "severity": "major"
+    },
+    {
+      "page": "reference/cli/remove.md",
+      "claim": "The --json payload is exactly `{projectName, removed}` and matches `RemoveHeadlessResult`; the doc states explicitly \"no `verifyWith` hint\".",
+      "docLocation": "docs/reference/cli/remove.md:104-127",
+      "evidence": "printRemoveResult in cli/commands/remove.tsx:87-93 builds the JSON payload as `{ projectName, removed, verifyWith: `cat .skmtc/${result.projectName}/deno.json` }`. The emitted JSON DOES carry a `verifyWith` field (and the text branch prints a matching \"Verify with:\" line at :98). So the documented shape is wrong and the explicit \"no verifyWith hint\" claim is false.",
+      "severity": "error",
+      "verificationCommand": "grep -q \"verifyWith\" cli/commands/remove.tsx && grep -qF 'no `verifyWith` hint' docs/reference/cli/remove.md"
+    },
+    {
+      "page": "reference/cli/remove.md",
+      "claim": "When the generator (or project) argument is unset and the CLI is not in strict mode, `remove` prompts with the project's installed generators.",
+      "docLocation": "docs/reference/cli/remove.md:23,30-31",
+      "evidence": "renderRemove (cli/commands/remove.tsx:36-54) calls failWithRecipe (which does Deno.exit(2)) whenever projectName or generator is undefined \u2014 this check runs BEFORE the `mode === 'strict'` branch at :56, so it fires unconditionally in every mode. Running `skmtc remove my-api` in an interactive TTY therefore exits 2 with a recipe error; it never prompts. The generator-selection prompt (RemoveGeneratorView) is only reachable through the top-level interactive menu, not the `remove` command.",
+      "severity": "error",
+      "verificationCommand": "grep -q \"generator === undefined\" cli/commands/remove.tsx && grep -qF \"the CLI prompts with the\" docs/reference/cli/remove.md"
+    },
+    {
+      "page": "reference/cli/remove.md",
+      "claim": "On a source-directory delete failure, \"the deno.json#imports removal succeeded but the directory delete didn't\" \u2014 the generator is logically removed but source files remain.",
+      "docLocation": "docs/reference/cli/remove.md:190-197",
+      "evidence": "In RootDenoJson.removeGenerator (cli/lib/root-deno-json.ts) the Deno.removeSync of the source directory happens at line 87, BEFORE the imports entry is filtered out at lines 93-96. If the delete throws, execution never reaches the imports mutation, so the import entry is NOT removed. The documented ordering (import removed, dir left behind) is inverted.",
+      "severity": "major",
+      "verificationCommand": "d=$(grep -n removeSync cli/lib/root-deno-json.ts | head -1 | cut -d: -f1); i=$(grep -n \"imports = Object.fromEntries\" cli/lib/root-deno-json.ts | head -1 | cut -d: -f1); [ \"$d\" -lt \"$i\" ] && grep -qF \"removal succeeded but the directory delete\" docs/reference/cli/remove.md"
+    },
+    {
+      "page": "reference/cli/remove.md",
+      "claim": "Exit code 1 is returned on operational failure (filesystem, post-remove bundle failure), and a missing/unknown generator yields `Error: generator '...' not in project '...'`.",
+      "docLocation": "docs/reference/cli/remove.md:167,173-179",
+      "evidence": "Project.removeGenerator (cli/lib/project.ts:281-304) wraps the whole operation in try/catch that only `console.error(error)`s and never rethrows; removeHeadless then returns normally and renderRemove does an unconditional `Deno.exit(0)` at cli/commands/remove.tsx:60. So filesystem/invariant failures (the underlying message is `Package source not found`, not the documented text \u2014 there is no \"not in project\" string in source) are swallowed and the command still prints a success payload and exits 0. There is no exit-1 path, and `remove` never bundles, so \"post-remove bundle failure\" cannot occur here.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"Deno.exit(0)\" cli/commands/remove.tsx && grep -q \"console.error(error)\" cli/lib/project.ts && ! grep -rq \"not in project\" cli/ && grep -qF \"Operational failure (filesystem\" docs/reference/cli/remove.md"
+    },
+    {
+      "page": "reference/error-codes.md",
+      "claim": "UNEXPECTED_PROPERTY typical message is `Unexpected property '<key>' at <location>`",
+      "docLocation": "reference/error-codes.md:107",
+      "evidence": "Source emits `Unexpected property '${key}' in '${parentType}'` (parentType, e.g. 'schema:string'), not a location suffix. core/context/ParseContext.ts:562",
+      "severity": "minor",
+      "verificationCommand": "grep -qF \"Unexpected property '<key>' at <location>\" docs/reference/error-codes.md && grep -qF \"Unexpected property '\\${key}' in '\\${parentType}'\" core/context/ParseContext.ts"
+    },
+    {
+      "page": "reference/error-codes.md",
+      "claim": "Recipe errors at exit code 2 always include a `Discover:` line pointing at the follow-up command",
+      "docLocation": "reference/error-codes.md:364-370",
+      "evidence": "The line is labelled `Discover valid values:` (not `Discover:`) and is emitted only conditionally (`if (discover) lines.push(...)`), so it is not always present. cli/lib/strict-mode.ts:103-105",
+      "severity": "minor",
+      "verificationCommand": "grep -qF 'A `Discover:` line' docs/reference/error-codes.md && grep -qF 'Discover valid values:' cli/lib/strict-mode.ts && grep -qF 'if (discover)' cli/lib/strict-mode.ts"
+    },
+    {
+      "page": "reference/glossary.md",
+      "claim": "The 'Generator key' table gives the four key formats as `<generatorId>|<path>|<method>` (OAS operation), `<generatorId>|<rootKind>|<fieldName>` (GraphQL operation), and `<generatorId>|<refName>` (model).",
+      "docLocation": "reference/glossary.md:271-274",
+      "evidence": "core/dsl/GeneratorKeys.ts builds each key WITH a trailing variant segment: line 293 `${generatorId}|${path}|${method}|${variant}`, line 388 `${generatorId}|${rootKind}|${fieldName}|${variant}`, line 441 `${generatorId}|${refName}|${variant}`. The Naked* string-template types (lines 90/101/116) also carry the extra `|${string}` segment. The doc's formats omit the variant segment, so a reader parsing or constructing a generator key (e.g. reading a 'Registered definition mismatch' error) would mis-count the fields.",
+      "verificationCommand": "grep -q 'method}|${variant}' core/dsl/GeneratorKeys.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/glossary.md",
+      "claim": "The Generator key has 'Four shapes' \u2014 OasOperationGeneratorKey, GqlOperationGeneratorKey, ModelGeneratorKey, GeneratorOnlyKey.",
+      "docLocation": "reference/glossary.md:268-274",
+      "evidence": "core/dsl/GeneratorKeys.ts defines a fifth shape, WebhookGeneratorKey (line 169), which is a member of the GeneratorKey union (lines 216-221). The count 'Four' is contradicted; there are five shapes.",
+      "verificationCommand": "grep -q 'WebhookGeneratorKey' core/dsl/GeneratorKeys.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/glossary.md",
+      "claim": "The File DSL class holds three maps: `imports: Map<module, Set<name>>`, `reExports: Map<module, { variable, type }>`, and `definitions: Map<name, Definition>`; imports dedup via `Set.add`.",
+      "docLocation": "reference/glossary.md:246-249",
+      "evidence": "After the language split the concrete file class lang-typescript/src/TsFile.ts stores `imports: Map<string, TsImport>` (line 44) and `reExports: Map<string, TsReExport>` (line 47) \u2014 wrapper-class values merged via `existing.merge(importEntry)` (line 84), not `Set<name>` deduped via `Set.add` nor a `{ variable, type }` record. The map value shapes in the doc are stale.",
+      "verificationCommand": "grep -q 'imports: Map<string, TsImport>' lang-typescript/src/TsFile.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/manifest-format.md",
+      "claim": "`skmtc workspaces runtime-logs <project>` fetches hosted Sandbox API errors from the service using `manifest.spanId`.",
+      "docLocation": "reference/manifest-format.md:180",
+      "evidence": "No `workspaces` command group and no `runtime-logs` subcommand exist in the CLI. cli/mod.ts registers only: init, create, clone, install, list, remove, generate, bundle, clean, describe, dev, publish, push, pull, login, logout, doctor, agent-context, project (create/rm), migrate (variants). `grep -rni 'runtime-logs' cli/` returns no hits (only a `mockRuntimeLogs` test fixture). A reader on a hosted run who runs the documented command gets an unknown-command failure.",
+      "verificationCommand": "! grep -rqi 'runtime-logs' /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno/cli",
+      "severity": "major"
+    },
+    {
+      "page": "reference/settings/client-json-schema.md",
+      "claim": "The file type is inferred from the URL extension first, then the Content-Type response header for URLs, then content sniffing.",
+      "docLocation": "reference/settings/client-json-schema.md:87-88",
+      "evidence": "cli/lib/schema-file.ts infers file type by extension only for local sources (toFileType, lines 111-127, throws on unrecognized extension) and by extension-then-Content-Type for remote sources (toFileTypeFromPathOrContentType, lines 145-168, which re-throws a descriptive error when neither yields a type). There is no content-sniffing (body inspection) stage anywhere; the described third fallback does not exist.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"then content sniffing\" docs/reference/settings/client-json-schema.md && ! grep -riq \"sniff\" cli/lib/schema-file.ts"
+    },
+    {
+      "page": "reference/settings/enrichments-shape.md",
+      "claim": "OAS operation enrichment lookup is a flat three-level get: `get(context.settings, `enrichments.${config.id}.${operation.path}.${operation.method}`)`, and the client.json payload sits directly at [generatorId][path][method] (example places `post`/`put` payloads directly under the path with no variant level).",
+      "docLocation": "reference/settings/enrichments-shape.md:24, :29-38, :43-58",
+      "evidence": "core/dsl/operation/oas/toOasOperationProjectionBase.ts:130-142 builds a three-scope umbrella `{subject, generator, stack}`; subject = get(context.settings, ['enrichments', config.id, operation.path, operation.method, variant]) \u2014 a 4th `variant` level below method \u2014 plus generator=[id,'_generator'] and stack=['_stack'], then v.parse(config.toEnrichmentSchema(), raw). The doc snippet omits both the `variant` level and the umbrella.",
+      "severity": "error",
+      "verificationCommand": "grep -qF 'enrichments.${config.id}.${operation.path}.${operation.method}' docs/reference/settings/enrichments-shape.md && grep -q 'GENERATOR_ENRICHMENT_KEY' core/dsl/operation/oas/toOasOperationProjectionBase.ts && grep -q 'operation.method,' core/dsl/operation/oas/toOasOperationProjectionBase.ts"
+    },
+    {
+      "page": "reference/settings/enrichments-shape.md",
+      "claim": "GraphQL operation enrichment lookup is a flat three-level get: `get(context.settings, `enrichments.${config.id}.${operation.rootKind}.${operation.fieldName}`)`, and the example client.json places field payloads directly under [rootKind][fieldName] with no variant level.",
+      "docLocation": "reference/settings/enrichments-shape.md:122, :127-133, :137-152",
+      "evidence": "core/dsl/operation/gql/toGqlOperationProjectionBase.ts:116-127: subject = get(context.settings, ['enrichments', config.id, operation.rootKind, operation.fieldName, variant]) (4th `variant` level), inside umbrella `{subject, generator, stack}`. The doc omits the variant level and the umbrella.",
+      "severity": "error",
+      "verificationCommand": "grep -qF 'enrichments.${config.id}.${operation.rootKind}.${operation.fieldName}' docs/reference/settings/enrichments-shape.md && grep -q 'GENERATOR_ENRICHMENT_KEY' core/dsl/operation/gql/toGqlOperationProjectionBase.ts && grep -q 'operation.fieldName, variant' core/dsl/operation/gql/toGqlOperationProjectionBase.ts"
+    },
+    {
+      "page": "reference/settings/enrichments-shape.md",
+      "claim": "A generator declares its enrichment schema as the flat leaf payload only: `toEnrichmentSchema = () => formSchema` where formSchema is `v.optional(v.object({ title, description, submitLabel, fields }))` \u2014 'The Valibot schema describes the leaf payload' and 'The schema's root is what arrives at the lookup target.'",
+      "docLocation": "reference/settings/enrichments-shape.md:166-204",
+      "evidence": "toEnrichmentSchema must return the three-scope umbrella composite `v.object({ subject, generator, stack })` (core/enrichments/toEnrichmentDescriptor.ts:265-266, 317-318; factory parses the raw umbrella via v.parse(config.toEnrichmentSchema(), raw) at toOasOperationProjectionBase.ts:142). The leaf payload is the `subject` field, not the schema root. A generator following the doc (returning the bare leaf) would have v.parse strip subject/generator/stack, yielding empty enrichments.",
+      "severity": "error",
+      "verificationCommand": "grep -qF 'export const toEnrichmentSchema = () => formSchema' docs/reference/settings/enrichments-shape.md && grep -qF 'v.object({ subject, generator, stack })' core/enrichments/toEnrichmentDescriptor.ts && grep -qF 'v.parse(config.toEnrichmentSchema(), raw)' core/dsl/operation/oas/toOasOperationProjectionBase.ts"
+    },
+    {
+      "page": "reference/settings/enrichments-shape.md",
+      "claim": "Validation step 2: 'The looked-up value (which may be undefined) is parsed against the generator's declared Valibot schema via `v.parse(schema, value)`.' \u2014 i.e. the single get() result is parsed.",
+      "docLocation": "reference/settings/enrichments-shape.md:213-214",
+      "evidence": "core/dsl/operation/oas/toOasOperationProjectionBase.ts:130-142 (and model:138-142, gql:120-127) parse the assembled umbrella object `raw = {subject, generator, stack}`, not a single looked-up value: `v.parse(config.toEnrichmentSchema(), raw)`. There are three get() lookups, not one, and the parse target is the composite.",
+      "severity": "major",
+      "verificationCommand": "grep -qF 'via `v.parse(schema, value)`' docs/reference/settings/enrichments-shape.md && grep -qF 'v.parse(config.toEnrichmentSchema(), raw)' core/dsl/operation/oas/toOasOperationProjectionBase.ts"
+    },
+    {
+      "page": "reference/settings/enrichments-shape.md",
+      "claim": "Validation step 1: the factory static is `toEnrichments({ operation | refName, context })`.",
+      "docLocation": "reference/settings/enrichments-shape.md:210-211",
+      "evidence": "toEnrichments destructures `{ operation, context, variant }` (toOasOperationProjectionBase.ts:119-123) / `{ refName, context, variant }` (toModelProjectionBase.ts:130); the `variant` argument is omitted from the doc signature.",
+      "severity": "minor",
+      "verificationCommand": "grep -qF 'toEnrichments({ operation | refName, context })' docs/reference/settings/enrichments-shape.md && grep -q 'operation,' core/dsl/operation/oas/toOasOperationProjectionBase.ts && grep -q 'variant$' core/dsl/operation/oas/toOasOperationProjectionBase.ts"
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "claim": "OAS 3.1 is down-converted (lossily) to OAS 3.0 before crossing into the worker \u2014 type arrays rewritten to nullable, plural examples reduced to first, $dynamicRef a parse error, const\u2192enum, unevaluatedProperties dropped, warnings emitted per dropped feature; and OAS is 'normalized to the engine's canonical shape \u2014 OAS 3.0'.",
+      "docLocation": "reference/settings/source-resolution.md:152-201, 375-411",
+      "evidence": "convert/toV3Document.ts:157-164 passes 3.1 documents through UNCHANGED with no down-convert: 'SKMTC parses OpenAPI 3.1 natively (core/parse/v3-1), so 3.1 documents pass through unchanged \u2014 no down-convert. The native parser reads the 3.1 idioms directly (type arrays, const, {type:\"null\"}, numeric exclusive bounds, examples[], webhooks).' Only Swagger 2.0 is converted. There is no 3.1\u21923.0 rewrite, no lossy table, no per-feature warning. The canonical shape is 3.0-OR-3.1, not 3.0.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'no down-convert' convert/toV3Document.ts && grep -q 'pass through unchanged' convert/toV3Document.ts"
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "claim": "Format detection has a third step, 'Content sniffing' on the first non-whitespace byte: '{' \u2192 JSON, 'swagger:'/'openapi:' at line start \u2192 YAML, 'type '/'schema '/'scalar ' at line start \u2192 GraphQL SDL.",
+      "docLocation": "reference/settings/source-resolution.md:136-148",
+      "evidence": "cli/lib/schema-file.ts detects format ONLY by file extension (toFileType, lines 111-127) for local sources, and extension-then-Content-Type (toFileTypeFromPathOrContentType, lines 145-168) for remote. There is no content/byte sniffing anywhere; an unrecognized local extension throws 'Schema file extension not recognized' rather than sniffing contents.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'Schema file extension not recognized' cli/lib/schema-file.ts && ! grep -qi 'sniff' cli/lib/schema-file.ts"
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "claim": "The CLI passes GraphQL SDL into toArtifacts as `{ type: 'gql', sdl: '...' }`.",
+      "docLocation": "reference/settings/source-resolution.md:212",
+      "evidence": "The GraphQL document input field is `value`, not `sdl`. cli/lib/document-input.ts:27 returns `{ type: 'gql', value: schemaContents }`, and core/types/SkmtcDocument.ts:86 types it as `{ type: 'gql'; value: string | GraphQLSchema }`.",
+      "severity": "major",
+      "verificationCommand": "grep -q \"type: 'gql', value: schemaContents\" cli/lib/document-input.ts && grep -q \"type: 'gql'; value\" core/types/SkmtcDocument.ts"
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "claim": "In strict mode with no source, the CLI exits code 2 with the message: 'Error: no schema source provided (in strict mode)\\n  Provide one as a positional argument or set source in client.json'.",
+      "docLocation": "reference/settings/source-resolution.md:79-84",
+      "evidence": "The exit code 2 is correct, but the message is wrong. cli/commands/generate-switch.ts:71-83 calls failWithRecipe \u2192 cli/lib/strict-mode.ts:86-120 which emits 'Error: missing required argument: <schema>' followed by the non-interactive recipe (Usage/Example/Discover). The string 'no schema source provided' does not exist anywhere in source.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'missing required argument' cli/lib/strict-mode.ts && ! grep -rq 'no schema source provided' cli core convert"
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "claim": "A failed Swagger 2 conversion surfaces as: 'Error: failed to convert Swagger 2 to OAS 3.0: <reason>'.",
+      "docLocation": "reference/settings/source-resolution.md:175-177",
+      "evidence": "No such error string exists. convert/toV3Document.ts:166-177 calls convertObj (from @skmtc/swagger2openapi) and lets its errors propagate directly; the only version error is 'Unrecognized OpenAPI version (...). Supported: OpenAPI 3.0.x, 3.1.x, and Swagger 2.0.' (line 186-188).",
+      "severity": "major",
+      "verificationCommand": "! grep -rq 'failed to convert Swagger' cli core convert"
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "claim": "HTTP Content-Type detection recognizes 'application/graphql' / 'text/graphql'.",
+      "docLocation": "reference/settings/source-resolution.md:139-141",
+      "evidence": "cli/lib/schema-file.ts:151 recognizes only 'application/graphql' for GraphQL; 'text/graphql' is not a case. (Conversely, source also accepts text/json, application/x-yaml, text/x-yaml which the doc omits.)",
+      "severity": "minor",
+      "verificationCommand": "! grep -q 'text/graphql' cli/lib/schema-file.ts && grep -q \"'application/graphql'\" cli/lib/schema-file.ts"
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "claim": "For GraphQL the CLI 'does a lightweight format check (it must contain a `type` declaration)' / 'validates that it looks like SDL' host-side before forwarding.",
+      "docLocation": "reference/settings/source-resolution.md:129-131, 209-211, 442-443",
+      "evidence": "No host-side SDL content validation exists. cli/lib/document-input.ts:26-28 forwards the raw string as-is (`{ type: 'gql', value: schemaContents }`) with no scan for a `type` declaration; format is decided solely by extension/Content-Type in schema-file.ts.",
+      "severity": "minor",
+      "verificationCommand": "! grep -rq 'type declaration' cli/lib/document-input.ts cli/lib/schema-file.ts && grep -q \"type: 'gql', value: schemaContents\" cli/lib/document-input.ts"
+    },
+    {
+      "page": "reference/stock-generators/gen-arktype.md",
+      "claim": "ArkType expresses 'string', 'number', 'integer' as string literals; the Projection produces these literally.",
+      "docLocation": "reference/stock-generators/gen-arktype.md:41",
+      "evidence": "There is no 'integer' literal in the output. ArktypeInteger.ts:28 maps integer schemas to 'number' (`return applyModifiers('number', this.modifiers)`, with the code comment \"Arktype uses number for integers as well\"). An integer field is emitted as `number`, never `integer`.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"applyModifiers('number', this.modifiers)\" /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-arktype/src/ArktypeInteger.ts && grep -q \"'integer'\" docs/reference/stock-generators/gen-arktype.md"
+    },
+    {
+      "page": "reference/stock-generators/gen-arktype.md",
+      "claim": "The entry is defined as toModelEntry({ id, transform }) with only id and the transform function.",
+      "docLocation": "reference/stock-generators/gen-arktype.md:30",
+      "evidence": "The real entry in mod.ts:6-11 is `toModelEntry<EnrichmentSchema>({ id, toEnrichmentSchema, transform })` \u2014 it carries the `<EnrichmentSchema>` generic and the `toEnrichmentSchema` field, which is a required (non-optional) property of ToModelEntryArgs (core/dsl/model/toModelEntry.ts:16). The doc's sample omits both, so it does not match source and would not typecheck as a template.",
+      "severity": "minor",
+      "verificationCommand": "grep -q '  toEnrichmentSchema,' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-arktype/src/mod.ts && ! grep -q 'toEnrichmentSchema' docs/reference/stock-generators/gen-arktype.md"
+    },
+    {
+      "page": "reference/stock-generators/gen-express.md",
+      "claim": "The 'What it generates' code block shows the output as `import express from 'express'`, `export const app = express()`, and synchronous arrow handlers like `app.get('/users/:id', (req, res) => { res.json({ id: req.params.id, name: 'TODO', email: 'TODO' }) })` / `app.post('/users', ...)` with `userBody.parse(req.body)` and `res.status(201).json(...)`.",
+      "docLocation": "reference/stock-generators/gen-express.md:18-33",
+      "evidence": "Source renders a `Router()` singleton (ExpressApp.toString \u2192 `Router()\\n\\n${this.routes}`), imports `['Router','Request','Response','NextFunction']` from express (not a default `express` import, no `express()` call). ExpressRoute.toString emits async handlers `async (req: Request, res: Response, next: NextFunction) => { try { ... } catch (error) { next(error) } }` that delegate to a `<method><Path>Service` imported from `@/<segment>/services.ts`. Request-body validation is `const body = v.parse(<name>, req.body)` (valibot) not `userBody.parse`. Responses come from Response.ts (`res.json(result)` / `res.status(404).send()`) and ResponseVoid.ts (`res.status(204).send()`). None of the doc's example lines appear in source.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'Router()' ../../skmtc-generators/gen-express/src/ExpressApp.ts && ! grep -rqi 'export const app = express' ../../skmtc-generators/gen-express/src/"
+    },
+    {
+      "page": "reference/stock-generators/gen-express.md",
+      "claim": "TODO comments survive into output: 'Each generated handler has a `// TODO` placeholder. Stub-and-edit by design \u2014 the generator produces a scaffold, not a working server.' (also 'Stub-and-edit output' in What to learn).",
+      "docLocation": "reference/stock-generators/gen-express.md:53-55",
+      "evidence": "No `TODO` string exists anywhere in gen-express/src/. Generated handlers delegate to real service functions (imported from `@/<segment>/services.ts`) and perform validation/response handling; there is no `// TODO` placeholder in ExpressRoute.ts, Response.ts, or ResponseVoid.ts.",
+      "severity": "error",
+      "verificationCommand": "! grep -rq 'TODO' ../../skmtc-generators/gen-express/src/"
+    },
+    {
+      "page": "reference/stock-generators/gen-express.md",
+      "claim": "Listed under 'Common customizations when cloned': 'Add automatic request-body validation via the Zod schemas from gen-zod.' \u2014 implying request-body validation is not already present.",
+      "docLocation": "reference/stock-generators/gen-express.md:81-82",
+      "evidence": "The generator already performs automatic request-body validation, using valibot via gen-valibot (not zod/gen-zod): RequestBody.ts imports `ValibotProjection` from `@skmtc/gen-valibot`, calls `context.insertNormalizedModel(ValibotProjection, ...)`, and emits `const body = v.parse(<name>, req.body)`.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'v.parse' ../../skmtc-generators/gen-express/src/RequestBody.ts && grep -q '@skmtc/gen-valibot' ../../skmtc-generators/gen-express/src/RequestBody.ts"
+    },
+    {
+      "page": "reference/stock-generators/gen-express.md",
+      "claim": "'Every operation's `transform` calls `app.append(operation)` to add its route to the shared instance.'",
+      "docLocation": "reference/stock-generators/gen-express.md:60-62",
+      "evidence": "The transform calls `app.value.append(operation)` \u2014 `app` is the Definition returned by findDefinition/insertOperation; `.value` is the ExpressApp projection carrying `append`. The doc's own invariant line uses `app?.value`, so `app.append` is internally inconsistent.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'app.value.append(operation)' ../../skmtc-generators/gen-express/src/mod.ts"
+    },
+    {
+      "page": "reference/stock-generators/gen-msw.md",
+      "claim": "The `toRoutesList` factory accepts dependencies (a mock data store) so consumers can inject deps at boot time, sidestepping the timing problem \u2014 the generated output is `(deps: { ... }) => [ ... ]`.",
+      "docLocation": "gen-msw.md:24-32, 42-45, 58-60",
+      "evidence": "MockRoutesList.toString() returns `() => ${this.list}` (skmtc-generators/gen-msw/src/MockRoutesList.ts:21-23) \u2014 a zero-argument arrow function returning the routes array. There is no `deps` parameter anywhere in the class; `add()` only pushes routes onto the list. The generated factory takes no arguments, so the entire deps-injection narrative (the page's stated 'Key decision' and 'What to learn') is contradicted by source.",
+      "verificationCommand": "grep -q '() => ${this.list}' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-msw/src/MockRoutesList.ts && ! grep -qi 'deps' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-msw/src/MockRoutesList.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-msw.md",
+      "claim": "All routes converge into a single `routesList` Projection per file (the aggregator is a Projection).",
+      "docLocation": "gen-msw.md:7",
+      "evidence": "The aggregator class `MockRoutesList` extends `SnippetBase`, not a projection base (skmtc-generators/gen-msw/src/MockRoutesList.ts:9). It is a Snippet, not a Projection \u2014 a distinction the docs' own concepts pages draw. Only the per-operation `MockRoute` (which extends `MswBase` \u2192 `toTsOasOperationProjectionBase`) is a Projection.",
+      "verificationCommand": "grep -q 'class MockRoutesList extends SnippetBase' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-msw/src/MockRoutesList.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/stock-generators/gen-msw.md",
+      "claim": "`defineAndRegister` is a member of the GenerateContext API (linked as 'GenerateContext \u2014 findDefinition / defineAndRegister').",
+      "docLocation": "gen-msw.md:76",
+      "evidence": "`defineAndRegister` is a standalone free function exported from lang-typescript/src/register.ts:99, called as `defineAndRegister(context, {...})`; it is not a method on GenerateContext (core/context/GenerateContext.ts contains zero occurrences). By contrast `findDefinition` genuinely is a GenerateContext method (GenerateContext.ts:1494). Attributing `defineAndRegister` to GenerateContext misdirects the reader.",
+      "verificationCommand": "grep -q 'export const defineAndRegister' /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno/lang-typescript/src/register.ts && ! grep -q 'defineAndRegister' /Users/dmitrigrabov/workspace/skmtc-root/skmtc/deno/core/context/GenerateContext.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-form.md",
+      "claim": "Per-field enrichment carries `.input (custom renderer)` alongside `.label`, `.placeholder`, `.references`.",
+      "docLocation": "reference/stock-generators/gen-shadcn-form.md:57",
+      "evidence": "src/enrichments.ts:11-16 defines formFieldItem as { moduleSelect, label?, placeholder?, references? } \u2014 there is no `input` key. The custom component is reached via `field.moduleSelect.module` (FormFields.ts:39). A reader configuring an `input` key in client.json would find it ignored; the real key is `moduleSelect`.",
+      "verificationCommand": "grep -q '\\.input' docs/reference/stock-generators/gen-shadcn-form.md && grep -q 'moduleSelect' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-shadcn-form/src/enrichments.ts && ! grep -qE '\\binput:' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-shadcn-form/src/enrichments.ts",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-form.md",
+      "claim": "schemaToField routes to React components named StringField, BooleanField, OperationReferenceField.",
+      "docLocation": "reference/stock-generators/gen-shadcn-form.md:53",
+      "evidence": "The emitted React components are StringField, NumberField, IntegerField, CheckboxField, SelectField, ListInput. Boolean routes to CheckboxInput which emits `<CheckboxField` (fields/CheckboxInput.ts:43); there is no `BooleanField`. No `OperationReferenceField` component exists anywhere in src.",
+      "verificationCommand": "grep -q 'BooleanField' docs/reference/stock-generators/gen-shadcn-form.md && ! grep -rq 'BooleanField' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-shadcn-form/src",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-form.md",
+      "claim": "ShadcnForm.ts imports TanstackQuery from @skmtc/gen-tanstack-query-supabase-zod (line 1).",
+      "docLocation": "reference/stock-generators/gen-shadcn-form.md:48",
+      "evidence": "In ShadcnForm.ts line 1 is `import { FunctionParameter } from '@skmtc/lang-typescript'`; the TanstackQuery import is on line 2.",
+      "verificationCommand": "grep -q 'line 1' docs/reference/stock-generators/gen-shadcn-form.md && grep -n 'gen-tanstack-query-supabase-zod' /Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-shadcn-form/src/ShadcnForm.ts | grep -q '^2:'",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-select.md",
+      "claim": "The stock produces a searchable combobox using the shadcn/ui Combobox component (<Combobox>/<ComboboxItem>), not a plain <select>.",
+      "docLocation": "reference/stock-generators/gen-shadcn-select.md:48",
+      "evidence": "skmtc-generators/gen-shadcn-select/src/ShadcnSelectInput.ts:90-108 emits a shadcn <Select> (SelectTrigger/SelectContent/SelectItem/SelectValue) imported from '@/components/ui/select.tsx' (lines 77-87). There is no Combobox anywhere in src/, and the output is not searchable. The 'What it generates' example (lines 20-27) and customization bullet (line 68) repeat the same wrong Combobox framing.",
+      "severity": "major",
+      "verificationCommand": "! grep -rq Combobox ../../skmtc-generators/gen-shadcn-select/src/ && grep -q SelectItem ../../skmtc-generators/gen-shadcn-select/src/ShadcnSelectInput.ts"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-select.md",
+      "claim": "The entry declares two extra hooks beyond transform: toPreviewModule and toMappingModule (toMappingModule for the form generator's references dispatch).",
+      "docLocation": "reference/stock-generators/gen-shadcn-select.md:43",
+      "evidence": "skmtc-generators/gen-shadcn-select/src/mod.ts declares only toPreviewModule (line 19); there is no toMappingModule. toMappingModule does not exist as a field in ToOasOperationConfigArgs/OasOperationEntry (core/dsl/operation/oas/toOasOperationEntry.ts) nor anywhere in core/, the generator packages, or the CLI source. The 'What to learn from it' bullet (lines 52-60) elaborates on this non-existent hook.",
+      "severity": "major",
+      "verificationCommand": "! grep -rq toMappingModule ../../skmtc-generators/gen-shadcn-select/ && grep -q toPreviewModule ../../skmtc-generators/gen-shadcn-select/src/mod.ts"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-select.md",
+      "claim": "The stock labels items using a `name` field if present.",
+      "docLocation": "reference/stock-generators/gen-shadcn-select.md:70",
+      "evidence": "skmtc-generators/gen-shadcn-select/src/InputOption.ts:21-22 defaults the accessor to [itemName, 'id'] (i.e. item.id), or a configured moduleSelect formatter/schemaPath. It never falls back to a `name` field.",
+      "severity": "minor",
+      "verificationCommand": "grep -q \"itemName, 'id'\" ../../skmtc-generators/gen-shadcn-select/src/InputOption.ts"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-table.md",
+      "claim": "Columns are derived automatically from the list-item schema: 'Each property of the list-item schema becomes a column. No filtering of which properties show up \u2014 the stock dumps everything.'",
+      "docLocation": "reference/stock-generators/gen-shadcn-table.md:52-55",
+      "evidence": "TanstackColumns.ts:27 builds columns from `settings.enrichments.subject?.table?.columns?.map(...)` and line 38 does `List.toArray(columns ?? [])`. Columns are opt-in via the `columns` enrichment array; with no enrichment the table emits ZERO columns. Nothing iterates the item schema's properties. The stock does the opposite of 'dumps everything' \u2014 it dumps nothing by default.",
+      "verificationCommand": "grep -q 'columns?.map' ../../skmtc-generators/gen-shadcn-table/src/TanstackColumns.ts && grep -q 'dumps everything' docs/reference/stock-generators/gen-shadcn-table.md",
+      "severity": "error"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-table.md",
+      "claim": "'Iterating an OasObject's properties to produce table columns is the table-version of gen-shadcn-form's schemaToField dispatch.'",
+      "docLocation": "reference/stock-generators/gen-shadcn-table.md:66-69",
+      "evidence": "TanstackColumns.ts:27 maps over `settings.enrichments.subject?.table?.columns`, not over an OasObject's properties. There is no properties iteration; columns come from the enrichment array. The 'schema-shape to columns' learning is not implemented by the stock.",
+      "verificationCommand": "grep -q 'enrichments.subject?.table?.columns' ../../skmtc-generators/gen-shadcn-table/src/TanstackColumns.ts && grep -q \"Iterating an\" docs/reference/stock-generators/gen-shadcn-table.md",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-table.md",
+      "claim": "'What it generates' example shows a component built from raw shadcn markup: <Table>, <TableHeader>, <TableRow>, <TableHead>, <TableBody>, <TableCell> with an inline data.map.",
+      "docLocation": "reference/stock-generators/gen-shadcn-table.md:19-43",
+      "evidence": "ShadcnTable.ts:61 emits `<DataTable columns={columns} data={...} />` wrapped in a `<div>` (importing DataTable from '@/components/data-table/data-table.tsx'), with an optional title/description header. Tanstack column definitions are generated separately via TanstackColumns/createColumnHelper. The generator never emits <Table>/<TableHeader>/<TableCell> markup, so the documented output shape is fabricated.",
+      "verificationCommand": "grep -q 'DataTable' ../../skmtc-generators/gen-shadcn-table/src/ShadcnTable.ts && ! grep -q 'TableHeader' ../../skmtc-generators/gen-shadcn-table/src/ShadcnTable.ts && grep -q 'TableHeader' docs/reference/stock-generators/gen-shadcn-table.md",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-shadcn-table.md",
+      "claim": "Suggested clone customization: 'Filter visible columns. Add enrichments for columns: { include?: string[], exclude?: string[] } to let users hide noisy fields.'",
+      "docLocation": "reference/stock-generators/gen-shadcn-table.md:73-75",
+      "evidence": "The stock already has a `columns` enrichment (enrichments.ts:33 `columns: v.optional(v.array(tableColumnItem))` where each item is `{ moduleSelect, label }`). Columns are already enrichment-driven and opt-in, so the advice to 'add' an include/exclude columns enrichment to escape a 'dumps everything' default rests on the false premise above and mischaracterizes the existing enrichment surface.",
+      "verificationCommand": "grep -q 'columns: v.optional(v.array(tableColumnItem))' ../../skmtc-generators/gen-shadcn-table/src/enrichments.ts && grep -q 'Add enrichments for' docs/reference/stock-generators/gen-shadcn-table.md",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-fetch-zod.md",
+      "claim": "\"Hardcoded request validation. Request bodies are validated with `<schema>.parse(body)` before send.\" The example (line 29) also shows `body: JSON.stringify(userBody.parse(body))`.",
+      "docLocation": "reference/stock-generators/gen-tanstack-query-fetch-zod.md:52-54 (and example line 29)",
+      "evidence": "MutationFn.toString() emits `body: JSON.stringify(body),` with NO `.parse()` call on the request body. There is no request-body validation anywhere; only the RESPONSE is validated via `${this.zodResponseName}.parse(data)`. Following the doc, a reader would expect generated mutations to reject invalid request bodies at call time \u2014 they do not.",
+      "verificationCommand": "G=/Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-tanstack-query-fetch-zod/src; grep -q 'JSON.stringify(body),' \"$G/MutationFn.ts\" && ! grep -q 'parse(body)' \"$G/MutationFn.ts\"",
+      "severity": "error"
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-fetch-zod.md",
+      "claim": "\"The `user`/`userBody` Zod schemas come from `gen-zod` via `insertNormalizedModel` \u2014 both generators share a single registered schema.\"",
+      "docLocation": "reference/stock-generators/gen-tanstack-query-fetch-zod.md:34-36",
+      "evidence": "The request body / args (`userBody`) is generated via `insertNormalizedModel(TsProjection, ...)` from `@skmtc/gen-typescript` (a TS type), NOT via `ZodProjection`. Only the response schema comes from `@skmtc/gen-zod` (`insertNormalizedModel(ZodProjection, ...)`). So `userBody` is not a Zod schema at all.",
+      "verificationCommand": "G=/Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-tanstack-query-fetch-zod/src; grep -q 'insertNormalizedModel(TsProjection' \"$G/MutationEndpoint.ts\" && grep -q 'insertNormalizedModel(TsProjection' \"$G/MutationFn.ts\"",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-fetch-zod.md",
+      "claim": "\"Per-method dispatch in the Projection. GET \u2192 query, POST/PUT/PATCH \u2192 mutation. The dispatch logic lives in the Projection's `toString()`.\"",
+      "docLocation": "reference/stock-generators/gen-tanstack-query-fetch-zod.md:65-66",
+      "evidence": "The per-method dispatch (`match(operation).with({ method: 'get' }, ...).otherwise(...)`) lives in the TanstackQuery CONSTRUCTOR, which picks a client instance. TanstackQuery.toString() merely delegates: `return this.client.toString()`. The dispatch is not in toString().",
+      "verificationCommand": "G=/Users/dmitrigrabov/workspace/skmtc-root/skmtc-generators/gen-tanstack-query-fetch-zod/src; grep -q 'match(operation)' \"$G/TanstackQuery.ts\" && grep -A2 'override toString' \"$G/TanstackQuery.ts\" | grep -q 'this.client.toString'",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-supabase-zod.md",
+      "claim": "The generated hook example calls the Postgrest query builder: supabase.from('users').select('*').then(({ data }) => userListSchema.parse(data))",
+      "docLocation": "reference/stock-generators/gen-tanstack-query-supabase-zod.md:19-25",
+      "evidence": "QueryFn.ts toString() emits `await supabase.functions.invoke(\\`...\\`, { method: '...' })` then `return <schema>.parse(data)` \u2014 it uses Supabase Edge Functions (functions.invoke), never `.from(...).select(...)`. No `.from(` or `.select('*')` exists anywhere in src/.",
+      "verificationCommand": "grep -q 'functions.invoke' ../../skmtc-generators/gen-tanstack-query-supabase-zod/src/QueryFn.ts && ! grep -rq \"select('\\*')\" ../../skmtc-generators/gen-tanstack-query-supabase-zod/src/",
+      "severity": "error"
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-supabase-zod.md",
+      "claim": "Hooks use Supabase's Postgrest-style client as the transport (frontmatter and 'hooks that call the Supabase Postgrest client').",
+      "docLocation": "reference/stock-generators/gen-tanstack-query-supabase-zod.md:3",
+      "evidence": "QueryFn.ts / MutationFn.ts / PaginatedQueryFn.ts all call `supabase.functions.invoke(...)` (Supabase Edge Functions), not the Postgrest query client (`.from().select()`). The transport is Edge Functions, not Postgrest.",
+      "verificationCommand": "! grep -rq '\\.from(' ../../skmtc-generators/gen-tanstack-query-supabase-zod/src/ && grep -rq 'functions.invoke' ../../skmtc-generators/gen-tanstack-query-supabase-zod/src/",
+      "severity": "error"
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-supabase-zod.md",
+      "claim": "Common customization: 'Customize the table-name derivation (the stock uses operationId or path; you may want a tag-based mapping).'",
+      "docLocation": "reference/stock-generators/gen-tanstack-query-supabase-zod.md:56-57",
+      "evidence": "The generator has no table-name derivation. It invokes an edge function via a path template (toPathTemplate(path)); the word 'table' appears nowhere in src/. This customization is premised on the incorrect Postgrest characterization.",
+      "verificationCommand": "! grep -rqi 'table' ../../skmtc-generators/gen-tanstack-query-supabase-zod/src/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-supabase-zod.md",
+      "claim": "'Hardcoded supabase client name. The generator assumes a supabase symbol exists in scope.'",
+      "docLocation": "reference/stock-generators/gen-tanstack-query-supabase-zod.md:39-41",
+      "evidence": "The generator does not assume `supabase` is ambient \u2014 each Fn registers an import of `supabase` from `@/lib/supabase` (`imports: { '@/lib/supabase': ['supabase'] }`).",
+      "verificationCommand": "grep -rq '@/lib/supabase' ../../skmtc-generators/gen-tanstack-query-supabase-zod/src/",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/stock-generators/gen-zod.md",
+      "claim": "ZodConstraints.ts centralizes per-variant constraint-rendering including `.email()`, `.uuid()`, etc.",
+      "docLocation": "reference/stock-generators/gen-zod.md:42-45",
+      "evidence": "ZodConstraints.ts exports a single generic class `ZodConstraint` whose toString only emits `.${name}(${value})` for numeric-valued constraints (min/max). No `.email()`, `.uuid()`, or `.url()` is rendered anywhere in gen-zod/src \u2014 a grep for email/uuid across the whole src returns nothing. The `format` field is stored on ZodString/ZodInteger but never used in toString. The page even contradicts itself at line 67-68, listing format-to-method mapping (`format:'uri'` -> `z.string().url()`) as a customization to ADD when cloning, confirming stock does not do it.",
+      "verificationCommand": "! grep -rqi 'email\\|\\.uuid' ../../skmtc-generators/gen-zod/src/",
+      "severity": "major"
+    },
+    {
+      "page": "reference/stock-generators/gen-zod.md",
+      "claim": "Look at `ZodProjection.ts` to see the `toZodValue` dispatch and how each variant class is invoked.",
+      "docLocation": "reference/stock-generators/gen-zod.md:52-54",
+      "evidence": "The toZodValue dispatch (the `switch (schema.type)` that invokes `new ZodObject`, `new ZodArray`, `new ZodString`, etc.) lives entirely in Zod.ts (lines 24-123). ZodProjection.ts merely imports `toZodValue` from './Zod.ts' and calls it once; the reader directed there will not see the variant dispatch.",
+      "verificationCommand": "grep -q 'import { toZodValue } from \"./Zod.ts\"' ../../skmtc-generators/gen-zod/src/ZodProjection.ts && grep -q 'switch (schema.type)' ../../skmtc-generators/gen-zod/src/Zod.ts",
+      "severity": "minor"
+    },
+    {
+      "page": "reference/stock-generators/overview.md",
+      "claim": "gen-tanstack-query-supabase-zod produces Tanstack Query hooks using a \"Supabase Postgrest transport\".",
+      "docLocation": "reference/stock-generators/overview.md:50",
+      "evidence": "The generated hooks call `supabase.functions.invoke(...)` (Supabase Edge Functions transport), not Postgrest table queries. gen-tanstack-query-supabase-zod/src/QueryFn.ts:46, MutationFn.ts:71 and PaginatedQueryFn.ts:47 all emit `await supabase.functions.invoke(\\`${toPathTemplate(path)}\\`, ...)`. There is no `.from()`/`.select()`/PostgREST usage anywhere in src/. This pairs with gen-supabase-hono, which the same page correctly describes as emitting \"Hono routes for Supabase Edge Functions\" (the endpoints these hooks invoke).",
+      "severity": "major",
+      "verificationCommand": "grep -rq 'functions\\.invoke' ../../skmtc-generators/gen-tanstack-query-supabase-zod/src && ! grep -rqiE 'postgrest|\\.from\\(' ../../skmtc-generators/gen-tanstack-query-supabase-zod/src"
+    },
+    {
+      "page": "skills/skmtc-architecture/SKILL.md",
+      "claim": "ManifestContent has a `mappings` field (\"previews, mappings // optional UI metadata\") and \u00a79 refers to \"the manifest's `previews` and `mappings`\".",
+      "docLocation": "skills/skmtc-architecture/SKILL.md:322 (also :383)",
+      "evidence": "core/types/Manifest.ts:161-191 defines `type ManifestContent` with `previews: Record<string, Preview>` and NO `mappings` field (both the type and the valibot `manifestContent` schema). `mappings` appears only in a stale JSDoc example at line 51. The manifest built in core/run/toArtifacts.ts:176-186 emits `previews` but never `mappings`.",
+      "severity": "major",
+      "verificationCommand": "grep -q mappings docs/skills/skmtc-architecture/SKILL.md && ! sed -n '161,191p' core/types/Manifest.ts | grep -q mappings"
+    },
+    {
+      "page": "skills/skmtc-architecture/SKILL.md",
+      "claim": "The attribution tuple stored in a sidecar is `{ genId, srcPtr, variant, defName }`.",
+      "docLocation": "skills/skmtc-architecture/SKILL.md:359",
+      "evidence": "core/anchors/types.ts:38-53 defines `type Attribution = { generatorId, schemaPointer, variant, definitionName, producerName }`. The short keys `genId`, `srcPtr`, `defName` do not exist anywhere; the serialized sidecar row (core/anchors/sidecar.ts) uses pooled numeric indices (`si`, `vi`), not those names either.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'genId' docs/skills/skmtc-architecture/SKILL.md && ! grep -qE 'genId|srcPtr|defName' core/anchors/types.ts"
+    },
+    {
+      "page": "skills/skmtc-architecture/SKILL.md",
+      "claim": "`srcPtr` is a schema pointer like `oas:#/components/schemas/User` (an `oas:`-prefixed pointer).",
+      "docLocation": "skills/skmtc-architecture/SKILL.md:366",
+      "evidence": "core/anchors/attribute.ts:61 states pointers are \"protocol-agnostic \u2014 no `oas:` / `gql:` prefix\"; core/context/StackTrail.ts:198 likewise says \"never an `oas:`/`gql:` scheme\". The example pointer with an `oas:` prefix contradicts source.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'oas:#/components/schemas/User' docs/skills/skmtc-architecture/SKILL.md && grep -q 'no .oas' core/anchors/attribute.ts"
+    },
+    {
+      "page": "skills/skmtc-architecture/SKILL.md",
+      "claim": "`deploymentId` comes \"from DENO_DEPLOYMENT_ID or a timestamp\" and `region` is \"set only for hosted (Deno Deploy) runs\"; \u00a710/\u00a711 say `DENO_DEPLOYMENT_ID` / `DENO_REGION` flow into the manifest and `deploymentId`/`region` populate it for tracing.",
+      "docLocation": "skills/skmtc-architecture/SKILL.md:315 (also :317,:333,:427,:465)",
+      "evidence": "core/run/toArtifacts.ts:183-184 hardcodes `deploymentId: Date.now().toString()` and `region: undefined`. No `DENO_DEPLOYMENT_ID` or `DENO_REGION` read exists in core/, server/, or worker/. deploymentId is always a timestamp and region is always undefined \u2014 the env vars never flow into the manifest.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'DENO_DEPLOYMENT_ID' docs/skills/skmtc-architecture/SKILL.md && ! grep -rq 'DENO_DEPLOYMENT_ID' core/ server/ worker/ --include='*.ts'"
+    },
+    {
+      "page": "skills/skmtc-architecture/SKILL.md",
+      "claim": "`AttributionState` is exported from `@skmtc/core/Anchors` (alongside `Sidecar`, `GenerationMapEntry`).",
+      "docLocation": "skills/skmtc-architecture/SKILL.md:388",
+      "evidence": "core/anchors/mod.ts (the `@skmtc/core/Anchors` barrel) exports `Sidecar` and `GenerationMapEntry` but not `AttributionState`. `AttributionState` is exposed at a separate subpath `@skmtc/core/AttributionState` (core/deno.json:49 \u2192 ./types/AttributionState.ts).",
+      "severity": "minor",
+      "verificationCommand": "! grep -q AttributionState core/anchors/mod.ts && grep -q '\"./AttributionState\"' core/deno.json"
+    },
+    {
+      "page": "skills/skmtc-architecture/SKILL.md",
+      "claim": "`server/src/createServer.ts` is ~150 lines with routes `POST /artifacts`, `GET /generators`, `POST /to-v3-json`.",
+      "docLocation": "skills/skmtc-architecture/SKILL.md:470",
+      "evidence": "server/src/createServer.ts is 298 lines (roughly 2x the stated ~150) and registers more routes than listed: `POST /artifacts`, `POST /subjects`, `POST /enrichment-defaults`, `GET /generators`, `POST /descriptors`, `POST /validate`, `POST /to-v3-json`. The three named routes do exist.",
+      "severity": "minor",
+      "verificationCommand": "test $(wc -l < server/src/createServer.ts) -gt 200"
+    },
+    {
+      "page": "skills/skmtc-cli/SKILL.md",
+      "claim": "The JSON output discriminator field is `kind` \u2014 stated at \u00a78 (\"Discriminator field is usually `kind`\") and shown in every JSON example: install `bundle: { \"kind\": \"bundled\" }` (\u00a7409), clone (\u00a7425), bundle `{ \"kind\": \"bundled\" }` (\u00a7440), generate `\"kind\": \"generated\"` (\u00a7446), typecheck `{ kind: \"passed\" | ... }` (\u00a7466), publish `\"kind\": \"published\"` / `\"kind\": \"failed\"` (\u00a7477,\u00a7499), and the task-card conditional `bundle.kind === \"bundled\"` (\u00a7561).",
+      "docLocation": "skills/skmtc-cli/SKILL.md:401",
+      "evidence": "Every CLI JSON result uses `type` as the discriminator, never `kind`. bundle-headless.ts:28 `type: 'bundled'`; print-generate-result.ts:43 `type: 'generated' as const`; publish.tsx:86,125 `result.type === 'published'` / `'failed'`; typecheck.ts:24-45 `type: 'skipped'|'no-tsconfig'|'passed'|'failed'|'tsc-error'`. A `grep -rn \"kind:\" cli/lib cli/commands` (excluding tests) returns nothing. An agent following the doc's `bundle.kind === \"bundled\"` check (\u00a7561) always reads `undefined` and mis-drives.",
+      "severity": "error",
+      "verificationCommand": "grep -q \"type: 'bundled'\" cli/lib/bundle-headless.ts && grep -qF '\"kind\": \"bundled\"' docs/skills/skmtc-cli/SKILL.md"
+    },
+    {
+      "page": "skills/skmtc-cli/SKILL.md",
+      "claim": "The hub origin override environment variable is `$SKMTC_ORIGIN` \u2014 \"Explicit `--origin` / `$SKMTC_ORIGIN` always win\" (\u00a7845) and \"`--origin` / `$SKMTC_ORIGIN` / store host\" (\u00a7906).",
+      "docLocation": "skills/skmtc-cli/SKILL.md:845",
+      "evidence": "The env var is `$SKMTC_API_ORIGIN`, not `$SKMTC_ORIGIN`. hub-token.ts:39 `Deno.env.get('SKMTC_API_ORIGIN')` in resolveOrigin and :155 in resolveHubAuth; every mod.ts --origin help string reads \"Defaults to $SKMTC_API_ORIGIN\". `$SKMTC_ORIGIN` appears nowhere in source, so an agent exporting it in CI would have it silently ignored (falling through to the stored host or production default).",
+      "severity": "major",
+      "verificationCommand": "grep -qF 'SKMTC_ORIGIN' docs/skills/skmtc-cli/SKILL.md && grep -qF 'SKMTC_API_ORIGIN' cli/lib/hub-token.ts && ! grep -qF 'SKMTC_API_ORIGIN' docs/skills/skmtc-cli/SKILL.md"
+    },
+    {
+      "page": "skills/skmtc-debug/SKILL.md",
+      "claim": "The manifest top-level shape includes a `mappings?: Record<\u2026, Mapping>` field.",
+      "docLocation": "skills/skmtc-debug/SKILL.md:120",
+      "evidence": "The current `ManifestContent` type and its `manifestContent` valibot schema (core/types/Manifest.ts:161-191) declare only deploymentId, traceId, spanId, region?, files, previews, results, parseIssues, startAt, endAt. There is no `mappings` field; the word appears only in a stale JSDoc example at Manifest.ts:51.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'mappings' docs/skills/skmtc-debug/SKILL.md && ! grep -qE '^[[:space:]]+mappings' core/types/Manifest.ts"
+    },
+    {
+      "page": "skills/skmtc-generator/SKILL.md",
+      "claim": "Scaffold C imports and annotates the isSupported predicate with `type IsSupportedOasOperationConfigArgs` from `@skmtc/core`, used generically as `IsSupportedOasOperationConfigArgs<EnrichmentSchema>`.",
+      "docLocation": "docs/skills/skmtc-generator/SKILL.md:549,571",
+      "evidence": "No such type exists in source. The isSupported args type is `IsSupportedOasOperationArgs` (core/dsl/operation/oas/types.ts:36) and is NOT generic \u2014 it takes no type parameter. `grep -rn IsSupportedOasOperationConfigArgs core lang-typescript` returns nothing; the config-object type is `ToOasOperationConfigArgs<E>` (toOasOperationEntry.ts:21), a different thing. Copying Scaffold C's import line fails to compile: the named import does not exist.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'IsSupportedOasOperationConfigArgs' docs/skills/skmtc-generator/SKILL.md && ! grep -rq 'IsSupportedOasOperationConfigArgs' core lang-typescript --include='*.ts'"
+    },
+    {
+      "page": "skills/skmtc-generator/SKILL.md",
+      "claim": "The isSupported args type 'ALSO carries `context` and `enrichments`, not only the two fields destructured here' (the two destructured being `{ operation, variant }`).",
+      "docLocation": "docs/skills/skmtc-generator/SKILL.md:567-570",
+      "evidence": "The actual arg type `IsSupportedOasOperationArgs` (core/dsl/operation/oas/types.ts:36-41) has exactly three members: `context`, `operation`, `variant`. There is no `enrichments` field. The only field beyond the destructured `{operation, variant}` is `context`. A reader who follows the doc and tries to destructure `enrichments` in isSupported gets `undefined`.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'context` and `enrichments`' docs/skills/skmtc-generator/SKILL.md && ! sed -n '/export type IsSupportedOasOperationArgs/,/^}/p' core/dsl/operation/oas/types.ts | grep -q enrichments"
+    },
+    {
+      "page": "skills/skmtc-lang-typescript/SKILL.md",
+      "claim": "The identifier's declaration kind is read via `identifier.kind` (e.g. `identifier.kind === 'type' ? { name, type: 'type' } : identifier.name`), and TsImport.fromIdentifier reads the identifier's `kind`.",
+      "docLocation": "docs/skills/skmtc-lang-typescript/SKILL.md:216 (also :229 and :151)",
+      "evidence": "The field is named `type`, not `kind`. TsIdentifier declares `type: TsEntityType` (lang-typescript/src/TsIdentifier.ts:30-34) and IdentifierBase carries no `kind`/`type` at all (core/dsl/IdentifierBase.ts:35-56). createVariable sets `count.type` (createIdentifier.ts:70), and TsImport.fromIdentifier reads `isTypeOnly(identifier.type)` (TsImport.ts:88-90). The doc's copyable example `identifier.kind === 'type'` accesses a non-existent property \u2014 it won't compile against TsIdentifier and would always be undefined, silently defeating the very TS1484-avoidance the section teaches.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'identifier.kind' docs/skills/skmtc-lang-typescript/SKILL.md && grep -q 'type: TsEntityType' lang-typescript/src/TsIdentifier.ts && echo DISCREPANCY"
+    },
+    {
+      "page": "skills/skmtc-lang-typescript/SKILL.md",
+      "claim": "TypeScript output has two entity kinds; `TsEntityType` is a two-kind vocabulary (`'variable' | 'type'`), and the identifier factories are `createVariable` / `createType` only.",
+      "docLocation": "docs/skills/skmtc-lang-typescript/SKILL.md:137 (also :74-75)",
+      "evidence": "TsEntityType is a five-member union `'variable' | 'type' | 'class' | 'interface' | 'namespace'` (lang-typescript/src/createIdentifier.ts:28), with factories createVariable, createType, createClass, createInterface, createNamespace all exported (mod.ts:84-99) and keyword mappings for all five (createIdentifier.ts:159-165). The 'two entity kinds' framing materially understates the capability \u2014 a reader wanting to emit a class/interface/namespace would conclude TypeScript output cannot do so.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'two entity kinds' docs/skills/skmtc-lang-typescript/SKILL.md && grep -q \"'variable' | 'type' | 'class' | 'interface' | 'namespace'\" lang-typescript/src/createIdentifier.ts && echo DISCREPANCY"
+    },
+    {
+      "page": "skills/skmtc-lang-typescript/SKILL.md",
+      "claim": "The projection-base veneer config is core's `ModelProjectionBaseConfig<E, TsLang>`.",
+      "docLocation": "docs/skills/skmtc-lang-typescript/SKILL.md:66 (also :313)",
+      "evidence": "There is no type named `TsLang` in the package. The veneer parameterizes the config with `TsIdentifierType`: `ModelProjectionBaseConfig<EnrichmentType, TsIdentifierType>` (lang-typescript/src/toTsModelProjectionBase.ts:30), and core's second type parameter is `IdType extends IdentifierType` (core/dsl/model/toModelProjectionBase.ts:56-59). `TsLang` does not exist anywhere in lang-typescript.",
+      "severity": "minor",
+      "verificationCommand": "grep -q 'ModelProjectionBaseConfig<E, TsLang>' docs/skills/skmtc-lang-typescript/SKILL.md && ! grep -rq 'TsLang' lang-typescript/ && echo DISCREPANCY"
+    },
+    {
+      "page": "skills/skmtc-lang-typescript/SKILL.md",
+      "claim": "Current release: `@skmtc/lang-typescript` 0.4.0 (against `@skmtc/core` 0.11.0).",
+      "docLocation": "docs/skills/skmtc-lang-typescript/SKILL.md:307",
+      "evidence": "lang-typescript/deno.json declares version 0.12.11 pinned to `@skmtc/core@0.26.0`, not 0.4.0/0.11.0.",
+      "severity": "minor",
+      "verificationCommand": "grep -q '0.4.0 (against' docs/skills/skmtc-lang-typescript/SKILL.md && grep -q '\"version\": \"0.12' lang-typescript/deno.json && echo DISCREPANCY"
+    },
+    {
+      "page": "using/how-to/configure-enrichments.md",
+      "claim": "The OAS-operation routing key path is `enrichments[generatorId][operation.path][operation.method]` and the client.json example nests the leaf (title/submitLabel/fields) directly under the method key.",
+      "docLocation": "using/how-to/configure-enrichments.md:40, :46-64",
+      "evidence": "Source keys OAS operation enrichments `[generatorId][path][method][variant]` \u2014 one level deeper. GenerateContext.ts:671-672 comment: 'enrichments are keyed `[generatorId][path][method][variant]`; the block at `[path][method]` is therefore a record of' variant names. toVariantList (core/helpers/toVariantList.ts:52-56) enumerates the keys of that block as variant names and THROWS when 'main' is absent. The doc example's block `{title, submitLabel, fields}` would be read as variants named title/submitLabel/fields, none of which is 'main', so `skmtc generate` throws `[@skmtc/gen-shadcn-form] Enrichments for 'POST /users' must include a 'main' variant.` The correct shape wraps the leaf in a `\"main\": { ... }` object.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'path\\]\\[method\\]\\[variant\\]' core/context/GenerateContext.ts && ! grep -qi 'variant' docs/using/how-to/configure-enrichments.md"
+    },
+    {
+      "page": "using/how-to/configure-enrichments.md",
+      "claim": "The model routing key path is `enrichments[generatorId][refName]` and the gen-zod example places the leaf `{ description }` directly under the refName `UserModel`.",
+      "docLocation": "using/how-to/configure-enrichments.md:41, :66-78",
+      "evidence": "Source keys model enrichments `[generatorId][refName][variant]`. GenerateContext.ts:935-936 comment: 'enrichments are keyed `[generatorId][refName][variant]`; the block at `[refName]` is therefore a record of variant names.' The block passes through toVariantList (core/helpers/toVariantList.ts:52-56), so `{ \"description\": \"A user account\" }` is read as a variant named 'description'; 'main' is absent, so generation throws the missing-'main' error. Correct shape: `\"UserModel\": { \"main\": { \"description\": \"A user account\" } }`.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'refName\\]\\[variant\\]' core/context/GenerateContext.ts && ! grep -q '\"main\"' docs/using/how-to/configure-enrichments.md"
+    },
+    {
+      "page": "using/how-to/configure-enrichments.md",
+      "claim": "Running `skmtc agent-context --json | jq '.projects[] | .settings.enrichmentsConfigured'` confirms client.json parsed.",
+      "docLocation": "using/how-to/configure-enrichments.md:106-108",
+      "evidence": "The agent-context output has no such field. ProjectSnapshot (cli/lib/agent-context-headless.ts:33-43) exposes only `name`, `basePath`, `schemaSource`, `generators` \u2014 there is no `settings` object and no `enrichmentsConfigured` key anywhere in cli/ or core/. The jq expression returns null for every project, so the troubleshooting step never confirms anything.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'enrichmentsConfigured' docs/using/how-to/configure-enrichments.md && ! grep -rq 'enrichmentsConfigured' cli/ core/"
+    },
+    {
+      "page": "using/how-to/debug-failing-generation.md",
+      "claim": "To inspect parse issues, run `jq '.manifest.diagnostics' generate-output.json`; \"If `diagnostics` is empty, the parse phase succeeded.\" The Troubleshooting section also says \"Check `manifest.diagnostics`\".",
+      "docLocation": "docs/using/how-to/debug-failing-generation.md:47 (also 209, 216)",
+      "evidence": "`skmtc generate --json` stdout is the flat payload built in cli/lib/print-generate-result.ts:42-73 \u2014 it has no `.manifest` wrapper key, and parse issues are exposed as a top-level `parseIssues` field (print-generate-result.ts:57 `parseIssues: result.parseIssues`). The manifest type itself names the field `parseIssues`, not `diagnostics` (core/types/Manifest.ts:172 `parseIssues: ParseIssue[]`; schema at :187 `parseIssues: v.array(parseIssue)`). `jq '.manifest.diagnostics'` therefore always returns `null`, so the reader always concludes \"parse phase succeeded\" regardless of actual parse issues.",
+      "severity": "error",
+      "verificationCommand": "grep -q \"jq '.manifest.diagnostics'\" docs/using/how-to/debug-failing-generation.md && grep -q 'parseIssues: result.parseIssues' cli/lib/print-generate-result.ts"
+    },
+    {
+      "page": "using/how-to/debug-failing-generation.md",
+      "claim": "To check per-operation results, run `jq '.manifest.files[] | { path: .destinationPath, result: .result }' generate-output.json` (also `select(.result == \"skipped\")`).",
+      "docLocation": "docs/using/how-to/debug-failing-generation.md:60 (also 95)",
+      "evidence": "In the `--json` stdout payload `files` is a plain array of path strings: print-generate-result.ts:53 `files: result.filePaths`, and generate-local.ts:76/140 defines `filePaths: string[]` = `Object.keys(artifacts)`. There is no `.manifest` wrapper and the entries are strings, so `.destinationPath` and `.result` do not exist. Even against the on-disk manifest, `files` is `Record<string, ManifestEntry>` with no `.manifest` prefix and entries carry no `result` field.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'result: .result' docs/using/how-to/debug-failing-generation.md && grep -q 'files: result.filePaths' cli/lib/print-generate-result.ts && grep -q 'filePaths: string\\[\\]' cli/lib/generate-local.ts"
+    },
+    {
+      "page": "using/how-to/debug-failing-generation.md",
+      "claim": "\"Each file has a `result` field \u2014 `success`, `warning`, `error`, or `skipped`.\"",
+      "docLocation": "docs/using/how-to/debug-failing-generation.md:63",
+      "evidence": "`ManifestEntry` has only `lines`, `characters`, `destinationPath` (core/types/Manifest.ts:136-140) \u2014 no `result` field. Per-item statuses live in a separate hierarchical `results: ResultsItem` tree on the manifest (Manifest.ts:168; core/types/Results.ts), not on file entries.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'Each file has a `result` field' docs/using/how-to/debug-failing-generation.md && ! grep -A3 'export type ManifestEntry = {' core/types/Manifest.ts | grep -qw result"
+    },
+    {
+      "page": "using/how-to/debug-failing-generation.md",
+      "claim": "Under \"Module not found in generated code\" \u2192 \"Stale bundle\": \"If you cloned a generator and edited it, but didn't `skmtc bundle`, the old bundle is used. `skmtc doctor` flags this.\"",
+      "docLocation": "docs/using/how-to/debug-failing-generation.md:130",
+      "evidence": "Doctor's bundle check (cli/lib/doctor-headless.ts checkProjectBundle:506-546) only warns when bundle.js is *absent*; it returns `ok` whenever a bundle.js exists, regardless of freshness, and doctor never calls any freshness check (no `freshness`/`checkBundleFreshness` reference in doctor-headless.ts). The only freshness detector, cli/lib/bundle-freshness.ts, compares the *set of generator import keys* in deno.json vs worker.ts \u2014 editing a generator's source without changing deno.json imports leaves it reporting `fresh`. So an edited-but-not-rebundled generator is flagged by neither doctor nor generate.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'flags this' docs/using/how-to/debug-failing-generation.md && ! grep -q 'freshness' cli/lib/doctor-headless.ts"
+    },
+    {
+      "page": "using/how-to/install-a-generator.md",
+      "claim": "After `skmtc list my-project --json`, the new generator \"should appear with `source: \"jsr\"` and a resolved version.\"",
+      "docLocation": "using/how-to/install-a-generator.md:56-58",
+      "evidence": "The `--json` output is `JSON.stringify(ListHeadlessResult)` where `ListHeadlessResult = { projectName: string; generators: string[] }` (cli/lib/list-headless.ts:20-23). `generators` is a flat array of bare package-id strings produced by `RootDenoJson.toGeneratorIds()`, which returns `Object.keys(imports).filter(...)` \u2014 e.g. `\"@skmtc/gen-zod\"` (cli/lib/root-deno-json.ts:42-46, test at cli/lib/root-deno-json.test.ts:26-31). There is no per-generator `source` field and no version in the output at all.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'generators: string\\[\\]' cli/lib/list-headless.ts && ! grep -q 'source' cli/lib/list-headless.ts"
+    },
+    {
+      "page": "using/how-to/install-a-generator.md",
+      "claim": "Troubleshoot missing output by running `skmtc generate my-project --json | jq '.diagnostics'`.",
+      "docLocation": "using/how-to/install-a-generator.md:74-78",
+      "evidence": "The generate `--json` payload has no top-level `diagnostics` key. Its fields are `type, projectName, basePath, manifestPath, stats, files, errors, parseIssues, [typecheck], [anchors]` (cli/lib/print-generate-result.ts:42-73). `jq '.diagnostics'` returns `null`; the field that carries per-operation skip/parse information is `parseIssues` (and `errors`). The only `diagnostics` in the file is the nested `typecheck.diagnostics` in the text formatter, not reachable via top-level `.diagnostics`.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'parseIssues: result.parseIssues' cli/lib/print-generate-result.ts && ! grep -qE 'diagnostics: ' cli/lib/print-generate-result.ts"
+    },
+    {
+      "page": "using/how-to/pin-schema-source.md",
+      "claim": "Verify by running `skmtc agent-context --json | jq '.projects[] | select(.name==\"<project>\") | .schema'` \u2014 it should report the configured `source`.",
+      "docLocation": "using/how-to/pin-schema-source.md:58",
+      "evidence": "The agent-context ProjectSnapshot has no `.schema` field. The schema source is exposed as a flat string field named `schemaSource` (cli/lib/agent-context-headless.ts:36 `schemaSource: string | null`, populated at :103), not a nested `.schema` object. The jq selector `.schema` returns null; the correct selector is `.schemaSource`.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'schemaSource: string | null' cli/lib/agent-context-headless.ts && ! grep -qE '^\\s+schema\\??:' cli/lib/agent-context-headless.ts"
+    },
+    {
+      "page": "using/how-to/pin-schema-source.md",
+      "claim": "agent-context should report a recent `lastFetched` timestamp for the project's schema.",
+      "docLocation": "using/how-to/pin-schema-source.md:60",
+      "evidence": "No `lastFetched` field exists anywhere in the CLI. The AgentContext / ProjectSnapshot types (cli/lib/agent-context-headless.ts:33-55) carry no fetch timestamp, and the CLI records no schema-fetch time (grep for `lastFetched` across cli/ matches nothing). The described field cannot appear in the output.",
+      "severity": "error",
+      "verificationCommand": "! grep -rq 'lastFetched' cli/"
+    },
+    {
+      "page": "using/how-to/pin-schema-source.md",
+      "claim": "Troubleshooting quotes CLI error messages \"GET <url> returned 401\" and \"GET <url> returned 404\" for unreachable/auth-gated schema endpoints.",
+      "docLocation": "using/how-to/pin-schema-source.md:64",
+      "evidence": "The remote schema fetch in cli/lib/schema-file.ts:71-72 does `const response = await fetch(schemaSource.url); const contents = await response.text()` with no `response.ok` / `response.status` check. A 401/404 body is passed straight to the schema parser, which fails with a parse error \u2014 the CLI never emits any \"GET <url> returned <status>\" message (the only `returned 404` string in the tree is an unrelated JSR-install test).",
+      "severity": "major",
+      "verificationCommand": "grep -q 'const response = await fetch(schemaSource.url)' cli/lib/schema-file.ts && ! grep -q 'response.ok' cli/lib/schema-file.ts && ! grep -qi 'response.status' cli/lib/schema-file.ts"
+    },
+    {
+      "page": "using/how-to/pin-schema-source.md",
+      "claim": "HTTPS / HTTP URLs are \"auto-detected by `Content-Type` or content sniff\".",
+      "docLocation": "using/how-to/pin-schema-source.md:36",
+      "evidence": "Remote-source format detection (cli/lib/schema-file.ts:84-85, 145-168) is extension-first (`toFileType` on the URL pathname) with a fallback to the response `Content-Type` header. There is no body/content sniffing anywhere in the path; the word 'sniff' does not appear.",
+      "severity": "minor",
+      "verificationCommand": "! grep -rqi 'sniff' cli/lib/schema-file.ts"
+    },
+    {
+      "page": "using/how-to/skip-or-include-operations.md",
+      "claim": "The Verification jq (`.results[][].generate | to_entries[] | { gen: .key, skipped: (.value | to_entries | map(select(.value == \"skipped\")) | map(.key)) }`) is presented as the way to list skipped items per generator.",
+      "docLocation": "using/how-to/skip-or-include-operations.md:108-114",
+      "evidence": "ResultsLog.toTree() builds the tree by splitting each captured key on ':' (core/helpers/ResultsLog.ts:239). The operation trace pushes `${operation.path}:${operation.method}` (core/context/GenerateContext.ts:669) and then `variant: ${variant}` (line 695). So under `.results[traceId][spanId].generate.<genId>` the value nests path \u2192 method \u2192 'variant' \u2192 variantName \u2192 resultString. The jq applies `.value | to_entries | select(.value == \"skipped\")` to the genId value, inspecting only its immediate path-key children whose values are objects, so it never matches the 'skipped' string leaves (which sit ~4 levels deeper) and always returns empty skipped arrays \u2014 misleading the reader into thinking nothing was skipped.",
+      "severity": "major",
+      "verificationCommand": "grep -q 'variant: ${variant}' core/context/GenerateContext.ts && grep -q '${operation.path}:${operation.method}' core/context/GenerateContext.ts && grep -q \"key.split(':')\" core/helpers/ResultsLog.ts"
+    },
+    {
+      "page": "using/how-to/update-a-schema.md",
+      "claim": "The cleanup workflow reads generated file paths from `skmtc generate <project> --json` via `jq -r '.artifacts | keys[]'`, implying the JSON output has an `artifacts` object keyed by path.",
+      "docLocation": "using/how-to/update-a-schema.md:49",
+      "evidence": "The generate --json payload built in cli/lib/print-generate-result.ts (lines 42-73) has no `artifacts` field. The file list is emitted as `files: result.filePaths` \u2014 a flat array of path strings, not an object. `jq -r '.artifacts | keys[]'` errors on null (`.artifacts` is absent), so after.txt is never populated and Option 1's diff/delete step fails. Correct expression is `jq -r '.files[]'`.",
+      "verificationCommand": "grep -q \"artifacts | keys\" docs/using/how-to/update-a-schema.md && ! grep -q \"artifacts\" cli/lib/print-generate-result.ts",
+      "severity": "error"
+    },
+    {
+      "page": "using/how-to/update-a-schema.md",
+      "claim": "`skmtc agent-context --json | jq '.projects[].lastGenerate'` confirms the run was recent and reports the number of artifacts produced.",
+      "docLocation": "using/how-to/update-a-schema.md:71",
+      "evidence": "The AgentContext shape in cli/lib/agent-context-headless.ts defines `ProjectSnapshot = { name, basePath, schemaSource, generators }` (lines 33-43). There is no `lastGenerate` field (nor any timestamp/artifact-count), so the jq filter returns `null` for every project \u2014 it cannot confirm recency or artifact count. agent-context is a passive static snapshot of config, not run history.",
+      "verificationCommand": "grep -q \"lastGenerate\" docs/using/how-to/update-a-schema.md && ! grep -q \"lastGenerate\" cli/lib/agent-context-headless.ts",
+      "severity": "major"
+    },
+    {
+      "page": "using/how-to/update-a-schema.md",
+      "claim": "When output is wildly different, check `manifest.diagnostics` for parse errors on the new spec.",
+      "docLocation": "using/how-to/update-a-schema.md:84",
+      "evidence": "core/types/Manifest.ts has no `diagnostics` field on the manifest. Parse-phase issues are recorded under `parseIssues: ParseIssue[]` (ManifestContent type line 175; valibot schema `manifestContent` line 188). The `.settings/manifest.json` the reader would inspect has `parseIssues`, not `diagnostics`.",
+      "verificationCommand": "grep -q \"manifest.diagnostics\" docs/using/how-to/update-a-schema.md && grep -q \"parseIssues\" core/types/Manifest.ts && ! grep -qE \"diagnostics:\" core/types/Manifest.ts",
+      "severity": "major"
+    },
+    {
+      "page": "using/how-to/use-in-ci-cd.md",
+      "claim": "The post-check jq filter reads generation errors from `.manifest.diagnostics` (array of objects with a `.level` field) in the `--json` output.",
+      "docLocation": "using/how-to/use-in-ci-cd.md:71",
+      "evidence": "The `--json` payload is built in cli/lib/print-generate-result.ts:42-73 and has top-level keys `type`, `projectName`, `basePath`, `manifestPath`, `stats`, `files`, `errors`, `parseIssues` (+ optional `typecheck`, `anchors`). There is no `manifest` object and no `diagnostics` field. `errors` is `result.stats.errors` typed `string[][]` (cli/lib/generationStats.ts:26), not objects with a `.level`. Running the doc's `jq '.manifest.diagnostics | map(...)'` hits `null | map(...)` \u2192 jq errors (\"Cannot iterate over null\"), so the CI gate never actually counts errors.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'manifest.diagnostics' docs/using/how-to/use-in-ci-cd.md && ! grep -q 'manifest' <(node -e 0 2>/dev/null; grep -o 'diagnostics' cli/lib/print-generate-result.ts | head -1) ; grep -q 'manifest.diagnostics' docs/using/how-to/use-in-ci-cd.md"
+    },
+    {
+      "page": "using/how-to/use-in-ci-cd.md",
+      "claim": "The generated manifest lives at `.skmtc/<project>/manifest.json` (used as the upload-artifact path).",
+      "docLocation": "using/how-to/use-in-ci-cd.md:88",
+      "evidence": "Project.toManifestPath() returns `join(this.toPath(), '.settings', 'manifest.json')` (cli/lib/project.ts:258-260), and toPath() resolves to `<root>/.skmtc/<project>` (cli/lib/project.ts:93-95 via to-project-path.ts / to-root-path.ts). The real path is `.skmtc/<project>/.settings/manifest.json`; the doc omits the `.settings/` segment, so the CI upload step points at a non-existent file.",
+      "severity": "major",
+      "verificationCommand": "grep -q '\\.skmtc/<project>/manifest.json' docs/using/how-to/use-in-ci-cd.md && grep -q \"'.settings', 'manifest.json'\" cli/lib/project.ts"
+    },
+    {
+      "page": "using/tutorials/03-customize-with-enrichments.md",
+      "claim": "OAS operation enrichments route as enrichments[generatorId][path][method] \u2014 the Step 2 client.json nests the payload ({title, submitLabel, fields}) directly under the method key (\"post\"/\"put\"), and the prose states the routing path is [generatorId][path][method].",
+      "docLocation": "using/tutorials/03-customize-with-enrichments.md:62-86 (client.json lines 62-78; routing statement line 83)",
+      "evidence": "toOasOperationProjectionBase.ts:130-137 reads subject enrichments with get(context.settings, ['enrichments', config.id, operation.path, operation.method, variant]) \u2014 a FOURTH variant level below method (default 'main'). validateConfig.ts:91-99 walks oasOperation leaves as 'path \u2192 { method: { variant: values } }'. With the doc's config, get(..., '/pet','post','main') resolves to undefined, so no enrichment lands and the Step 4 verification (h2 = 'Add a new pet', submit = 'Add to inventory') fails. Correct shape nests the payload under a variant key, e.g. \"post\": { \"main\": { \"title\": ... } }.",
+      "severity": "error",
+      "verificationCommand": "grep -q 'path \u2192 { method: { variant: values } }' core/enrichments/validateConfig.ts && grep -q 'operation.method,' core/dsl/operation/oas/toOasOperationProjectionBase.ts && grep -q '`\\[generatorId\\]\\[path\\]\\[method\\]`' docs/using/tutorials/03-customize-with-enrichments.md"
+    },
+    {
+      "page": "using/tutorials/03-customize-with-enrichments.md",
+      "claim": "'The toOasOperationProjectionBase factory looks up enrichments[generatorId][operation.path][operation.method] for the current operation.'",
+      "docLocation": "using/tutorials/03-customize-with-enrichments.md:116-118",
+      "evidence": "Same root cause: the actual lookup in toOasOperationProjectionBase.ts:130-137 includes the trailing variant segment, so the described key path is one level short. The factory also parses the full {subject, generator, stack} umbrella (line 142, v.parse(config.toEnrichmentSchema(), raw)), not just 'the result'.",
+      "severity": "error",
+      "verificationCommand": "grep -A7 \"subject: get(context.settings\" core/dsl/operation/oas/toOasOperationProjectionBase.ts | grep -q variant"
+    }
+  ],
+  "gaps": [
+    {
+      "page": "reference/api/content-settings.md",
+      "description": "The Properties section (lines 57-113) documents only `identifier`, `exportPath`, and `enrichments`, omitting a `### variant` subsection. `variant` is one of the four class fields (named in the byline at line 3 and present on the class/constructor) and carries meaningful semantics (the operation-variant axis; `'main'` for variants-unaware Projections). A reference page listing four properties but explaining only three leaves the reader without the variant field's semantics.",
+      "sourceEvidence": "core/dsl/ContentSettings.ts:146-152 declares `variant: string` with a doc comment explaining it carries the variant name threaded from per-operation dispatch, defaulting to `'main'`; core/types/Variant.ts documents the variant axis. The doc's own byline (content-settings.md:3) and constructor (lines 28,33) list `variant` as a field, but the Properties section has no subsection for it."
+    },
+    {
+      "page": "reference/api/core-overview.md",
+      "description": "The page omits the webhook generator family. Core exports `toWebhookEntry` (a Pipeline entry-point factory) and `toWebhookProjectionBase` (a Projection-base factory), plus `WebhookDriver` and `OasWebhook`, but the 'Pipeline entry points' table (only toOasOperationEntry/toModelEntry/toGqlOperationEntry) and the 'Projection bases (factories)' section ('The three factory functions') list only three families. On an index page claiming to cover the entry-point and projection-base surface, the fourth (webhook) family is missing.",
+      "sourceEvidence": "core/dsl/webhook/toWebhookEntry.ts:83 `export const toWebhookEntry`; core/dsl/webhook/toWebhookProjectionBase.ts:95 `export const toWebhookProjectionBase`; core/oas/webhook/Webhook.ts:77 `export class OasWebhook`; all re-exported from core/mod.ts."
+    },
+    {
+      "page": "reference/api/dsl-custom-value.md",
+      "description": "The reference Class block enumerates the public methods (isRef, resolve, toString) but omits `resolveOnce(): CustomValue`, which the source class defines. A reference API page that lists the class's methods should include it.",
+      "sourceEvidence": "core/dsl/CustomValue.ts defines `resolveOnce(): CustomValue { return this }` (lines 66-72), but the string 'resolveOnce' appears nowhere in docs/reference/api/dsl-custom-value.md."
+    },
+    {
+      "page": "reference/api/dsl-definition.md",
+      "description": "The TsDefinition section (fields at lines 46-49, constructor at 51-58) enumerates only `description` and `noExport` as the TS-specific extras, but source also has a third documented field and constructor arg `leadingComment?: string` (a verbatim `//` line comment rendered above the declaration). A reference page listing the class fields/constructor should include it.",
+      "sourceEvidence": "lang-typescript/src/TsDefinition.ts:20 (constructor arg `leadingComment?`), :38 (field `leadingComment: string | undefined`), :61-66 (rendered in toString); also surfaced through defineAndRegister (lang-typescript/src/register.ts:86)."
+    },
+    {
+      "page": "reference/api/generate-context.md",
+      "description": "The page's Class block and Methods section document the cross-generator coordination surface (insertOperation, insertModel, insertNormalizedModel) but omit `insertWebhook(args: InsertWebhookArgs<V, E>): Inserted<V, E>` \u2014 the public OAS-3.1 webhook coordination method that is a direct sibling of insertOperation. Its companion `toWebhookContentSettings` is also omitted. A generator author coordinating with a webhook peer would find no reference for it.",
+      "sourceEvidence": "core/context/GenerateContext.ts:1226 defines `insertWebhook`, and it is part of the GenerateContextType interface (generateTypes.ts:541); the doc never mentions it (grep -c returns 0)."
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "description": "The GqlRegistry class block documents only createRef and toSchemasRefNames, but the class also exposes add(refName, schema), has(refName), and removeSchema(refName). removeSchema participates in the same prune machinery the page discusses.",
+      "sourceEvidence": "core/gql/registry/GqlRegistry.ts:58 (add), :65 (has), :89 (removeSchema)"
+    },
+    {
+      "page": "reference/api/gql-document.md",
+      "description": "The GqlArgument class block omits the `gqlType` member (the captured original GraphQL type string, e.g. 'ID!'), which generators use to reconstruct SDL fragments.",
+      "sourceEvidence": "core/gql/argument/GqlArgument.ts:50 `readonly gqlType: string` (fields type gqlType?: string at :23)"
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "description": "The OasParameter class listing omits `style`, `explode`, `content`, `allowEmptyValue`, and `allowReserved` \u2014 the serialization fields (style/explode especially) that a parameter-emitting generator needs to render query serialization correctly.",
+      "sourceEvidence": "core/oas/parameter/Parameter.ts:213-216 declares `style: OasParameterStyle | undefined` and `explode: boolean | undefined` (plus content/allowEmptyValue/allowReserved), none of which appear in the doc's class block (oas-document-model.md:325-342)."
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "description": "The OasHeader listing omits the `toSchema()` method (and `examples`/`content` fields). Generators reading a response header's type need `header.toSchema()`.",
+      "sourceEvidence": "core/oas/header/Header.ts:105 defines `toSchema(mediaType = 'application/json'): OasSchema | OasRef<'schema'>`; the doc's OasHeader block (oas-document-model.md:358-369) lists only isRef/resolve/resolveOnce."
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "description": "OasResponse omits the `links` property; the doc even states the shape is OasRequestBody 'with the addition of headers', overlooking links.",
+      "sourceEvidence": "core/oas/response/Response.ts:214 declares `links: Record<string, OasLink | OasRef<'link'>> | undefined`, absent from the doc's OasResponse block (oas-document-model.md:305-320)."
+    },
+    {
+      "page": "reference/api/oas-document-model.md",
+      "description": "OasComponents omits the `links` component dictionary from its class listing.",
+      "sourceEvidence": "core/oas/components/Components.ts:348 exposes a `links` getter returning `Record<RefName, OasLink | OasRef<'link'>> | undefined`, not present in the doc's OasComponents block (oas-document-model.md:414-424)."
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "description": "The Class signature and Methods sections omit the public method `isSchemaRef(): this is OasRef<'schema'>`, a type guard narrowing a ref to a schema ref.",
+      "sourceEvidence": "core/oas/ref/Ref.ts:301 `isSchemaRef(): this is OasRef<'schema'> { return this.refType === 'schema' }`"
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "description": "The Class signature and Methods sections omit the public method `traverse(path: SchemaPath): OasSchema | OasRef<'schema'>`, which resolves the ref and descends a schema path (throws for non-schema refs).",
+      "sourceEvidence": "core/oas/ref/Ref.ts:318 `traverse(path: SchemaPath): OasSchema | OasRef<'schema'>`"
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "description": "The Class signature (Getters), Properties, and the `RefFields` type reproduction omit the use-site `nullable` field/getter. `RefFields<T>` has an optional `nullable?: boolean` and OasRef exposes `get nullable(): boolean | undefined`; the getter existing on the prototype makes `'nullable' in ref` always true, which generators rely on.",
+      "sourceEvidence": "core/oas/ref/Ref.ts:56-70 (RefFields.nullable) and Ref.ts:341 `get nullable(): boolean | undefined`"
+    },
+    {
+      "page": "reference/api/oas-ref.md",
+      "description": "The class signature omits that `OasRef` extends `OasBase`, and that the constructor calls `super(context)`. This is why the constructor takes a ParseContext (OasBase supplies context/stackTrail), not a document.",
+      "sourceEvidence": "core/oas/ref/Ref.ts:158 `export class OasRef<T ...> extends OasBase` and Ref.ts:176 `super(context)`"
+    },
+    {
+      "page": "reference/api/parse-context.md",
+      "description": "The Class block enumerates members but omits the public property `currentStackTrail: StackTrail | undefined`, which factories set via withStackTrail so OasBase can snapshot the current trail.",
+      "sourceEvidence": "core/context/ParseContext.ts:114 declares `currentStackTrail: StackTrail | undefined` as a public field with a doc comment (lines 108-114)."
+    },
+    {
+      "page": "reference/api/parse-context.md",
+      "description": "The Class block and Methods section omit the public method `withStackTrail<T>(stackTrail: StackTrail, fn: () => T): T`, which runs fn with currentStackTrail set (try/finally restore).",
+      "sourceEvidence": "core/context/ParseContext.ts:373-381 defines `withStackTrail<T>(stackTrail, fn): T`; it is the mechanism by which currentStackTrail is populated during the walk."
+    },
+    {
+      "page": "reference/api/stack-trail.md",
+      "description": "The ## Class reference block omits the public instance method toSchemaPointer(): JsonPointer, which returns the document-relative JSON Pointer (phase-frame-stripped) used as the schema pointer in the gen-maps/attribution subsystem \u2014 a production feature. A reference page presenting the full class shape should include it.",
+      "sourceEvidence": "core/context/StackTrail.ts:213-224 defines toSchemaPointer(); its JSDoc ties it to gen-maps schema pointers."
+    },
+    {
+      "page": "reference/api/stack-trail.md",
+      "description": "The ## Class block omits toJsonPointer(): JsonPointer, the RFC 6901 JSON Pointer serializer (escapes / and ~) used to attach a location to every parsed OAS schema. It is a distinct public method from toStackRef/toString and is entirely undocumented.",
+      "sourceEvidence": "core/context/StackTrail.ts:179-181 defines toJsonPointer(); JSDoc: 'works for any visitor path \u2014 not just components-rooted references... Used by the gen-maps system'."
+    },
+    {
+      "page": "reference/api/stack-trail.md",
+      "description": "The ## Class block omits the static empty() factory and the isEmpty() instance method, which encode the canonical positionless/synthetic-node trail contract (no parsed OasBase sits at the empty trail).",
+      "sourceEvidence": "core/context/StackTrail.ts:18-25 defines static empty() and isEmpty()."
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "description": "The documented return type is `{ artifacts, manifest }` only, but toArtifacts actually returns `{ artifacts, manifest, sidecars?, generationMap?, inspection? }`. On a reference page describing the signature exhaustively, the three extra return fields (attribution sidecars, generation-map index, inspection snapshot) are omitted.",
+      "sourceEvidence": "core/run/toArtifacts.ts:148-154,189 \u2014 return type and `return { artifacts, manifest, sidecars, generationMap, inspection }`."
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "description": "The documented TransformArgs type omits `attribution?: AttributionState` and `inspect?: boolean`, both real optional fields of the args object.",
+      "sourceEvidence": "core/run/toArtifacts.ts:54-65 \u2014 `attribution?: AttributionState` and `inspect?: boolean` in TransformArgs."
+    },
+    {
+      "page": "reference/api/to-artifacts.md",
+      "description": "The OAS document input type is shown as `{ type: 'oas'; value: OpenAPIV3.Document<Record<string, never>> }` but source intersects `value` with `{ webhooks?: Record<string, OpenAPIV3.PathItemObject> }` to carry retained 3.1 webhooks.",
+      "sourceEvidence": "core/types/SkmtcDocument.ts:79-86 \u2014 oas value is `OpenAPIV3.Document<Record<string, never>> & { webhooks?: ... }`."
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "description": "The real output includes a top-level `commands` array (the entire CLI command surface: name, description, args, flags, agentMode) \u2014 arguably the command's primary purpose ('Print the CLI surface + current SKMTC state for agents'). The page never mentions it.",
+      "sourceEvidence": "AgentContext.commands: CommandDescriptor[] (cli/lib/agent-context-headless.ts:54, populated from COMMAND_DESCRIPTORS); descriptor at cli/lib/cli-schema.ts:301-307 with description 'Print the CLI surface + current SKMTC state for agents'."
+    },
+    {
+      "page": "reference/cli/agent-context.md",
+      "description": "The real output includes top-level `globalStateDir` (~/.skmtc auth/cache dir) and `jsrUrl` (JSR_URL env or https://jsr.io/) keys, both undocumented.",
+      "sourceEvidence": "cli/lib/agent-context-headless.ts:48-52,65-66,71 \u2014 globalStateDir = join(homedir(), '.skmtc'); jsrUrl = Deno.env.get('JSR_URL') ?? 'https://jsr.io/'."
+    },
+    {
+      "page": "reference/cli/create.md",
+      "description": "The \"deno.json imports updated\" section documents only the imports-map mutation, but create also adds the generator to the project deno.json's workspace array (project.rootDenoJson.addWorkspace(this.toPath({relative:true}))). A reference page enumerating create's deno.json effects omits the workspace mutation.",
+      "sourceEvidence": "cli/lib/generator.ts:117-118 \u2014 add() calls both addImport(...) and addWorkspace(this.toPath({relative:true})) on project.rootDenoJson."
+    },
+    {
+      "page": "reference/cli/describe.md",
+      "description": "The page never documents the required precondition that the project must be bundled first. If no bundle.js exists, describe exits 1 with the message `Error: no bundle for \"<project>\". Run \\`skmtc bundle <project>\\` first ...`. This exit-1 precondition failure is a distinct, common outcome absent from both the Arguments and Output sections.",
+      "sourceEvidence": "cli/commands/describe.ts:62-69 \u2014 existsSync(toBundleFsPath(...)) guard, console.error with the bundle hint, then Deno.exit(1)."
+    },
+    {
+      "page": "reference/cli/describe.md",
+      "description": "The Output section lists only three categories (supported subjects, enrichment descriptors, enrichment defaults) but the actual result \u2014 and the `--json` object \u2014 also carries a fourth field, `parseIssues`, and the text output prints a `(N parse issue(s))` line. parseIssues is undocumented.",
+      "sourceEvidence": "cli/lib/describe-worker.ts:16-21 DescribeResponse includes `parseIssues: ParseIssue[]`; cli/commands/describe.ts:121 JSON-stringifies the whole result and lines 138-140 print the parse-issue count in text mode."
+    },
+    {
+      "page": "reference/cli/dev.md",
+      "description": "The page does not state that dev requires a LOCAL project; running it against a remote-only project fails immediately.",
+      "sourceEvidence": "cli/commands/dev.ts:38-39: `invariant(project instanceof Project, \\`Project \"${projectName}\" must be a local project\\`)` throws before any bundle/watch work, exiting 1."
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "description": "The reference page (which claims an exhaustive check enumeration) entirely omits the project-worker-pin/<project> check, which verifies the project's deno.json pins @skmtc/worker so the generated worker.ts will bundle.",
+      "sourceEvidence": "cli/lib/doctor-headless.ts:558-604 (checkProjectWorkerPin, id `project-worker-pin/${projectName}`), pushed at line 257."
+    },
+    {
+      "page": "reference/cli/doctor.md",
+      "description": "The page omits the three gen-maps/anchors per-project checks (anchors-config, anchors-coverage, anchors-staleness) that run for every project.",
+      "sourceEvidence": "cli/lib/doctor-headless.ts:262-264 push checkAnchorsConfig/Coverage/Staleness; IDs anchors-config/anchors-coverage/anchors-staleness defined in cli/lib/doctor-anchors.ts."
+    },
+    {
+      "page": "reference/cli/generate.md",
+      "description": "The `--json` output section and its field reference (lines 158-232) omit the `anchors` object that the CLI emits into the JSON payload whenever the gen-maps post-pass ran (i.e. when `--anchors` / config enable it \u2014 the page documents that flag prominently). The emitted object is `anchors: { enabled, outDir, filesWritten, totalBytes, generationMapEntries }`. A reference page documenting the stdout JSON shape should list this field, since its presence is the documented signal that attribution output was written.",
+      "sourceEvidence": "cli/lib/print-generate-result.ts:62-72 spreads `anchors: { enabled: true, outDir, filesWritten, totalBytes, generationMapEntries }` into the JSON payload when `result.anchors` is set; `grep generationMapEntries docs/reference/cli/generate.md` returns nothing."
+    },
+    {
+      "page": "reference/cli/project.md",
+      "description": "The 'JSON output' example for a successful `created` result omits three fields that source always/optionally emits at the top level: `projectName` (always present) and `origin` (always present), plus the optional `baseFilesPushed` (emitted when `--base-files` seeds files). A reader scripting against the documented shape would not know these fields exist.",
+      "sourceEvidence": "cli/lib/project-headless.ts:71-86 \u2014 CreateResult 'created' variant includes `projectName`, `origin`, and `baseFilesPushed?` alongside the documented `project`, `stack`, `api`, `apiRegistered`, `enrichmentCount`, `remoteWritten`, `url`. The JSON block at docs/reference/cli/project.md:51-62 lists only the latter set."
+    },
+    {
+      "page": "reference/cli/publish.md",
+      "description": "The 'What gets uploaded \u2192 Source tree' section presents a fixed exclusion list as complete but never mentions the project's optional `.skmtcignore` (gitignore-syntax) file \u2014 the primary user-facing lever for controlling what publish uploads. It layers over the built-in defaults, can re-include a default-excluded file via `!pattern`, and `skmtc init` seeds one into new projects (SKMTCIGNORE_TEMPLATE). A reader wanting to exclude (or force-include) a file has no way to discover this from the page.",
+      "sourceEvidence": "cli/lib/source-upload.ts:83-103 (SKMTC_IGNORE_FILE = '.skmtcignore', SKMTCIGNORE_TEMPLATE seed) and toUploadFilter (lines 143-151) which adds the project's .skmtcignore over DEFAULT_IGNORE; the doc contains zero occurrences of 'skmtcignore'."
+    },
+    {
+      "page": "reference/glossary.md",
+      "description": "The page omits the entire OpenAPI 3.1 webhook subject, though it enumerates the parallel constructs for operations/models. Source has a webhook entry factory (core/dsl/webhook/toWebhookEntry.ts), a WebhookGeneratorKey shape with format `generatorId|webhook|name|method|variant` (core/dsl/GeneratorKeys.ts:169,340), a WebhookSource variant in the Preview union (core/types/Preview.ts:127), and webhook enrichment routing `enrichments[id][name][method]` (core/dsl/webhook/types.ts:30). The Generator, Generator key, Preview, and Enrichment entries all present the operation/model/gql triad without the webhook peer.",
+      "sourceEvidence": "core/dsl/webhook/toWebhookEntry.ts; core/dsl/GeneratorKeys.ts:169; core/types/Preview.ts:127 (`OasOperationSource | WebhookSource | GqlOperationSource | ModelSource`); core/dsl/webhook/types.ts:30"
+    },
+    {
+      "page": "reference/settings/enrichments-shape.md",
+      "description": "The page claims exhaustiveness ('There are three' routing shapes) but documents only the per-subject lookup and omits the other two scopes each factory actually reads and assembles into the enrichment umbrella: the generator scope at [generatorId]['_generator'] (GENERATOR_ENRICHMENT_KEY) and the stack scope at ['_stack'] (STACK_ENRICHMENT_KEY). These are reserved top-level/slot keys (core/types/Enrichments.ts:128,136) present in every factory and surfaced to generators as this.settings.enrichments.generator / .stack \u2014 a reader configuring _generator/_stack enrichments has no routing documentation.",
+      "sourceEvidence": "core/dsl/operation/oas/toOasOperationProjectionBase.ts:138-139, core/dsl/model/toModelProjectionBase.ts:139-140, core/dsl/operation/gql/toGqlOperationProjectionBase.ts:126-127 all read `generator: get(context.settings, ['enrichments', config.id, GENERATOR_ENRICHMENT_KEY])` and `stack: get(context.settings, ['enrichments', STACK_ENRICHMENT_KEY])`; keys defined at core/types/Enrichments.ts:128 ('_stack') and :136 ('_generator')."
+    },
+    {
+      "page": "reference/settings/source-resolution.md",
+      "description": "The '.graphqls' extension is a supported GraphQL SDL extension but the reference page's format list omits it (lists only .graphql/.gql).",
+      "sourceEvidence": "cli/lib/schema-file.ts:117-120 recognizes '.graphql', '.gql', and '.graphqls'; the error at line 124 lists all three."
+    },
+    {
+      "page": "reference/stock-generators/README.md",
+      "description": "The catalog omits @skmtc/gen-daisyui-form (\"DaisyUI Form\"), a shipped stock generator. The page declares its scope as \"the generators shipped under @skmtc/gen-*\" and lists 12 generators, but gen-daisyui-form is a published, shipped generator missing from the table (and has no corresponding gen-daisyui-form.md reference page). A reader looking for the full set of stock generators would not find it here.",
+      "sourceEvidence": "skmtc-generators/README.md lists gen-daisyui-form with status \"\ud83d\ude80 Now\" alongside the other 12 catalog entries; skmtc-generators/gen-daisyui-form/deno.json declares name \"@skmtc/gen-daisyui-form\" version 0.3.0 (same maturity as the gen-shadcn-* entries at 0.3.1). No gen-daisyui-form.md exists in docs/reference/stock-generators/."
+    },
+    {
+      "page": "reference/stock-generators/gen-tanstack-query-fetch-zod.md",
+      "description": "The page states \"GET \u2192 useQuery\" as the whole GET story, but list-returning GETs are dispatched to a separate PaginatedQueryEndpoint that emits `useQuery` with `placeholderData: keepPreviousData` (imported alongside `useQuery` from `@tanstack/react-query`). List detection is `isListResponse(operation)` (object-typed array items). This third dispatch branch is a documented Key-decision-level behavior omitted from the page.",
+      "sourceEvidence": "TanstackQuery.ts: `isListResponse(operation) ? new PaginatedQueryEndpoint(...) : new QueryEndpoint(...)`; PaginatedQueryEndpoint.ts registers `['useQuery', 'keepPreviousData']` and emits `placeholderData: keepPreviousData`; listFns.ts defines isListResponse."
+    },
+    {
+      "page": "skills/skmtc-lang-typescript/SKILL.md",
+      "description": "The \u00a71 exports table lists model/oasOperation/gqlOperation projection-base veneers but omits `toTsWebhookProjectionBase`, a full fourth projection-base flavour (webhooks). A reader authoring a webhook generator against this reference-style export table would not learn it exists.",
+      "sourceEvidence": "lang-typescript/mod.ts:52 exports `toTsWebhookProjectionBase` from './src/toTsWebhookProjectionBase.ts'; the doc never mentions it."
+    },
+    {
+      "page": "skills/skmtc-lang-typescript/SKILL.md",
+      "description": "The identifier-factory / entity-kind surface has grown but the page only documents `createVariable` / `createType`. Omitted: the factories `createClass` / `createInterface` / `createNamespace`, the vocabulary helpers `toTsEntityType` / `isTsEntityType` / `isBlockType` / `isTypeOnly`, and the whole class-authoring family `TsClass` / `TsProperty` / `TsMethod` / `TsConstructor` / `TsHeritage` / `TsIdentifier`.",
+      "sourceEvidence": "mod.ts:59-71 exports TsClass/TsProperty/TsMethod/TsConstructor/TsHeritage/TsIdentifier; mod.ts:84-99 exports createClass/createInterface/createNamespace/toTsEntityType/isTsEntityType/isBlockType/isTypeOnly; createIdentifier.ts:111-150,170-211 define them."
+    },
+    {
+      "page": "using/how-to/update-a-schema.md",
+      "description": "The page's declared task is cleaning up artifacts for operations/models the new spec no longer contains, yet it offers only two manual approaches (fragile jq diff, or `rm -rf src/generated/`) and never mentions the first-class `skmtc clean <project>` command, which is designed for exactly this. Run BEFORE regenerating, `skmtc clean` deletes every file recorded in the current manifest and prunes emptied directories (with a `--dry-run` preview), giving a scoped, safer equivalent of Option 2 that doesn't require hardcoding `src/generated/`.",
+      "sourceEvidence": "cli/commands/clean.ts documents clean as deleting 'every generated file a project's manifest recorded, prunes the directories that held them, then removes the manifest itself' and supports `--dry-run`/`--json`; cli/lib/cli-schema.ts lists it as a top-level command."
+    }
+  ]
+}

--- a/deno/docs/friction-log/docs-remediation-tracker.md
+++ b/deno/docs/friction-log/docs-remediation-tracker.md
@@ -1,0 +1,82 @@
+# Docs remediation tracker
+
+Living ledger for the docs-vs-source cleanup kicked off by the
+[2026-07-07 audit](2026-07-07-docs-vs-source-audit.md). **Any session
+can resume from this file.** Update it as work lands — tick items,
+record PRs, note what's in flight.
+
+Companion state that also survives across sessions:
+
+- Raw audit findings: `2026-07-07-docs-vs-source-audit-findings.json`
+  (195 discrepancies + 53 gaps from the partial run).
+- Re-audit findings (the 90 unaudited pages):
+  `docs-remediation-reaudit-findings.json` (written when that run
+  completes; absent until then).
+- Mechanical guards that prevent *new* drift: `docs/verify-docs.ts`
+  (source↔doc sync checks) and `docs/doc-test.ts` (fenced-block
+  compile), both wired into `deno task verify-docs`.
+
+## How to work an item (the loop)
+
+1. **Verify against source first** — do not trust an audit finding.
+   The audit was wrong more than once (e.g. `insertOperation` is
+   object-arg only on `context.`; the projection-base
+   `this.insertOperation(proj, op)` is positional and correct). Read
+   `core/` before editing.
+2. **Fix tree-wide, not page-by-page** — grep the whole `docs/` tree
+   for the bad pattern; systematic issues recur on pages the audit
+   never listed.
+3. **Gate**: `cd deno && deno task verify-docs` must stay green.
+4. **One PR per cluster** (or per coherent batch); update this file
+   with the PR number; commit the tracker change with the work.
+
+## Systematic clusters (pre-0.8 API drift) — DONE
+
+All six verified against source and fixed.
+
+- [x] `acc`/`reduce` removed from `transform` — PR #45 (merged)
+- [x] `insert*` arg shapes + return types — PR #47 (merged)
+- [x] Enrichment three-scope umbrella model — PR #47 (merged)
+- [x] Bundle behavior + `worker.ts` template — PR #48 (merged)
+- [x] Attribution / gen-maps rewrite (+ architecture skill) — PR #48 (merged)
+
+Lesson banked: the skills / `llms.md` / canonical concept pages were
+already correct on clusters 1–3 (drift was in authoring
+how-tos/tutorials/recipes); attribution was the exception (skill wrong
+too).
+
+## Re-audit of the 90 unaudited pages — IN PROGRESS
+
+The original audit reached only 36 of 126 pages (credits ran out). An
+**audit-only** re-run (no adversarial verify phase — findings are
+verified by hand during triage) covers the rest. Page list:
+`scratchpad/unaudited.json` at run time; the 90 are the complement of
+the 36 in the original findings JSON.
+
+- [ ] Re-audit run complete → findings in
+      `docs-remediation-reaudit-findings.json`
+- [ ] Re-audit findings triaged + fixed (verify-first, tree-wide)
+
+Workflow resume: the audit workflow supports `resumeFromRunId`
+(cached agents replay). Script + runId are recorded in the run's
+tool result; if lost, re-run fresh over the pages still lacking a
+result line in the run journal.
+
+## Long tail from the original audit — NOT STARTED
+
+- [ ] 113 lower-severity "misc" findings (per-item triage) —
+      `2026-07-07-docs-vs-source-audit-findings.json`, `uncertain[]`
+      minus the systematic clusters already fixed
+- [ ] 53 gaps (per-item triage) — same file, `gaps[]`
+
+Many of these are on pages the systematic tree-wide sweeps already
+touched; re-verify each against current source before acting (some are
+already resolved, some were audit false positives).
+
+## Definition of done
+
+The corpus is "done" for a pass when: every page has been audited once
+against current source; every confirmed discrepancy is fixed or logged
+here with a reason; `deno task verify-docs` is green; and the
+mechanical guards cover the systematic patterns so they cannot silently
+return.


### PR DESCRIPTION
A committed, resumable ledger for the multi-session docs-vs-source cleanup — so it survives session boundaries. Records the six fixed clusters, the in-progress 90-page re-audit, the untriaged long tail, the work loop, and the definition of done. Complements the memory note and the audit report.