### PR TITLE
feat(vite): serve the attribution gen-map for the desktop code panel

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://skm.tc",

--- a/packages/vite/src/artifacts.ts
+++ b/packages/vite/src/artifacts.ts
@@ -16,7 +16,10 @@ export type ArtifactEntry = { path: string; lines?: number; characters?: number 
 const manifestPath = (root: string, project: string): string =>
   join(root, '.skmtc', project, '.settings', 'manifest.json')
 
-const readManifestFiles = async (
+/** The manifest `files` map (`path -> { lines, characters }`), `{}` when the
+ *  project hasn't been generated. Shared with the gen-map reader, which uses
+ *  membership as its path guard and `characters` for span-alignment checks. */
+export const readManifestFiles = async (
   root: string,
   project: string
 ): Promise<Record<string, unknown>> => {

--- a/packages/vite/src/client-json.ts
+++ b/packages/vite/src/client-json.ts
@@ -24,6 +24,21 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
  *  `settings.enrichments` subtree; every other field passes through untouched. */
 export type ClientJson = Record<string, unknown> & { settings: Record<string, unknown> }
 
+/** The engine's own fallback when `settings.basePath` is absent (it is
+ *  `v.optional` in `@skmtc/core` Settings): generated files land relative to
+ *  the project root — `skmtc` cli `project-headless.ts` `basePath ?? "."`.
+ *  Must stay identical, or path resolution here disagrees with where the
+ *  engine actually wrote files. */
+const ENGINE_DEFAULT_BASE_PATH = '.'
+
+/** `settings.basePath`, with the engine's `'.'` fallback. `ClientJson` is
+ *  deliberately loose (`settings` values are `unknown`), so the narrowing
+ *  lives here rather than inline at every consumer. */
+export const basePathOf = (clientJson: ClientJson): string =>
+  typeof clientJson.settings.basePath === 'string'
+    ? clientJson.settings.basePath
+    : ENGINE_DEFAULT_BASE_PATH
+
 const subjectRefSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('operation'), path: z.string(), method: z.string() }),
   z.object({ type: z.literal('model'), refName: z.string() })

--- a/packages/vite/src/gen-map.test.ts
+++ b/packages/vite/src/gen-map.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { readGenMap } from './gen-map.ts'
+
+// A minimal v2 sidecar: pools + anchor rows `[Li, Pi, gi, si, vi, from, to]`.
+// Two anchors — an attributed outer definition and an unattributed inner
+// snippet (`<unknown>` generator, empty pointer), mirroring real output.
+const petSource = 'export type Pet = { name: string }\n'
+const petSidecar = {
+  v: 2,
+  f: '@/models/pet.generated.ts',
+  G: [
+    { name: '<unknown>', version: '', r: 0 },
+    { name: '@acme/gen-typescript', version: '', r: 0 }
+  ],
+  S: ['', '#/components/schemas/Pet'],
+  V: ['main'],
+  L: ['Pet'],
+  P: [''],
+  A: [
+    [0, 0, 1, 1, 0, 0, 34],
+    [0, 0, 0, 0, 0, 18, 34]
+  ],
+  N: ['TsDefinition', 'CustomValue'],
+  An: [0, 1]
+}
+
+// Same shape for a file that will be made stale (formatted after generate).
+const barSidecar = {
+  ...petSidecar,
+  f: '@/models/bar.generated.ts',
+  A: [[0, 0, 1, 1, 0, 0, 10]],
+  An: [0]
+}
+
+// A sidecar for an artifact no longer in the manifest (a removed file whose
+// sidecar lingers in `.maps`).
+const goneSidecar = { ...petSidecar, f: '@/models/gone.generated.ts' }
+
+const manifest = {
+  files: {
+    'src/models/pet.generated.ts': { lines: 1, characters: petSource.length },
+    'src/models/bar.generated.ts': { lines: 1, characters: 10 }
+  }
+}
+
+describe('readGenMap', () => {
+  const project = 'demo'
+  let root: string
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'skmtc-gen-map-'))
+    const projectDir = join(root, '.skmtc', project)
+    await mkdir(join(projectDir, '.settings'), { recursive: true })
+    await writeFile(join(projectDir, '.settings', 'manifest.json'), JSON.stringify(manifest))
+    const maps = join(projectDir, '.maps', '@', 'models')
+    await mkdir(maps, { recursive: true })
+    await writeFile(join(maps, 'pet.generated.ts.skm.json'), JSON.stringify(petSidecar))
+    await writeFile(join(maps, 'bar.generated.ts.skm.json'), JSON.stringify(barSidecar))
+    await writeFile(join(maps, 'gone.generated.ts.skm.json'), JSON.stringify(goneSidecar))
+    await writeFile(join(maps, 'broken.generated.ts.skm.json'), '{not json')
+    await mkdir(join(root, 'src', 'models'), { recursive: true })
+    await writeFile(join(root, 'src', 'models', 'pet.generated.ts'), petSource)
+    // bar on disk is LONGER than the manifest render — a formatter ran.
+    await writeFile(join(root, 'src', 'models', 'bar.generated.ts'), 'x'.repeat(24))
+  })
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('decodes anchor rows into entries with realigned paths', async () => {
+    const { entries } = await readGenMap(root, project, 'src')
+    expect(entries).toEqual([
+      {
+        artifactPath: 'src/models/pet.generated.ts',
+        artifactSpan: [0, 34],
+        projectionName: 'Pet',
+        producerName: 'TsDefinition',
+        generatorRef: '@acme/gen-typescript',
+        schemaPointer: '#/components/schemas/Pet',
+        variant: 'main'
+      },
+      {
+        artifactPath: 'src/models/pet.generated.ts',
+        artifactSpan: [18, 34],
+        projectionName: 'Pet',
+        producerName: 'CustomValue',
+        generatorRef: '<unknown>',
+        schemaPointer: '',
+        variant: 'main'
+      }
+    ])
+  })
+
+  it('reports a formatted (length-drifted) file as stale, entries excluded', async () => {
+    const { entries, staleFiles } = await readGenMap(root, project, 'src')
+    expect(staleFiles).toEqual(['src/models/bar.generated.ts'])
+    expect(entries.some((entry) => entry.artifactPath.includes('bar'))).toBe(false)
+  })
+
+  it('drops sidecars not in the manifest and malformed sidecars', async () => {
+    const { entries, staleFiles } = await readGenMap(root, project, 'src')
+    const paths = new Set(entries.map((entry) => entry.artifactPath))
+    expect(paths.has('src/models/gone.generated.ts')).toBe(false)
+    expect(staleFiles.includes('src/models/gone.generated.ts')).toBe(false)
+  })
+
+  it('returns empty for a project with no .maps tree', async () => {
+    expect(await readGenMap(root, 'other', 'src')).toEqual({ entries: [], staleFiles: [] })
+  })
+
+  it("strips the alias without a prefix for the engine's root-relative fallback", async () => {
+    // basePath absent → the engine writes relative to the project root ('.')
+    // and manifest keys carry no prefix; nothing here matches the src/-keyed
+    // manifest, so entries drop out via the membership guard rather than
+    // being mis-prefixed.
+    const { entries } = await readGenMap(root, project, '.')
+    expect(entries).toEqual([])
+  })
+})

