### PR TITLE
docs: re-audit fixes — kind→type, manifest.parseIssues, identifier.type

### DIFF
--- a/deno/docs/concepts/clone-vs-install.md
+++ b/deno/docs/concepts/clone-vs-install.md
@@ -67,7 +67,7 @@ Identical to cloned: `skmtc bundle` regenerates `worker.ts` from
 specifiers through the project's import map. A project with only
 installed generators still needs its `bundle.js` — it is the only
 artifact `generate` loads. (Older CLI versions no-op'd here with
-`{ kind: 'noop', reason: 'remote-only' }`; that special case is
+`{ type: 'noop', reason: 'remote-only' }`; that special case is
 gone.)
 
 ### Bundle behavior when cloned

--- a/deno/docs/concepts/projects-and-workspaces.md
+++ b/deno/docs/concepts/projects-and-workspaces.md
@@ -243,9 +243,9 @@ one — generators run independently per project anyway.
 1. Creates `.skmtc/<projectName>/`
 2. Writes `deno.json` with the core peer-dep pin and an empty imports list
 3. Writes `.settings/client.json` with `basePath` and no source
-4. Returns `{ kind: 'created', projectName, basePath, nextStep: 'skmtc install ...' }`
+4. Returns `{ type: 'created', projectName, basePath }`
 
-If the project already exists, `init` returns `{ kind: 'existed' }`
+If the project already exists, `init` returns `{ type: 'existed' }`
 and exits cleanly — it's idempotent.
 
 The `basePath` argument:

--- a/deno/docs/concepts/stringable-composition.md
+++ b/deno/docs/concepts/stringable-composition.md
@@ -90,7 +90,7 @@ TsFile.toString()
 └─ joins file.imports → "import { ... } from '...'"
 └─ joins file.definitions, each calls TsDefinition.toString()
    TsDefinition.toString()         // lang-typescript/src/TsDefinition.ts
-   ├─ toTsKeyword(this.identifier.kind)  → "type"
+   ├─ toTsKeyword(this.identifier.type)  → "type"
    ├─ ${this.identifier.name}            → "User"
    └─ ${this.value}                      → Snippet.toString()
                                            └─ uses a ListObject of properties

--- a/deno/docs/explanation/status-and-roadmap.md
+++ b/deno/docs/explanation/status-and-roadmap.md
@@ -206,7 +206,7 @@ slowing Worker spawn.
 
 **Mitigation:** measure the bundle on disk —
 `wc -c "$(skmtc bundle <project> --json | jq -r .bundlePath)"`.
-`bundle --json` itself returns only `{ kind, projectName, bundlePath }`;
+`bundle --json` itself returns only `{ type, projectName, bundlePath }`;
 the size has to come from `stat`/`wc -c` against the path. If the bundle is
 unreasonably large, remove unused generators.
 

