### PR TITLE
chore(openapi-overlays): make package publishable to JSR

### DIFF
--- a/deno/openapi-overlays/deno.json
+++ b/deno/openapi-overlays/deno.json
@@ -1,7 +1,6 @@
 {
   "name": "@skmtc/openapi-overlays",
   "version": "0.2.0",
-  "private": true,
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",


### PR DESCRIPTION
## What

Removes the `"private": true` flag from `openapi-overlays/deno.json` so `@skmtc/openapi-overlays` can be published to JSR.

## Why

The package is a proper workspace member with a name, version, exports, Apache-2.0 license, and publish config — the only thing preventing publication was the `private` flag. It is currently absent from jsr.io (404).

## Verification

`deno publish --dry-run` passes with no slow-type issues:

```
Simulating publish of @skmtc/openapi-overlays@0.2.0 with files:
   LICENSE.txt, README.md, cli.ts, deno.json, jsonpath.ts, mod.ts, overlay.ts
Success  Dry run complete
```

## Follow-up

Actual JSR publish happens via the release cascade (`deno task release`), not by hand — to run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)