### PR TITLE
docs: definitions-and-files — the create-or-reuse mechanism page

### DIFF
--- a/deno/docs/README.md
+++ b/deno/docs/README.md
@@ -99,6 +99,8 @@ CLI:    ◀──────── Persist files ◀┘
 - **Generate:** walk generators; memoized Drivers coordinate cross-generator dependencies.
 - **Render:** serialize to `{ path: content }` strings. (No Prettier — consumers format their own output.)
 
+This is not the codegen you know: a file is a keyed map of definitions, not a text buffer, and every generator either creates or reuses its dependencies — which is why generation order can't affect output. See [`concepts/definitions-and-files.md`](concepts/definitions-and-files.md) for the mechanism in one page.
+
 Generators are TypeScript classes you `install` from JSR or `clone` into your project for editing. See [`concepts/the-three-phases.md`](concepts/the-three-phases.md).
 
 ---

--- a/deno/docs/concepts/cross-generator-coordination.md
+++ b/deno/docs/concepts/cross-generator-coordination.md
@@ -5,6 +5,10 @@
 > hits guaranteed to produce the same Definition that a fresh
 > construction would.
 
+New to the mechanism? Start with
+[Definitions and files](definitions-and-files.md) — the one-page
+create-or-reuse model this page deepens.
+
 Cross-generator coordination in SKMTC is **memoization keyed by
 `(identifier.name, exportPath)`**, where both halves of the key are
 pure functions of the input. Same inputs → same key → same cached

--- a/deno/docs/concepts/cross-generator-coordination.md
+++ b/deno/docs/concepts/cross-generator-coordination.md
@@ -5,9 +5,9 @@
 > hits guaranteed to produce the same Definition that a fresh
 > construction would.
 
-New to the mechanism? Start with
-[Definitions and files](definitions-and-files.md) — the one-page
-create-or-reuse model this page deepens.
+The whole mechanism in one page:
+[Definitions and files](definitions-and-files.md). This page deepens
+its multi-generator side.
 
 Cross-generator coordination in SKMTC is **memoization keyed by
 `(identifier.name, exportPath)`**, where both halves of the key are