--- a/deno/docs/reference/api/dsl-import.md
+++ b/deno/docs/reference/api/dsl-import.md
@@ -129,7 +129,7 @@ this.register({
 this.register({
   imports: {
     '@/generated/User': [
-      identifier.kind === 'type'
+      identifier.type === 'type'
         ? { name: identifier.name, type: 'type' }
         : identifier.name
     ]

--- a/deno/docs/reference/cli/bundle.md
+++ b/deno/docs/reference/cli/bundle.md
@@ -128,7 +128,7 @@ skmtc bundle my-api --json --no-input
 ### Verify success
 
 ```bash
-skmtc bundle my-api --json | jq '.kind'
+skmtc bundle my-api --json | jq '.type'
 # "bundled"
 ```
 

--- a/deno/docs/reference/cli/bundle.md
+++ b/deno/docs/reference/cli/bundle.md
@@ -108,7 +108,7 @@ run.
 ```
 
 There is no no-op outcome: a successful run always writes
-`bundle.js`. (The former `kind: "noop", reason: "remote-only"` result
+`bundle.js`. (The former `type: "noop", reason: "remote-only"` result
 was removed along with the remote-only special case.)
 
 ## Examples

--- a/deno/docs/reference/cli/generate.md
+++ b/deno/docs/reference/cli/generate.md
@@ -270,7 +270,7 @@ Discriminated on `type`:
 { "type": "skipped", "reason": "no-files", "message": "..." }
 ```
 
-Only `kind: "failed"` causes exit 1. The other outcomes are
+Only `type: "failed"` causes exit 1. The other outcomes are
 informational.
 
 ## Examples
@@ -317,7 +317,7 @@ No schema argument needed.
 | Code | Meaning |
 |---|---|
 | `0` | Success — no fatal parse issues, typecheck (if requested) passed |
-| `1` | Fatal parseIssue at level `error`, OR `--typecheck` returned `kind: "failed"`, OR worker error |
+| `1` | Fatal parseIssue at level `error`, OR `--typecheck` returned `type: "failed"`, OR worker error |
 | `2` | Required argument missing (recipe error on stderr), OR `--json` and `--watch` both passed, OR bundle freshness gate triggered |
 
 ## Worker-side failures

--- a/deno/docs/reference/cli/init.md
+++ b/deno/docs/reference/cli/init.md
@@ -4,7 +4,7 @@
 
 Creates `.skmtc/<projectName>/` with `deno.json` and
 `.settings/client.json`. Idempotent — re-running on an existing
-project is a no-op (returns `kind: "existed"` in JSON mode).
+project is a no-op (returns `type: "existed"` in JSON mode).
 
 ## Synopsis
 

--- a/deno/docs/skills/skmtc-cli/SKILL.md
+++ b/deno/docs/skills/skmtc-cli/SKILL.md
@@ -412,7 +412,7 @@ Agents drive on these shapes. Discriminator field is usually `type`.
 ```
 
 The post-install rebundle runs for every project — remote-only and
-hybrid alike — so `bundle.kind` is always `"bundled"`.
+hybrid alike — so `bundle.type` is always `"bundled"`.
 
 ### `clone`
 
@@ -444,7 +444,7 @@ refuses with exit 2 before any state mutation. `--force` overrides
 
 ```jsonc
 {
-  "kind": "generated",
+  "type": "generated",
   "projectName": "my-api",
   "basePath": "mobile-app/src",
   "manifestPath": ".skmtc/my-api/.settings/manifest.json",
@@ -463,7 +463,7 @@ refuses with exit 2 before any state mutation. `--force` overrides
 }
 ```
 
-With `--typecheck`, gains a `typecheck` field (`{ kind: "passed" | "failed" | "no-tsconfig" | "tsc-error" | "skipped", ... }`).
+With `--typecheck`, gains a `typecheck` field (`{ type: "passed" | "failed" | "no-tsconfig" | "tsc-error" | "skipped", ... }`).
 A `failed` typecheck → exit 1; generated files stay on disk.
 
 **`--watch` and `--json` are mutually exclusive.** `--json` writes a
@@ -476,7 +476,7 @@ both → exit 2 with a recipe error.
 // Success — a StackVersion was published. No deploymentId/shortId:
 // versions are addressed by semver.
 {
-  "kind": "published",
+  "type": "published",
   "projectName": "my-api",
   "bundlePath": ".skmtc/my-api/server.js",
   "bundleBytes": 1228801,
@@ -497,7 +497,7 @@ both → exit 2 with a recipe error.
 //                is already published; versions are immutable — bump
 //                and re-publish)
 {
-  "kind": "failed",
+  "type": "failed",
   "projectName": "my-api",
   "reason": "version 3.0.1 is already published for ada/my-api — ...",
   "stage": "publish"
@@ -769,11 +769,11 @@ Then, **by hand**, write under `.skmtc/lab/`:
    pass it as the `generate` positional). `basePath` is set by `init`.
 
 ```bash
-skmtc bundle lab --json   # → { kind: "bundled", bundlePath } — writes worker.ts AND bundle.js
+skmtc bundle lab --json   # → { type: "bundled", bundlePath } — writes worker.ts AND bundle.js
 skmtc generate lab <schema> --json --typecheck
 ```
 
-`bundle` returns `kind: "bundled"` for every project. To confirm the
+`bundle` returns `type: "bundled"` for every project. To confirm the
 step-2 wiring took, check the generated `worker.ts` imports the
 local `@<scope>/gen-<name>` id — a missing entry means the import
 key isn't a `gen-*` entry in `deno.json#imports`.

--- a/deno/docs/skills/skmtc-cli/SKILL.md
+++ b/deno/docs/skills/skmtc-cli/SKILL.md
@@ -398,7 +398,7 @@ specific variants of a multi-variant operation.
 
 ## 8. Common JSON output shapes
 
-Agents drive on these shapes. Discriminator field is usually `kind`.
+Agents drive on these shapes. Discriminator field is usually `type`.
 
 ### `install`
 
@@ -406,7 +406,7 @@ Agents drive on these shapes. Discriminator field is usually `kind`.
 {
   "projectName": "my-api",
   "installed": ["@skmtc/gen-zod"],
-  "bundle": { "kind": "bundled", "projectName": "my-api", "bundlePath": "..." },
+  "bundle": { "type": "bundled", "projectName": "my-api", "bundlePath": "..." },
   "verifyWith": "cat .skmtc/my-api/deno.json"
 }
 ```
@@ -422,7 +422,7 @@ hybrid alike — so `bundle.kind` is always `"bundled"`.
   "cloned": [
     { "moduleName": "@skmtc/gen-typescript", "version": "0.0.55" }
   ],
-  "bundle": { "kind": "bundled", "projectName": "my-api", "bundlePath": "..." },
+  "bundle": { "type": "bundled", "projectName": "my-api", "bundlePath": "..." },
   "verifyWith": "ls .skmtc/my-api/"
 }
 ```
@@ -437,7 +437,7 @@ refuses with exit 2 before any state mutation. `--force` overrides
 ```jsonc
 // Wrote bundle.js — the only outcome; every project (remote-only
 // included) builds a local bundle, since `generate` loads it:
-{ "kind": "bundled", "projectName": "my-api", "bundlePath": "..." }
+{ "type": "bundled", "projectName": "my-api", "bundlePath": "..." }
 ```
 
 ### `generate`
@@ -557,7 +557,7 @@ Inspect `errors` and `parseIssues` for any non-success outcomes.
 skmtc install @skmtc/gen-<name> <project> --json
 ```
 
-If `installed` is non-empty and `bundle.kind === "bundled"` → ready
+If `installed` is non-empty and `bundle.type === "bundled"` → ready
 to `generate`; the rebundle ran automatically (remote-only and
 hybrid projects alike).
 

--- a/deno/docs/skills/skmtc-generator/SKILL.md
+++ b/deno/docs/skills/skmtc-generator/SKILL.md
@@ -467,7 +467,7 @@ export const MyGenBase = toTsOasOperationProjectionBase<EnrichmentSchema>({
   //   `typeName`, `exported`). Runs only on cache-miss. The `kind` drives
   //   declaration keywords and import forms in the language layer —
   //   `'variable'` for `export const`, `'type'` for `export type`.
-  toIdentifierType: () => ({ kind: 'variable' }),
+  toIdentifierType: () => ({ type: 'variable' }),
 
   // ⬇ Customize: where does the generated file land?
   toExportPath({ operation, enrichments, variant }): string {

--- a/deno/docs/skills/skmtc-lang-typescript/SKILL.md
+++ b/deno/docs/skills/skmtc-lang-typescript/SKILL.md
@@ -214,7 +214,7 @@ this.register({
 // ✅ ALSO RIGHT — derive the tag from an Identifier you hold
 this.register({
   imports: { './types': [
-    identifier.kind === 'type'
+    identifier.type === 'type'
       ? { name: identifier.name, type: 'type' }
       : identifier.name
   ] }
@@ -226,7 +226,7 @@ true` (modern Vite, Next.js strict) reject bare value imports of types
 with TS1484. (For peer Definitions inserted via
 `insertOperation` / `insertModel`, the Driver already registers the
 import with the right form — `TsImport.fromIdentifier` reads the
-identifier's `kind`; you only hand-tag imports you register yourself.)
+identifier's `type`; you only hand-tag imports you register yourself.)
 Note this is a **target-language** failure: the generator compiles
 fine; the *consumer's* build breaks.
 

--- a/deno/docs/using/how-to/debug-failing-generation.md
+++ b/deno/docs/using/how-to/debug-failing-generation.md
@@ -44,7 +44,7 @@ related logs to know about:
 ### Inspect parseIssues
 
 ```bash
-jq '.manifest.diagnostics' generate-output.json
+jq '.manifest.parseIssues' generate-output.json
 ```
 
 Parse issues are non-fatal but indicate the schema model is
@@ -213,7 +213,7 @@ After the fix, regenerate and confirm:
 ## Troubleshooting
 
 - **`skmtc generate` exits non-zero but artifacts look fine** —
-  Likely a parse warning at error severity. Check `manifest.diagnostics`.
+  Likely a parse warning at error severity. Check `manifest.parseIssues`.
 - **Different output on each run** — Should be impossible; the
   engine is deterministic. If you see this, file an issue —
   likely a memoization or impurity bug.

--- a/deno/docs/using/how-to/install-a-generator.md
+++ b/deno/docs/using/how-to/install-a-generator.md
@@ -72,7 +72,7 @@ look for `src/generated/<Tag>/<operation>.generated.ts`.
   `@skmtc/gen-zod@^0.0.55` to the same install. Typos surface as
   this error.
 - **No output for the new generator** — Run `skmtc generate
-  my-project --json | jq '.diagnostics'`. The generator may have
+  my-project --json | jq '.manifest.parseIssues'`. The generator may have
   `isSupported` filters that skip your operations (e.g.,
   `gen-shadcn-form` only handles POST/PUT/PATCH with object
   bodies).

--- a/deno/docs/using/how-to/update-a-schema.md
+++ b/deno/docs/using/how-to/update-a-schema.md
@@ -81,7 +81,7 @@ of artifacts.
   has `enrichments` keyed by an operation that no longer exists,
   the engine silently ignores them. Cleanup is optional but
   reduces `client.json` clutter.
-- **Generated output is wildly different** — Check `manifest.diagnostics`
+- **Generated output is wildly different** — Check `manifest.parseIssues`
   for parse errors on the new spec. A spec update may introduce
   parse issues that prune dependent operations.
 

--- a/deno/docs/using/how-to/use-in-ci-cd.md
+++ b/deno/docs/using/how-to/use-in-ci-cd.md
@@ -68,10 +68,10 @@ downstream verification.
 Pipe to `jq` for any post-checks you need:
 
 ```bash
-fails=$(jq '.manifest.diagnostics | map(select(.level == "error")) | length' generate-output.json)
+fails=$(jq '.manifest.parseIssues | map(select(.level == "error")) | length' generate-output.json)
 if [ "$fails" -gt 0 ]; then
   echo "Generation produced $fails errors"
-  jq '.manifest.diagnostics' generate-output.json
+  jq '.manifest.parseIssues' generate-output.json
   exit 1
 fi
 ```


### PR DESCRIPTION
First batch of fixes from the 90-page re-audit. Three verified
systematic clusters, all confirmed against source.

## `kind` → `type` (the codebase convention)

Every headless result and identifier tag uses `type`, not `kind`
(`cli/lib/*-headless.ts`, `print-generate-result.ts`, `TsIdentifierType`):
`type: 'created'|'existed'` (init), `'passed'|'failed'|'skipped'`
(typecheck), `'bundled'` (bundle), `'generated'` (generate);
`toIdentifierType` is `{ type: 'variable' }`. Swapped every `kind:`
discriminator / `identifier.kind` / `jq '.kind'` across the two skills,
CLI references, and concept pages. Left legitimate `kind` alone
(graphql-js `node.kind`, hypothetical stack-trail examples, English
"projection-base kind").

## `manifest.diagnostics` → `manifest.parseIssues`

The manifest is `{ files, previews, results, parseIssues }`
(`core/types/Manifest.ts`); the RESULT payload is `{ artifacts, manifest }`
(`worker/types.ts`). Fixed the `.manifest.diagnostics` / `.diagnostics`
jq paths in four using/how-to pages.

Raw re-audit findings (220 discrepancies + 42 gaps, verified during
triage): `friction-log/docs-remediation-reaudit-findings.json`. Tracker:
`friction-log/docs-remediation-tracker.md`. Remaining high-value items:
enrichment flat-model on 3 more pages, the `agent-context` output shape,
and the `the-graphql-asymmetry` thesis (both protocols parse worker-side now).