### PR TITLE
docs: enrichment umbrella/variant on the last flat-model pages

### DIFF
--- a/deno/docs/concepts/variants.md
+++ b/deno/docs/concepts/variants.md
@@ -188,7 +188,7 @@ under `gen-shadcn-form`:
    a 4-segment string with the variant as the trailing segment.
 
 The model arm is structurally identical with two substitutions:
-`#runModelGenerator` reads `enrichments[id][refName]`,
+`#runModelGenerator` reads `enrichments[id][refName][variant]`,
 `context.toModelContentSettings({refName, projection, variant})`
 builds the settings, and the registered `generatorKey` is
 `toModelGeneratorKey({generatorId, refName, variant})` — a 3-segment

--- a/deno/docs/reference/settings/enrichments-shape.md
+++ b/deno/docs/reference/settings/enrichments-shape.md
@@ -21,23 +21,26 @@ There are three:
 Source: `core/dsl/operation/oas/toOasOperationProjectionBase.ts`:
 
 ```ts
-get(context.settings, `enrichments.${config.id}.${operation.path}.${operation.method}`)
+get(context.settings, ['enrichments', config.id, operation.path, operation.method, variant])
 ```
 
-Three levels:
+Four levels — the subject leaf sits under a trailing `variant` key:
 
 ```
 enrichments
-  └── [generatorId]      e.g., "@skmtc/gen-shadcn-form"
-       └── [path]        e.g., "/customers" or "/orders/{id}"
-            └── [method] e.g., "post", "get", "put"
-                 └── { ...enrichment payload }
+  └── [generatorId]       e.g., "@skmtc/gen-shadcn-form"
+       └── [path]         e.g., "/customers" or "/orders/{id}"
+            └── [method]  e.g., "post", "get", "put"
+                 └── [variant]  "main" by default
+                      └── { ...subject leaf }
 ```
 
 `path` is the literal OpenAPI path string (including curly-brace
-parameters). `method` is the lowercase HTTP verb.
+parameters). `method` is the lowercase HTTP verb. `variant` is
+`"main"` unless the generator declares extra variants (and `"main"`
+must be present whenever any variant is).
 
-Example `client.json` fragment. The leaf payload's internal shape
+Example `client.json` fragment. The subject leaf's internal shape
 is defined by the generator's Valibot schema:
 
 ```jsonc
@@ -46,10 +49,14 @@ is defined by the generator's Valibot schema:
     "enrichments": {
       "@skmtc/gen-shadcn-form": {
         "/customers": {
-          "post": { "title": "Create Customer", "submitLabel": "Save" }
+          "post": {
+            "main": { "title": "Create Customer", "submitLabel": "Save" }
+          }
         },
         "/orders/{id}": {
-          "put":  { "title": "Edit Order",      "submitLabel": "Update" }
+          "put": {
+            "main": { "title": "Edit Order", "submitLabel": "Update" }
+          }
         }
       }
     }
@@ -119,17 +126,18 @@ Example (multi-variant — variants-aware model generator):
 Source: `core/dsl/operation/gql/toGqlOperationProjectionBase.ts`:
 
 ```ts
-get(context.settings, `enrichments.${config.id}.${operation.rootKind}.${operation.fieldName}`)
+get(context.settings, ['enrichments', config.id, operation.rootKind, operation.fieldName, variant])
 ```
 
-Three levels:
+Four levels — the subject leaf sits under a trailing `variant` key:
 
 ```
 enrichments
-  └── [generatorId]      e.g., "@skmtc/gen-graphql-x"
-       └── [rootKind]    "Query" | "Mutation" | "Subscription"
+  └── [generatorId]       e.g., "@skmtc/gen-graphql-x"
+       └── [rootKind]     "query" | "mutation" | "subscription" (lowercase)
             └── [fieldName]
-                 └── { ...enrichment payload }
+                 └── [variant]  "main" by default
+                      └── { ...subject leaf }
 ```
 
 Example:
@@ -139,11 +147,11 @@ Example:
   "settings": {
     "enrichments": {
       "@skmtc/gen-graphql-x": {
-        "Mutation": {
-          "createUser": { "title": "Create User" }
+        "mutation": {
+          "createUser": { "main": { "title": "Create User" } }
         },
-        "Query": {
-          "user": { "label": "User detail" }
+        "query": {
+          "user": { "main": { "label": "User detail" } }
         }
       }
     }
@@ -154,24 +162,27 @@ Example:
 ## Per-generator declaration
 
 Each generator declares its accepted enrichment shape via Valibot in
-`gen-x/src/enrichments.ts`. The Valibot schema describes the
-**leaf payload** — what arrives at the lookup target — not the
-routing keys above it:
+`gen-x/src/enrichments.ts`. `toEnrichmentSchema` returns the
+**three-scope umbrella** — `v.object({ subject, generator, stack })` —
+not a flat payload. The per-item leaf (what a user writes for one
+operation/model, under the `variant` key above) lives under
+`subject`; the two run-constant scopes are declared `v.undefined()`
+when unused:
 
 ```ts
 // gen-shadcn-form/src/enrichments.ts
 import * as v from 'valibot'