--- a/deno/docs/concepts/definitions-and-files.md
+++ b/deno/docs/concepts/definitions-and-files.md
@@ -1,0 +1,185 @@
+# Definitions and files: the create-or-reuse model
+
+> Generation does not append text to files. A file is an object with
+> keyed maps — `imports` and `definitions` — and generating code means
+> writing definition objects into file objects. Because the maps are
+> keyed, files double as a cache; because every producer creates the
+> definitions it depends on, inserting is create-or-reuse; and because
+> inserting is create-or-reuse, generation produces the same valid
+> output in any order. This page is the shortest complete statement of
+> that mechanism. Read it before the deeper pages it links to.
+
+If you arrive from other codegen tools, you likely carry this model:
+templates run over a schema in a fixed order, each appending text to
+an output buffer, and anything shared between outputs must be
+generated first or wired up by hand. Judged by that model, SKMTC —
+many independent generators writing into shared files, in no
+particular order — looks like it shouldn't work. It works because the
+model is different at the bottom: output is not text being appended
+but keyed objects being inserted, and insertion is idempotent.
+
+## The model in one breath
+
+1. A file is an object carrying keyed maps — most importantly
+   `definitions`, which maps an identifier to its value, and
+   `imports`, keyed by source module. (TypeScript files carry a third
+   map, `reExports` — see
+   [files-and-dedup.md](files-and-dedup.md).)
+2. Generating code means writing definition objects into file
+   objects. Nothing is text until the Render phase serializes each
+   file at the end.
+3. Because the maps are keyed, a file doubles as a **cache**:
+   inserting a definition that is already registered is a lookup, not
+   a recompute.
+4. Every producer — a [Projection or
+   Snippet](projections-and-snippets.md) — creates the definitions it
+   depends on, during its own construction.
+5. Combined, 3 and 4 make inserting **create-or-reuse**: a producer
+   asking for a dependency either constructs it (first time) or
+   reuses the registered definition (every time after).
+6. Therefore generation order cannot affect output: each generator
+   either creates or reuses its dependencies, and the file maps
+   converge to the same content whichever generator runs first.
+
+Point 6 is not an optimization — it is the property that makes the
+whole system composable. The rest of this page unpacks the chain.
+
+## A file is a keyed object, not a text buffer
+
+```ts fragment
+// the shape that matters (TsFile, abridged)
+class TsFile {
+  imports: Map<string, TsImport> // keyed by source module
+  definitions: Map<string, TsDefinition> // keyed by the identifier's declaration slot
+  reExports: Map<string, TsReExport> // keyed by source module
+}
+```
+
+During Generate, `GenerateContext` holds a map of path → file object,
+and generators write into those objects through `register` and the
+`insert*` methods. At Render time each file serializes its maps in a
+fixed order (re-exports, then imports, then definitions) into the
+final source text. Two consequences fall out immediately:
+
+- **Imports dedup for free.** Two producers registering
+  `{ zod: ['z'] }` against the same file produce one merged import
+  line, because the map is keyed by module.
+- **Definitions can be shared.** A definition written once under its
+  identifier is visible to every later lookup of that identifier —
+  which is what turns the file into a cache.
+
+## Insert is create-or-reuse
+
+Here is the mechanism on a concrete pair. A query-hook producer needs
+the Zod schema for a response body, so it inserts it:
+
+```ts fragment
+// inside the hook Projection's constructor
+const zodResponse = this.insertNormalizedModel(ZodProjection, {
+  schema: operation.toSuccessResponse()?.resolve().toSchema() ?? OasVoid.empty(),
+  fallbackName: `${decapitalize(settings.identifier.name)}Response`
+})
+
+this.zodResponseName = zodResponse.identifier.name
+```
+
+What the engine does with that call:
+
+```
+insertNormalizedModel / insertModel / insertOperation
+        │
+        ▼
+is (identifier.name, exportPath) already in the
+destination file's definitions map?
+        │
+  ┌─────┴──────────────────────────┐
+  no — create                      yes — reuse
+  │                                │
+  ▼                                ▼
+construct the dependency's    integrity check passes →
+producer; its constructor     return the registered
+inserts ITS dependencies      definition (a lookup,
+the same way (recursion       not a recompute)
+bottoms out at producers
+with no dependencies)
+  │
+  ▼
+write the Definition into
+the file object
+        │
+        ▼
+the caller interpolates the identifier into its
+own template; if the two land in different files,
+the engine registers the import between them
+```
+
+The recursion in the create branch is point 4 of the model: the
+`ZodProjection` constructed here inserts the TypeScript type *it*
+depends on, and so on down. No generator ever assembles its
+dependency tree up front — each producer pulls in exactly what it
+needs, and the cache turns repeated pulls into lookups.
+
+## Why order cannot matter
+
+Run `gen-zod` before the hook generator, and the hook's insert finds
+the schema already registered — reuse. Run it after, and the hook's
+insert creates the schema first; when `gen-zod` reaches the same
+schema, *it* reuses. Either way the definitions map ends up with one
+schema under one identifier, and the rendered output is identical.
+This is the mechanism behind two things you can observe directly:
+re-running a generation produces byte-identical output, and
+reordering generators in `client.json` changes nothing. The proof
+walkthrough lives in
+[how-idempotency-works.md](../explanation/how-idempotency-works.md).
+
+## Duplication or collision? Generator keys
+
+One question remains: when an insert finds the identifier already
+registered, how does the engine know the registered definition is
+*the same thing* and not a different definition that happens to want
+the same name? Every definition inserted through a Driver carries a
+**generator key** — a record of which generator and which schema or
+operation produced it. On a cache hit the engine compares keys:
+
+- **Same key** — same generator, same input: safe reuse. This is the
+  duplication case, and it is expected.
+- **Different key** — two different generator-and-input pairs landed
+  on the same name in the same file: a real naming collision. The
+  engine throws `Registered definition mismatch` rather than silently
+  keeping one and dropping the other.
+
+That distinction — duplication is reuse, collision is an error — is
+what lets first-write-wins dedup stay safe. The full integrity story,
+including how to read the mismatch error and the shapes a generator
+key can take, is in [files-and-dedup.md](files-and-dedup.md).
+
+## Common questions
+
+### Is output deduplicated after generation?
+
+No. There is no post-pass — a duplicate never exists in the first
+place, because the definitions map gates writes by key. What you see
+in the output is exactly what the maps accumulated.
+
+### Do I need to order generators in `client.json`?
+
+No. Order affects nothing observable. Install order and array order
+are both irrelevant to output — see
+[cross-generator-coordination.md](cross-generator-coordination.md)
+for how generators reference each other's output without ordering.
+
+## Further reading
+
+- [Files, deduplication, and integrity](files-and-dedup.md) — the
+  file object in full: per-map dedup rules, the integrity layer, and
+  generator key shapes
+- [Cross-generator coordination](cross-generator-coordination.md) —
+  the multi-generator view: how producers reference each other's
+  definitions by name
+- [How generators produce output](how-generators-produce-output.md)
+  — the producer side: `transform`, `register`, and the pull-based
+  flow that calls the inserts described here
+- [How idempotency works](../explanation/how-idempotency-works.md) —
+  the worked A/B ordering proof that output is order-independent
+- [Reference: file classes](../reference/api/dsl-file.md) — the
+  API-level reference for `FileBase`, `TsFile`, and `JsonFile`