--- a/packages/vite/src/gen-map.test.ts
+++ b/packages/vite/src/gen-map.test.ts
@@ -39,10 +39,34 @@ const barSidecar = {
 // sidecar lingers in `.maps`).
 const goneSidecar = { ...petSidecar, f: '@/models/gone.generated.ts' }
 
+// Truncated + non-numeric rows between two good ones: both bad rows must be
+// dropped WITHOUT shifting the later good row's `An` producer pairing.
+const rowsSource = 'export type Rows = { a: string }\n'
+const rowsSidecar = {
+  ...petSidecar,
+  f: '@/models/rows.generated.ts',
+  A: [
+    [0, 0, 1, 1, 0, 0, 32],
+    [0, 0, 1],
+    [0, 0, 1, 1, 0, 'x', 32],
+    [0, 0, 0, 0, 0, 21, 27]
+  ],
+  An: [0, 1, 1, 1]
+}
+
+// A duplicate sidecar declaring the same `f` as petSidecar from a stale,
+// non-mirror path — the mirror-path copy must win.
+const petImpostorSidecar = {
+  ...petSidecar,
+  A: [[0, 0, 1, 1, 0, 5, 9]],
+  An: [1]
+}
+
 const manifest = {
   files: {
     'src/models/pet.generated.ts': { lines: 1, characters: petSource.length },
-    'src/models/bar.generated.ts': { lines: 1, characters: 10 }
+    'src/models/bar.generated.ts': { lines: 1, characters: 10 },
+    'src/models/rows.generated.ts': { lines: 1, characters: rowsSource.length }
   }
 }
 
@@ -60,9 +84,15 @@ describe('readGenMap', () => {
     await writeFile(join(maps, 'pet.generated.ts.skm.json'), JSON.stringify(petSidecar))
     await writeFile(join(maps, 'bar.generated.ts.skm.json'), JSON.stringify(barSidecar))
     await writeFile(join(maps, 'gone.generated.ts.skm.json'), JSON.stringify(goneSidecar))
+    await writeFile(join(maps, 'rows.generated.ts.skm.json'), JSON.stringify(rowsSidecar))
     await writeFile(join(maps, 'broken.generated.ts.skm.json'), '{not json')
+    // A stale duplicate for pet at a NON-mirror path (sorts before the mirror
+    // copy lexicographically — '_' < 'p' — so mirror preference, not order,
+    // must decide the winner).
+    await writeFile(join(maps, '_stale-pet.skm.json'), JSON.stringify(petImpostorSidecar))
     await mkdir(join(root, 'src', 'models'), { recursive: true })
     await writeFile(join(root, 'src', 'models', 'pet.generated.ts'), petSource)
+    await writeFile(join(root, 'src', 'models', 'rows.generated.ts'), rowsSource)
     // bar on disk is LONGER than the manifest render — a formatter ran.
     await writeFile(join(root, 'src', 'models', 'bar.generated.ts'), 'x'.repeat(24))
   })
@@ -72,7 +102,10 @@ describe('readGenMap', () => {
 
   it('decodes anchor rows into entries with realigned paths', async () => {
     const { entries } = await readGenMap(root, project, 'src')
-    expect(entries).toEqual([
+    const petEntries = entries.filter(
+      (entry) => entry.artifactPath === 'src/models/pet.generated.ts'
+    )
+    expect(petEntries).toEqual([
       {
         artifactPath: 'src/models/pet.generated.ts',
         artifactSpan: [0, 34],
@@ -98,6 +131,35 @@ describe('readGenMap', () => {
     const { entries, staleFiles } = await readGenMap(root, project, 'src')
     expect(staleFiles).toEqual(['src/models/bar.generated.ts'])
     expect(entries.some((entry) => entry.artifactPath.includes('bar'))).toBe(false)
+  })
+
+  it('drops malformed anchor rows without shifting producer attribution', async () => {
+    const { entries } = await readGenMap(root, project, 'src')
+    const rowsEntries = entries.filter(
+      (entry) => entry.artifactPath === 'src/models/rows.generated.ts'
+    )
+    // The truncated and non-numeric rows are gone; the surviving second good
+    // row still pairs with An[3] → N[1] ('CustomValue'), not a shifted index.
+    expect(rowsEntries).toHaveLength(2)
+    expect(rowsEntries[0].producerName).toBe('TsDefinition')
+    expect(rowsEntries[1]).toMatchObject({
+      artifactSpan: [21, 27],
+      producerName: 'CustomValue'
+    })
+  })
+
+  it('one sidecar wins per artifact, preferring the mirror path', async () => {
+    const { entries, staleFiles } = await readGenMap(root, project, 'src')
+    const petEntries = entries.filter(
+      (entry) => entry.artifactPath === 'src/models/pet.generated.ts'
+    )
+    // The impostor at `_stale-pet.skm.json` sorts FIRST lexicographically, so
+    // only mirror preference keeps the canonical two-anchor sidecar's entries
+    // (the impostor has one anchor at [5, 9]).
+    expect(petEntries).toHaveLength(2)
+    expect(petEntries.some((entry) => entry.artifactSpan[0] === 5)).toBe(false)
+    // And no artifact is reported stale twice.
+    expect(new Set(staleFiles).size).toBe(staleFiles.length)
   })
 
   it('drops sidecars not in the manifest and malformed sidecars', async () => {

--- a/packages/vite/src/gen-map.ts
+++ b/packages/vite/src/gen-map.ts
@@ -45,7 +45,10 @@ export type GenMapResult = {
   entries: GenMapEntry[]
   /** Manifest files whose on-disk length no longer matches the engine render
    *  (`manifest.characters`) — their spans are stale (e.g. the project ran a
-   *  formatter after generate) and must not be decorated. */
+   *  formatter after generate) and must not be decorated. Length equality is
+   *  a HEURISTIC, not content-exact: a rewrite that preserves character count
+   *  (balanced quote-style flips, tab/space swaps) escapes detection. It is
+   *  the best signal the manifest offers (`lines`/`characters` only). */
   staleFiles: string[]
 }
 
@@ -64,6 +67,15 @@ const asGeneratorNames = (value: unknown): string[] =>
 const asNumberArray = (value: unknown): number[] =>
   Array.isArray(value) ? value.map((entry) => (typeof entry === 'number' ? entry : -1)) : []
 
+/** One well-formed anchor row `[Li, Pi, gi, si, vi, from, to]`, paired with
+ *  its producer-name pool index. The sidecar's `An` array is parallel to the
+ *  RAW `A`, so the pairing must happen BEFORE malformed rows are dropped —
+ *  filtering first would shift every later row's producer attribution. */
+type AnchorRow = { row: number[]; producerIndex: number | undefined }
+
+const isWellFormedRow = (row: unknown): row is number[] =>
+  Array.isArray(row) && row.length >= 7 && row.every((n) => typeof n === 'number')
+
 type SidecarLike = {
   /** `@/`-aliased artifact path the sidecar describes. */
   f: string
@@ -71,18 +83,18 @@ type SidecarLike = {
   S: string[]
   V: string[]
   L: string[]
-  /** Anchor rows: `[Li, Pi, gi, si, vi, from, to]`. */
-  A: number[][]
+  anchors: AnchorRow[]
   N: string[]
-  /** Parallel to `A` — `An[i]` indexes into `N` for `A[i]`. */
-  An: number[]
 }
 
 const toSidecar = (value: unknown): SidecarLike | null => {
   if (!isRecord(value) || typeof value.f !== 'string') return null
+  const producerIndices = asNumberArray(value.An)
+  // Truncated or non-numeric rows are dropped entirely — they must not
+  // materialize as zero-width entries at position 0.
   const anchors = Array.isArray(value.A)
-    ? value.A.filter(
-        (row): row is number[] => Array.isArray(row) && row.every((n) => typeof n === 'number')
+    ? value.A.flatMap((row, index): AnchorRow[] =>
+        isWellFormedRow(row) ? [{ row, producerIndex: producerIndices[index] }] : []
       )
     : []
   return {
@@ -91,9 +103,8 @@ const toSidecar = (value: unknown): SidecarLike | null => {
     S: asStringArray(value.S),
     V: asStringArray(value.V),
     L: asStringArray(value.L),
-    A: anchors,
-    N: asStringArray(value.N),
-    An: asNumberArray(value.An)
+    anchors,
+    N: asStringArray(value.N)
   }
 }
 
@@ -109,9 +120,8 @@ const resolveAliasPath = (path: string, basePath: string): string => {
 }
 
 const sidecarToEntries = (sidecar: SidecarLike, artifactPath: string): GenMapEntry[] =>
-  sidecar.A.map((row, index) => {
+  sidecar.anchors.map(({ row, producerIndex }) => {
     const [li, , gi, si, vi, from, to] = row
-    const producerIndex = sidecar.An[index]
     return {
       artifactPath,
       artifactSpan: [from ?? 0, to ?? 0],
@@ -151,7 +161,13 @@ const sidecarPaths = async (dir: string): Promise<string[]> => {
  * artifacts read uses — `.maps` accumulates sidecars for renamed/removed
  * artifacts and older generates). Files whose on-disk length differs from the
  * manifest's `characters` land in `staleFiles` with their entries EXCLUDED —
- * a stale span is worse than no span.
+ * a stale span is worse than no span (and see {@link GenMapResult} for why
+ * length equality is a heuristic).
+ *
+ * One sidecar wins per artifact: `.maps` accumulation means two files can
+ * declare the same `f` (e.g. a lingering copy at a stale mirror path). The
+ * sidecar at the canonical mirror path (`.maps/<f>.skm.json`) is preferred;
+ * ties fall to the lexicographically first path — deterministic either way.
  */
 export const readGenMap = async (
   root: string,
@@ -159,17 +175,30 @@ export const readGenMap = async (
   basePath: string
 ): Promise<GenMapResult> => {
   const manifestFiles = await readManifestFiles(root, project)
+  const dir = mapsDir(root, project)
+
+  const decoded: { path: string; sidecar: SidecarLike }[] = []
+  for (const path of await sidecarPaths(dir)) {
+    try {
+      const sidecar = toSidecar(JSON.parse(await readFile(path, 'utf8')))
+      if (sidecar !== null) decoded.push({ path, sidecar })
+    } catch {
+      // malformed JSON — skip
+    }
+  }
+  const isMirror = (candidate: { path: string; sidecar: SidecarLike }): boolean =>
+    candidate.path === join(dir, `${candidate.sidecar.f}.skm.json`)
+  decoded.sort(
+    (a, b) => Number(isMirror(b)) - Number(isMirror(a)) || a.path.localeCompare(b.path)
+  )
+
+  const seenArtifacts = new Set<string>()
   const entries: GenMapEntry[] = []
   const staleFiles: string[] = []
-  for (const path of await sidecarPaths(mapsDir(root, project))) {
-    let sidecar: SidecarLike | null
-    try {
-      sidecar = toSidecar(JSON.parse(await readFile(path, 'utf8')))
-    } catch {
-      continue
-    }
-    if (sidecar === null) continue
+  for (const { sidecar } of decoded) {
     const artifactPath = resolveAliasPath(sidecar.f, basePath)
+    if (seenArtifacts.has(artifactPath)) continue
+    seenArtifacts.add(artifactPath)
     const meta = manifestFiles[artifactPath]
     if (meta === undefined) continue
     const characters = isRecord(meta) && typeof meta.characters === 'number' ? meta.characters : null

--- a/packages/vite/src/gen-map.ts
+++ b/packages/vite/src/gen-map.ts
@@ -1,0 +1,187 @@
+// Decode the attribution sidecars from the last `--anchors` generate
+// (`.skmtc/<project>/.maps/**/*.skm.json`) into flat gen-map entries — the
+// same shape the hub's run gen-map endpoint serves — for the desktop code
+// panel's attribution overlay.
+//
+// Ported from skmtc-hub `apps/service/src/lib/gen-map-readers.ts`
+// (`sidecarsToGenMapEntries`), adapted for the local working tree: generator
+// pools carry real package names (no bundle-key resolution), `variant` is
+// included from the `V` pool, and per-file span alignment against the on-disk
+// artifact is reported (a project-side formatter rewrites the raw engine
+// render, invalidating every span in that file until the next raw generate).
+//
+// Like the hub reader, the sidecar shape is hand-mirrored with defensive
+// narrowing rather than imported from `@skmtc/core` — malformed sidecars and
+// out-of-range pool indices degrade to empty strings, never throw.
+
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { readManifestFiles } from './artifacts.ts'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+/** One attributed span — the hub's contract `GenMapEntry`, plus `variant`. */
+export type GenMapEntry = {
+  /** Manifest-keyed artifact path (`src/...`), realigned from the sidecar's
+   *  `@/`-aliased form. */
+  artifactPath: string
+  /** `[from, to)` span in UTF-16 code units — CodeMirror positions. */
+  artifactSpan: [number, number]
+  /** Enclosing Projection/Definition name (the `L` pool). */
+  projectionName: string
+  /** Exact emitting Projection/Snippet class (the `N` pool). */
+  producerName: string
+  /** Generator package name (the `G` pool) — `''`/`<unknown>` when the
+   *  snippet didn't thread its generator. */
+  generatorRef: string
+  /** JSON pointer into the source schema; `''` when not captured. */
+  schemaPointer: string
+  /** Enrichment variant the span belongs to (the `V` pool); `'main'` default. */
+  variant: string
+}
+
+export type GenMapResult = {
+  entries: GenMapEntry[]
+  /** Manifest files whose on-disk length no longer matches the engine render
+   *  (`manifest.characters`) — their spans are stale (e.g. the project ran a
+   *  formatter after generate) and must not be decorated. */
+  staleFiles: string[]
+}
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map((entry) => (typeof entry === 'string' ? entry : '')) : []
+
+/** The `G` pool holds `{ name, version, r }` records; only `name` is used —
+ *  locally it is the generator's real package name. */
+const asGeneratorNames = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.map((entry) =>
+        isRecord(entry) && typeof entry.name === 'string' ? entry.name : ''
+      )
+    : []
+
+const asNumberArray = (value: unknown): number[] =>
+  Array.isArray(value) ? value.map((entry) => (typeof entry === 'number' ? entry : -1)) : []
+
+type SidecarLike = {
+  /** `@/`-aliased artifact path the sidecar describes. */
+  f: string
+  G: string[]
+  S: string[]
+  V: string[]
+  L: string[]
+  /** Anchor rows: `[Li, Pi, gi, si, vi, from, to]`. */
+  A: number[][]
+  N: string[]
+  /** Parallel to `A` — `An[i]` indexes into `N` for `A[i]`. */
+  An: number[]
+}
+
+const toSidecar = (value: unknown): SidecarLike | null => {
+  if (!isRecord(value) || typeof value.f !== 'string') return null
+  const anchors = Array.isArray(value.A)
+    ? value.A.filter(
+        (row): row is number[] => Array.isArray(row) && row.every((n) => typeof n === 'number')
+      )
+    : []
+  return {
+    f: value.f,
+    G: asGeneratorNames(value.G),
+    S: asStringArray(value.S),
+    V: asStringArray(value.V),
+    L: asStringArray(value.L),
+    A: anchors,
+    N: asStringArray(value.N),
+    An: asNumberArray(value.An)
+  }
+}
+
+/** Realign a sidecar's `@/`-aliased path to the manifest's basePath-rooted
+ *  form (`@/forms/Foo.tsx` → `src/forms/Foo.tsx`). With the engine's
+ *  root-relative fallback (`basePath` absent → `'.'`) manifest keys carry no
+ *  prefix, so the alias is simply stripped. */
+const resolveAliasPath = (path: string, basePath: string): string => {
+  if (!path.startsWith('@/')) return path
+  const trimmed = basePath.replace(/\/+$/, '')
+  if (trimmed === '' || trimmed === '.') return path.slice(2)
+  return `${trimmed}/${path.slice(2)}`
+}
+
+const sidecarToEntries = (sidecar: SidecarLike, artifactPath: string): GenMapEntry[] =>
+  sidecar.A.map((row, index) => {
+    const [li, , gi, si, vi, from, to] = row
+    const producerIndex = sidecar.An[index]
+    return {
+      artifactPath,
+      artifactSpan: [from ?? 0, to ?? 0],
+      projectionName: (li !== undefined ? sidecar.L[li] : undefined) ?? '',
+      producerName: (producerIndex !== undefined ? sidecar.N[producerIndex] : undefined) ?? '',
+      generatorRef: (gi !== undefined ? sidecar.G[gi] : undefined) ?? '',
+      schemaPointer: (si !== undefined ? sidecar.S[si] : undefined) ?? '',
+      variant: (vi !== undefined ? sidecar.V[vi] : undefined) || 'main'
+    }
+  })
+
+const mapsDir = (root: string, project: string): string =>
+  join(root, '.skmtc', project, '.maps')
+
+/** Every `*.skm.json` under `.maps`, recursively. `[]` when the tree is
+ *  absent (the project has never generated with `--anchors`). */
+const sidecarPaths = async (dir: string): Promise<string[]> => {
+  let dirents
+  try {
+    dirents = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const nested = await Promise.all(
+    dirents.map((dirent) => {
+      const path = join(dir, dirent.name)
+      if (dirent.isDirectory()) return sidecarPaths(path)
+      return Promise.resolve(dirent.name.endsWith('.skm.json') ? [path] : [])
+    })
+  )
+  return nested.flat()
+}
+
+/**
+ * Read + decode the project's gen-map. Only sidecars whose realigned path is
+ * a manifest `files` key are included (the same membership guard the
+ * artifacts read uses — `.maps` accumulates sidecars for renamed/removed
+ * artifacts and older generates). Files whose on-disk length differs from the
+ * manifest's `characters` land in `staleFiles` with their entries EXCLUDED —
+ * a stale span is worse than no span.
+ */
+export const readGenMap = async (
+  root: string,
+  project: string,
+  basePath: string
+): Promise<GenMapResult> => {
+  const manifestFiles = await readManifestFiles(root, project)
+  const entries: GenMapEntry[] = []
+  const staleFiles: string[] = []
+  for (const path of await sidecarPaths(mapsDir(root, project))) {
+    let sidecar: SidecarLike | null
+    try {
+      sidecar = toSidecar(JSON.parse(await readFile(path, 'utf8')))
+    } catch {
+      continue
+    }
+    if (sidecar === null) continue
+    const artifactPath = resolveAliasPath(sidecar.f, basePath)
+    const meta = manifestFiles[artifactPath]
+    if (meta === undefined) continue
+    const characters = isRecord(meta) && typeof meta.characters === 'number' ? meta.characters : null
+    const onDiskLength = await readFile(join(root, artifactPath), 'utf8')
+      .then((content) => content.length)
+      .catch(() => null)
+    if (onDiskLength === null || (characters !== null && characters !== onDiskLength)) {
+      staleFiles.push(artifactPath)
+      continue
+    }
+    entries.push(...sidecarToEntries(sidecar, artifactPath))
+  }
+  staleFiles.sort()
+  return { entries, staleFiles }
+}

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -368,7 +368,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
         const generate = await enqueue(async () => {
           const next = applyEditToClientJson(await readClientJson(root, options.project), edit)
           await writeClientJson(root, options.project, next)
-          return runGenerate(root, options.project, true)
+          return runGenerate(root, options.project)
         }).catch((error): CliResult => ({ ok: false, code: 1, message: messageOf(error) }))
         // The generate rewrote the source the matcher type-checks against —
         // bump the state's file versions + drop its generate-derived caches.
@@ -378,7 +378,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
 
       // Regenerate without an edit (initial render / manual refresh).
       const regenerateHandler: Connect.NextHandleFunction = async (_request, response) => {
-        const generate = await enqueue(() => runGenerate(root, options.project, true))
+        const generate = await enqueue(() => runGenerate(root, options.project))
         if (generate.ok) state.onGenerateSuccess()
         respondJson(response, generate.ok ? 200 : 500, { generate })
       }
@@ -401,7 +401,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
         // first open without the user first hitting Regenerate. A plain
         // `vite dev` user who never opens the editor never triggers this.
         if (genMapMissing()) {
-          const generate = await enqueue(() => runGenerate(root, options.project, true))
+          const generate = await enqueue(() => runGenerate(root, options.project))
           if (generate.ok) state.onGenerateSuccess()
         }
         try {
@@ -545,7 +545,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
               skip: toFilterEntries(filters.skip)
             }
           })
-          return runGenerate(root, options.project, true)
+          return runGenerate(root, options.project)
         }).catch((error): CliResult => ({ ok: false, code: 1, message: messageOf(error) }))
         if (generate.ok) state.onGenerateSuccess()
         respondJson(response, generate.ok ? 200 : 500, { generate })

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -13,6 +13,7 @@ import type { Connect, Plugin } from 'vite'
 import { runDescribe, runGenerate, type CliResult } from './skmtc-cli.ts'
 import {
   applyEditToClientJson,
+  basePathOf,
   clientJsonPath,
   enrichmentEditSchema,
   inputMatchesSchema,
@@ -36,6 +37,7 @@ import {
 import { readPreviews } from './manifest.ts'
 import { previewOptimizeDeps } from './optimize-deps.ts'
 import { readArtifactContent, readArtifacts } from './artifacts.ts'
+import { readGenMap } from './gen-map.ts'
 import { filtersWriteSchema, fromFilterEntries, toFilterEntries } from './filters.ts'
 import { readSource } from './project-sources.ts'
 
@@ -271,15 +273,15 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       server.watcher.add(HARNESS_SOURCE_PATH)
       server.watcher.add(clientJsonFile)
 
-      // The gen-map (`.maps/_map.ndjson`) resolves a model name to its generated
-      // file for the input matcher; only `--anchors` generates emit it. The
-      // regenerate path always anchors, but edit/filters don't (the map is heavy
-      // and stable across enrichment edits) — so a project only ever generated
-      // without `--anchors` (a repo `generate` script that omits it, or an
-      // edit-only session) has NO map, and every field picker reports
-      // `model-missing`. Bootstrap it exactly once, when it's absent, on any
-      // generate path and lazily before the first match — then the fast no-anchor
-      // path takes over.
+      // The gen-map (`.maps/`) serves two consumers: `_map.ndjson` resolves a
+      // model name to its generated file for the input matcher, and the
+      // per-file span sidecars (`*.skm.json`) drive the code panel's
+      // attribution overlay. Only `--anchors` generates emit them — and span
+      // sidecars go stale on EVERY content change (spans shift), so every
+      // generate path passes `--anchors` now (measured: the full reapit
+      // generate with anchors is ~270 ms; the old "heavy, skip on edits"
+      // assumption predates measurement). `genMapMissing` remains only as the
+      // lazy bootstrap trigger for a project never generated with anchors.
       const genMapPath = join(root, '.skmtc', options.project, '.maps', '_map.ndjson')
       const genMapMissing = (): boolean => !existsSync(genMapPath)
 
@@ -366,7 +368,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
         const generate = await enqueue(async () => {
           const next = applyEditToClientJson(await readClientJson(root, options.project), edit)
           await writeClientJson(root, options.project, next)
-          return runGenerate(root, options.project, genMapMissing())
+          return runGenerate(root, options.project, true)
         }).catch((error): CliResult => ({ ok: false, code: 1, message: messageOf(error) }))
         // The generate rewrote the source the matcher type-checks against —
         // bump the state's file versions + drop its generate-derived caches.
@@ -374,9 +376,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
         respondJson(response, generate.ok ? 200 : 500, { generate })
       }
 
-      // Regenerate without an edit (initial render / manual refresh). Pass anchors
-      // here so the gen-map (`.maps`) is (re)populated on render — the edit loop
-      // skips it (heavy + the model→file map is stable across enrichment edits).
+      // Regenerate without an edit (initial render / manual refresh).
       const regenerateHandler: Connect.NextHandleFunction = async (_request, response) => {
         const generate = await enqueue(() => runGenerate(root, options.project, true))
         if (generate.ok) state.onGenerateSuccess()
@@ -415,8 +415,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       const previewsHandler: Connect.NextHandleFunction = async (_request, response) => {
         try {
           const clientJson = await readClientJson(root, options.project)
-          const basePath =
-            typeof clientJson.settings.basePath === 'string' ? clientJson.settings.basePath : 'src'
+          const basePath = basePathOf(clientJson)
           respondJson(response, 200, await readPreviews(root, options.project, basePath))
         } catch (error) {
           respondJson(response, 500, { error: messageOf(error) })
@@ -463,8 +462,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
           const inputDirs = Array.isArray(clientJson.settings.inputDirs)
             ? clientJson.settings.inputDirs.filter((dir): dir is string => typeof dir === 'string')
             : []
-          const basePath =
-            typeof clientJson.settings.basePath === 'string' ? clientJson.settings.basePath : 'src'
+          const basePath = basePathOf(clientJson)
           const candidates = await state.candidates(inputDirs, basePath)
           respondJson(response, 200, {
             candidates: candidates.map(({ exportName, exportPath }) => ({
@@ -494,6 +492,20 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
             return
           }
           respondJson(response, 200, { path, content })
+        } catch (error) {
+          respondJson(response, 500, { error: messageOf(error) })
+        }
+      }
+
+      // The attribution gen-map from the last `--anchors` generate: every
+      // sidecar span decoded to a flat entry (the hub's `GenMapEntry` shape,
+      // plus `variant`), with formatter-drifted files reported as stale
+      // instead of decorated wrongly. Drives the code panel's overlay.
+      const genMapHandler: Connect.NextHandleFunction = async (_request, response) => {
+        try {
+          const clientJson = await readClientJson(root, options.project)
+          const basePath = basePathOf(clientJson)
+          respondJson(response, 200, await readGenMap(root, options.project, basePath))
         } catch (error) {
           respondJson(response, 500, { error: messageOf(error) })
         }
@@ -533,7 +545,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
               skip: toFilterEntries(filters.skip)
             }
           })
-          return runGenerate(root, options.project, genMapMissing())
+          return runGenerate(root, options.project, true)
         }).catch((error): CliResult => ({ ok: false, code: 1, message: messageOf(error) }))
         if (generate.ok) state.onGenerateSuccess()
         respondJson(response, generate.ok ? 200 : 500, { generate })
@@ -575,6 +587,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       server.middlewares.use('/__skmtc/source', methodGuard('GET', gated(sourceHandler)))
       server.middlewares.use('/__skmtc/candidates', methodGuard('GET', gated(candidatesHandler)))
       server.middlewares.use('/__skmtc/artifacts', methodGuard('GET', gated(artifactsHandler)))
+      server.middlewares.use('/__skmtc/gen-map', methodGuard('GET', gated(genMapHandler)))
       server.middlewares.use('/__skmtc/filters', methodGuard('GET', gated(filtersReadHandler)))
       server.middlewares.use('/__skmtc/filters', methodGuard('POST', gated(filtersWriteHandler)))
       server.middlewares.use(

--- a/packages/vite/src/skmtc-cli.ts
+++ b/packages/vite/src/skmtc-cli.ts
@@ -82,9 +82,10 @@ export const runDescribe = (root: string, project: string): Promise<CliResult> =
   runJson(root, ['describe', project, '--json'], 60_000)
 
 /** `skmtc generate <project> --json` — writes generated files to `basePath` and
- *  returns the manifest summary (files, stats, errors, parseIssues). `anchors`
- *  adds `--anchors` to also emit the gen-map (`.maps/_map.ndjson` + the span
- *  sidecars the attribution overlay reads) — every generate path passes it, so
- *  spans stay aligned with the regenerated files. */
-export const runGenerate = (root: string, project: string, anchors = false): Promise<CliResult> =>
-  runJson(root, ['generate', project, ...(anchors ? ['--anchors'] : []), '--json'], 120_000)
+ *  returns the manifest summary (files, stats, errors, parseIssues). Always
+ *  passes `--anchors` so the gen-map (`.maps/_map.ndjson` + the span sidecars
+ *  the attribution overlay reads) stays aligned with the regenerated files —
+ *  spans shift on every content change, so a generate without anchors would
+ *  silently stale the whole overlay. */
+export const runGenerate = (root: string, project: string): Promise<CliResult> =>
+  runJson(root, ['generate', project, '--anchors', '--json'], 120_000)

--- a/packages/vite/src/skmtc-cli.ts
+++ b/packages/vite/src/skmtc-cli.ts
@@ -83,7 +83,8 @@ export const runDescribe = (root: string, project: string): Promise<CliResult> =
 
 /** `skmtc generate <project> --json` — writes generated files to `basePath` and
  *  returns the manifest summary (files, stats, errors, parseIssues). `anchors`
- *  adds `--anchors` to also emit the gen-map (`.maps/_map.ndjson`) — used on the
- *  regenerate (not edit) path, since the gen-map is heavy + stable across edits. */
+ *  adds `--anchors` to also emit the gen-map (`.maps/_map.ndjson` + the span
+ *  sidecars the attribution overlay reads) — every generate path passes it, so
+ *  spans stay aligned with the regenerated files. */
 export const runGenerate = (root: string, project: string, anchors = false): Promise<CliResult> =>
   runJson(root, ['generate', project, ...(anchors ? ['--anchors'] : []), '--json'], 120_000)


### PR DESCRIPTION
## What

- **`GET /__skmtc/gen-map`** — decodes the `.maps` span sidecars from the last `--anchors` generate into flat entries (the hub's `GenMapEntry` shape plus `variant`), for the desktop code panel's attribution overlay (see the companion skmtc-hub PR).
  - Path realignment `@/…` → basePath-rooted manifest keys; only sidecars whose realigned path is a manifest `files` key are served (`.maps` accumulates sidecars for removed/renamed artifacts).
  - **Per-file staleness**: files whose on-disk length no longer matches the manifest's `characters` (a formatter ran after generate — e.g. a repo `generate` script ending in `oxfmt src`) land in `staleFiles` with their entries excluded. A stale span is worse than no span.
- **Every generate path now passes `--anchors`.** The edit/filters paths previously skipped it ("heavy + stable across edits") — true for the `_map.ndjson` name index, false for span sidecars, which shift on every content edit. Measured: a full reapit generate (1,112 files) with anchors is ~270 ms, so the skip bought nothing.
- **`basePathOf()`** centralizes the `settings.basePath` narrowing three handlers inlined — and fixes the default: the engine's fallback is `'.'` (`project-headless.ts` `basePath ?? "."`; the field is `v.optional` in core Settings), not the `'src'` the handlers guessed. Only basePath-less projects change behavior, from a wrong guess to engine-faithful.
- Version → **0.5.0** (merging publishes).

## Verification

- 101 vitest tests green (5 new for the sidecar reader: decode, alias realignment incl. the `'.'` fallback, manifest guard, stale detection, malformed-sidecar skip), `tsc` clean, `tsdown` build clean.
- Verified live against skmtc-reapit's dev server: 22,431 entries served aligned after a plugin regenerate; stale detection correctly excluded 1109/1112 files after `oxfmt src` ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)