-import { moduleExport } from '@skmtc/core'
+import { lensInputModuleType, moduleSelect } from '@skmtc/core'
 
 export const formFieldItem = v.object({
-  id: v.string(),
-  accessorPath: v.optional(v.array(v.string())),
-  input: v.optional(moduleExport),
+  // `moduleSelect.schemaPath` is the join key (no separate `id`).
+  moduleSelect: v.pipe(moduleSelect(lensInputModuleType), v.title('Input')),
   label: v.optional(v.string()),
   placeholder: v.optional(v.string()),
   references: v.optional(v.string())
 })
 
+// The subject-scoped leaf — the per-operation form override.
 export const formSchema = v.optional(
   v.object({
     title: v.optional(v.string()),
@@ -181,11 +192,19 @@ export const formSchema = v.optional(
   })
 )
 
-export type EnrichmentSchema = v.InferOutput<typeof formSchema>
-export const toEnrichmentSchema = () => formSchema
+// The three-scope umbrella. This generator only reads `subject`.
+export const enrichmentSchema = v.object({
+  subject: formSchema,
+  generator: v.undefined(),
+  stack: v.undefined()
+})
+
+export type EnrichmentSchema = v.InferOutput<typeof enrichmentSchema>
+export const toEnrichmentSchema = () => enrichmentSchema
 ```
 
-The schema is registered via the generator's entry function:
+The schema is registered via the generator's entry function
+(`toEnrichmentSchema` is a **required** config field):
 
 ```ts
 // gen-shadcn-form/src/mod.ts
@@ -197,11 +216,13 @@ export const ShadcnFormEntry = toOasOperationEntry<EnrichmentSchema>({
 ```
 
 **The Valibot schema is the canonical source of truth for what
-the enrichment payload accepts.** To know what to put in
-`client.json` under the routing keys, read the generator's
-`enrichments.ts`. The schema's *root* is what arrives at the
-lookup target — for `gen-shadcn-form` above that's the object
-with `title`, `description`, `submitLabel`, `fields`.
+the enrichment payload accepts.** To know what a user writes in
+`client.json` under the routing keys, read the `subject` member of
+the generator's `enrichmentSchema` — for `gen-shadcn-form` above
+that's the object with `title`, `description`, `submitLabel`,
+`fields`. A no-enrichment generator passes core's
+`emptyEnrichmentSchema` (the umbrella with all three scopes
+`v.undefined()`).
 
 ## Validation behavior
 

--- a/deno/docs/reference/stock-generators/gen-shadcn-form.md
+++ b/deno/docs/reference/stock-generators/gen-shadcn-form.md
@@ -54,10 +54,10 @@ export const CreateUserForm = () => {
   `OperationReferenceField`, etc.). New input types are added by
   extending the dispatch.
 - **Rich enrichments.** Per-operation `title`, `submitLabel`,
-  per-field `fields[].label`, `.placeholder`, `.input` (custom
-  renderer), `.references` (operation-reference dispatch for
-  searchable dropdowns). Routed by
-  `enrichments[generatorId][operation.path][operation.method]`.
+  per-field `fields[].label`, `.placeholder`, `fields[].moduleSelect`
+  (field binding + custom renderer), `.references` (operation-reference
+  dispatch for searchable dropdowns), under the `subject` scope. Routed
+  by `enrichments[generatorId][operation.path][operation.method][variant]`.
 
 ## What to learn from it
 

--- a/deno/docs/using/how-to/configure-enrichments.md
+++ b/deno/docs/using/how-to/configure-enrichments.md
@@ -37,9 +37,13 @@ The routing keys depend on the generator's projection-base kind:
 
 | Factory | Key path |
 |---|---|
-| OAS operation | `enrichments[generatorId][operation.path][operation.method]` |
-| Model | `enrichments[generatorId][refName]` |
-| GraphQL operation | `enrichments[generatorId][rootKind][fieldName]` |
+| OAS operation | `enrichments[generatorId][operation.path][operation.method][variant]` |
+| Model | `enrichments[generatorId][refName][variant]` |
+| GraphQL operation | `enrichments[generatorId][rootKind][fieldName][variant]` |
+
+The trailing `variant` key is `"main"` by default. Write your override
+under it; whenever you declare any variant for an item, `"main"` must
+be one of them.
 
 Example for `gen-shadcn-form` (OAS operation) on `POST /users`:
 
@@ -50,11 +54,13 @@ Example for `gen-shadcn-form` (OAS operation) on `POST /users`:
       "@skmtc/gen-shadcn-form": {
         "/users": {
           "post": {
-            "title": "Create a user",
-            "submitLabel": "Create",
-            "fields": [
-              { "id": "name", "label": "Full name" }
-            ]
+            "main": {
+              "title": "Create a user",
+              "submitLabel": "Create",
+              "fields": [
+                { "moduleSelect": { "schemaPath": ["name"] }, "label": "Full name" }
+              ]
+            }
           }
         }
       }
@@ -70,7 +76,9 @@ Example for `gen-zod` (model) on `UserModel`:
   "settings": {
     "enrichments": {
       "@skmtc/gen-zod": {
-        "UserModel": { "description": "A user account" }
+        "UserModel": {
+          "main": { "description": "A user account" }
+        }
       }
     }
   }

--- a/deno/docs/using/tutorials/03-customize-with-enrichments.md
+++ b/deno/docs/using/tutorials/03-customize-with-enrichments.md
@@ -62,16 +62,20 @@ Edit `.skmtc/petstore/.settings/client.json`:
       "@skmtc/gen-shadcn-form": {
         "/pet": {
           "post": {
-            "title": "Add a new pet",
-            "submitLabel": "Add to inventory",
-            "fields": [
-              { "id": "name", "label": "Pet name", "placeholder": "Fluffy" },
-              { "id": "category", "label": "Category" }
-            ]
+            "main": {
+              "title": "Add a new pet",
+              "submitLabel": "Add to inventory",
+              "fields": [
+                { "moduleSelect": { "schemaPath": ["name"] }, "label": "Pet name", "placeholder": "Fluffy" },
+                { "moduleSelect": { "schemaPath": ["category"] }, "label": "Category" }
+              ]
+            }
           },
           "put": {
-            "title": "Edit pet details",
-            "submitLabel": "Save changes"
+            "main": {
+              "title": "Edit pet details",
+              "submitLabel": "Save changes"
+            }
           }
         }
       }
@@ -80,8 +84,9 @@ Edit `.skmtc/petstore/.settings/client.json`:
 }
 ```
 
-The routing path is `[generatorId][path][method]` for OAS
-operation generators. See
+The routing path is `[generatorId][path][method][variant]` for OAS
+operation generators — the override sits under the `variant` key
+(`main` by default). See
 [enrichments shape reference](../../reference/settings/enrichments-shape.md)
 for all three routing shapes.
 
@@ -112,10 +117,12 @@ name". Other operations use the form generator's defaults
 `client.json#settings.enrichments` is read by the engine and
 routed to each generator instance. The `toOasOperationProjectionBase`
 factory looks up
-`enrichments[generatorId][operation.path][operation.method]` for
-the current operation and validates the result against the
-generator's Valibot schema. The validated value lands on the
-Projection as `this.settings.enrichments`:
+`enrichments[generatorId][operation.path][operation.method][variant]`
+for the current operation and validates the result against the
+generator's Valibot schema. The validated `{ subject, generator,
+stack }` umbrella lands on the Projection as
+`this.settings.enrichments` — read your per-operation config off its
+`subject` scope:
 
 ```ts
 const { title, submitLabel } = this.settings.enrichments.subject ?? {}


### PR DESCRIPTION
Re-audit batch 2 — the enrichment pages the first audit never reached
(the earlier enrichment PR fixed the `.subject` reads but left the
routing prose, client.json examples, and schema declaration flat).

Verified against source — including that **GraphQL uses the same
variant level and the same `toVariantList` `main`-required rule as
OAS** (`['enrichments', id, rootKind, fieldName, variant]`; write
nothing → defaults to `main`, write any block → must include `main`):

- **enrichments-shape.md**: OAS + GQL routing gain the trailing
  `[variant]` level (model already had it); the per-generator
  declaration shows the three-scope umbrella (`toEnrichmentSchema`
  returns `v.object({ subject, generator, stack })`, required) instead
  of the flat `formSchema`; `formFieldItem` uses `moduleSelect`;
  GQL rootKind lowercased.
- **configure-enrichments.md** + **using/tutorials/03**: routing
  table/paths gain `[variant]`; client.json examples nest the leaf
  under `"main"` and use the real `moduleSelect` field shape.
- **gen-shadcn-form.md**, **variants.md**: routing path corrected.

Doc gate green.