--- a/deno/docs/concepts/files-and-dedup.md
+++ b/deno/docs/concepts/files-and-dedup.md
@@ -20,6 +20,11 @@ generator both contribute to a form's file; a form file imports a
 model file's type). The file class is what keeps these concurrent
 writers consistent.
 
+New to the mechanism? Start with
+[Definitions and files](definitions-and-files.md) — the one-page
+create-or-reuse model; this page is its file-and-integrity deep
+dive.
+
 This page covers the `TsFile` shape, how each map dedups, the
 `JsonFile` sibling, and the integrity check on top of definitions
 that distinguishes "safe reuse" from "collision."

--- a/deno/docs/concepts/files-and-dedup.md
+++ b/deno/docs/concepts/files-and-dedup.md
@@ -20,10 +20,9 @@ generator both contribute to a form's file; a form file imports a
 model file's type). The file class is what keeps these concurrent
 writers consistent.
 
-New to the mechanism? Start with
-[Definitions and files](definitions-and-files.md) — the one-page
-create-or-reuse model; this page is its file-and-integrity deep
-dive.
+The whole mechanism in one page:
+[Definitions and files](definitions-and-files.md). This page deepens
+its file-and-integrity side.
 
 This page covers the `TsFile` shape, how each map dedups, the
 `JsonFile` sibling, and the integrity check on top of definitions

--- a/deno/docs/concepts/how-generators-produce-output.md
+++ b/deno/docs/concepts/how-generators-produce-output.md
@@ -7,9 +7,9 @@
 > class does not, by itself, cause it to run). Output is produced by
 > side-effect through `context.register` and `context.insert*`.
 
-New to the mechanism? Start with
-[Definitions and files](definitions-and-files.md) — the one-page
-create-or-reuse model; this page covers the producer side of it.
+The whole mechanism in one page:
+[Definitions and files](definitions-and-files.md). This page deepens
+its producer side.
 
 If you have written generators for other tools (orval,
 openapi-generator, kubb, graphql-codegen) you probably expect the

--- a/deno/docs/concepts/how-generators-produce-output.md
+++ b/deno/docs/concepts/how-generators-produce-output.md
@@ -7,6 +7,10 @@
 > class does not, by itself, cause it to run). Output is produced by
 > side-effect through `context.register` and `context.insert*`.
 
+New to the mechanism? Start with
+[Definitions and files](definitions-and-files.md) — the one-page
+create-or-reuse model; this page covers the producer side of it.
+
 If you have written generators for other tools (orval,
 openapi-generator, kubb, graphql-codegen) you probably expect the
 following: the engine walks the schema, calls your transform for

--- a/deno/docs/using/tutorials/01-your-first-generation.md
+++ b/deno/docs/using/tutorials/01-your-first-generation.md
@@ -104,10 +104,12 @@ const validated = pet.parse(someApiResponse)
 The CLI ran the engine, which executed the [three phases](../../concepts/the-three-phases.md):
 
 1. **Parse:** the OpenAPI document was normalized to OAS 3.0 and
-   converted to typed `OasDocument`/`OasSchema` instances.
-2. **Generate:** `gen-zod`'s entry function iterated every schema
-   component and called `insertModel(ZodProjection, refName)` for
-   each, populating the file map.
+   converted to a typed object model.
+2. **Generate:** `gen-zod` produced one definition per schema
+   component and wrote each into an in-memory file map. (How that
+   map works — and why it lets generators share output — is
+   [Definitions and files](../../concepts/definitions-and-files.md);
+   you'll see it pay off in tutorial 02.)
 3. **Render:** the file map was serialized to `{ path: content }`
    artifacts and written to disk.
 

--- a/deno/docs/using/tutorials/02-multiple-generators.md
+++ b/deno/docs/using/tutorials/02-multiple-generators.md
@@ -93,24 +93,17 @@ The output is **identical**. Generator order doesn't matter — see
 
 ## What just happened
 
-Each generator's `transform` function ran against the same parsed
-`OasDocument`. Internally:
+Three generators ran against the same schema, two of them needed the
+same shared pieces — and each shared piece exists exactly once,
+referenced by imports. Nothing was deduplicated after the fact: every
+generator either created a definition or reused one that was already
+registered, so a duplicate never existed in the first place. The same
+mechanism is why the rerun was byte-identical and why reordering the
+generators changed nothing.
 
-- `gen-zod` called `insertModel(ZodProjection, refName)` for each
-  schema → produced `Pet.generated.ts` with `export const pet =
-  ...`
-- `gen-typescript` called `insertModel(TsProjection, refName)` for
-  each schema → produced `export type Pet = ...` in the same file
-- `gen-tanstack-query-fetch-zod` ran per operation, and its
-  Projection's `toString()` called `insertNormalizedModel` for the
-  request/response schemas. Both calls landed on the same cache
-  key `(name, exportPath)` as the standalone generators — the
-  engine returned the existing definitions without creating
-  duplicates.
-
-Output is what each generator registered; nothing was deduplicated
-*after the fact*. The cache key made duplicates structurally
-impossible.
+How that works — files as keyed maps, insert as create-or-reuse — is
+one short page:
+[Definitions and files](../../concepts/definitions-and-files.md).
 
 ## Next steps
 
@@ -118,5 +111,7 @@ impossible.
   add per-operation overrides via `client.json`
 - [Recipe: Full-stack TypeScript app](../recipes/full-stack-typescript-app.md) —
   add forms, mocks, and tables on top of this stack
+- [Definitions and files](../../concepts/definitions-and-files.md) —
+  why this worked: the create-or-reuse mechanism
 - [Cross-generator coordination concept](../../concepts/cross-generator-coordination.md) —
   the deeper mechanism


### PR DESCRIPTION
One canonical concept page for the model that makes SKMTC composable — the single biggest comprehension risk for new users arriving with template-per-endpoint codegen priors:

1. A file is an object of keyed maps (`imports`, `definitions`) — not a text buffer.
2. Generating means writing definition objects into file objects; Render serializes at the end.
3. Keyed maps make files double as a cache: inserting an already-registered definition is a lookup.
4. Every producer creates the definitions it depends on, so insert = create-or-reuse.
5. Therefore generation order cannot affect output.
6. Generator keys (advanced) distinguish safe duplication from real naming collisions.

**New page:** `docs/concepts/definitions-and-files.md` — the six-step chain, an ASCII create-or-reuse flow, a worked hook→Zod pair, and hand-offs to the three existing deep dives.

**Repoints (no restructures):**
- Root README "How it works": one assert sentence + link.
- Tutorials 01/02 "What just happened": now state outcomes and link the page instead of inlining `insertModel` internals (the audit's most consistent leak).
- `files-and-dedup` / `cross-generator-coordination` / `how-generators-produce-output`: parallel start-here pointers naming which side of the model each deepens.

Verified against source before writing (cache key vs integrity key kept distinct; `affirmDefinition` fires on cache hit in the Driver). `deno task verify-docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)