### PR TITLE
Structured misfit reasons for the input matcher (+ valibot swap)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://skm.tc",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "ts-pattern": "^5.9.0",
-    "zod": "^4.4.3"
+    "valibot": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.3",

--- a/packages/vite/src/client-json.test.ts
+++ b/packages/vite/src/client-json.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import * as v from 'valibot'
 import {
   applyEdit,
   applyEditToClientJson,
@@ -100,7 +101,7 @@ describe('applyEditToClientJson', () => {
 
 describe('enrichmentEditSchema (boundary validation)', () => {
   it('parses a valid writeLeaf edit', () => {
-    const parsed = enrichmentEditSchema.parse({
+    const parsed = v.parse(enrichmentEditSchema, {
       op: 'writeLeaf',
       generator: GEN,
       subject: { type: 'operation', path: '/x', method: 'get' },
@@ -112,12 +113,12 @@ describe('enrichmentEditSchema (boundary validation)', () => {
   })
 
   it('rejects an unknown op', () => {
-    expect(() => enrichmentEditSchema.parse({ op: 'nope' })).toThrow()
+    expect(() => v.parse(enrichmentEditSchema, { op: 'nope' })).toThrow()
   })
 
   it('rejects a malformed subject', () => {
     expect(() =>
-      enrichmentEditSchema.parse({
+      v.parse(enrichmentEditSchema, {
         op: 'addVariant',
         generator: GEN,
         subject: { type: 'banana' },

--- a/packages/vite/src/client-json.ts
+++ b/packages/vite/src/client-json.ts
@@ -1,12 +1,12 @@
 // Read/write the project's `client.json` and apply enrichment edits to it. The
 // nested `settings.enrichments` tree is the single source of truth (no flat
 // representation); an edit is a positional write via the enrichment-leaf
-// adapter, validated at the boundary with zod.
+// adapter, validated at the boundary with valibot.
 
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { match } from 'ts-pattern'
-import { z } from 'zod'
+import * as v from 'valibot'
 import {
   addVariant,
   removeVariant,
@@ -39,83 +39,83 @@ export const basePathOf = (clientJson: ClientJson): string =>
     ? clientJson.settings.basePath
     : ENGINE_DEFAULT_BASE_PATH
 
-const subjectRefSchema = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('operation'), path: z.string(), method: z.string() }),
-  z.object({ type: z.literal('model'), refName: z.string() })
+const subjectRefSchema = v.variant('type', [
+  v.object({ type: v.literal('operation'), path: v.string(), method: v.string() }),
+  v.object({ type: v.literal('model'), refName: v.string() })
 ])
 
 /** Body of `POST /__skmtc/input-matches`: which inputs fit one field.
  *  `generator` scopes the slot-contract lookup to the generator whose module
  *  field is being edited (two generators can map the same subject). */
-export const inputMatchesSchema = z.object({
+export const inputMatchesSchema = v.object({
   subject: subjectRefSchema,
-  schemaPath: z.array(z.string()).min(1),
-  generator: z.string().optional()
+  schemaPath: v.pipe(v.array(v.string()), v.minLength(1)),
+  generator: v.optional(v.string())
 })
-const valuesSchema = z.record(z.string(), z.unknown())
-const describedKeysSchema = z.array(z.string())
+const valuesSchema = v.record(v.string(), v.unknown())
+const describedKeysSchema = v.array(v.string())
 
 /**
  * One enrichment edit, validated at the HTTP boundary. The shape mirrors the
  * enrichment-leaf adapter ops; `EnrichmentEdit` is inferred from this schema so
  * the validator is the single source of truth.
  */
-export const enrichmentEditSchema = z.discriminatedUnion('op', [
-  z.object({
-    op: z.literal('writeLeaf'),
-    generator: z.string(),
+export const enrichmentEditSchema = v.variant('op', [
+  v.object({
+    op: v.literal('writeLeaf'),
+    generator: v.string(),
     subject: subjectRefSchema,
-    variant: z.string(),
+    variant: v.string(),
     values: valuesSchema,
     describedKeys: describedKeysSchema
   }),
-  z.object({
-    op: z.literal('writeGeneratorScope'),
-    generator: z.string(),
+  v.object({
+    op: v.literal('writeGeneratorScope'),
+    generator: v.string(),
     values: valuesSchema,
     describedKeys: describedKeysSchema
   }),
-  z.object({
-    op: z.literal('writeStackScope'),
+  v.object({
+    op: v.literal('writeStackScope'),
     values: valuesSchema,
     describedKeys: describedKeysSchema
   }),
-  z.object({
-    op: z.literal('addVariant'),
-    generator: z.string(),
+  v.object({
+    op: v.literal('addVariant'),
+    generator: v.string(),
     subject: subjectRefSchema,
-    variant: z.string()
+    variant: v.string()
   }),
-  z.object({
-    op: z.literal('removeVariant'),
-    generator: z.string(),
+  v.object({
+    op: v.literal('removeVariant'),
+    generator: v.string(),
     subject: subjectRefSchema,
-    variant: z.string()
+    variant: v.string()
   }),
-  z.object({
-    op: z.literal('renameVariant'),
-    generator: z.string(),
+  v.object({
+    op: v.literal('renameVariant'),
+    generator: v.string(),
     subject: subjectRefSchema,
-    from: z.string(),
-    to: z.string()
+    from: v.string(),
+    to: v.string()
   })
 ])
 
-export type EnrichmentEdit = z.infer<typeof enrichmentEditSchema>
+export type EnrichmentEdit = v.InferOutput<typeof enrichmentEditSchema>
 
 /** Apply one edit to an enrichments tree — pure dispatch over the adapter. */
 export function applyEdit(tree: EnrichmentTree, edit: EnrichmentEdit): EnrichmentTree {
   return match(edit)
-    .with({ op: 'writeLeaf' }, (e) =>
+    .with({ op: 'writeLeaf' }, e =>
       writeLeaf(tree, e.generator, e.subject, e.variant, e.values, e.describedKeys)
     )
-    .with({ op: 'writeGeneratorScope' }, (e) =>
+    .with({ op: 'writeGeneratorScope' }, e =>
       writeGeneratorScope(tree, e.generator, e.values, e.describedKeys)
     )
-    .with({ op: 'writeStackScope' }, (e) => writeStackScope(tree, e.values, e.describedKeys))
-    .with({ op: 'addVariant' }, (e) => addVariant(tree, e.generator, e.subject, e.variant))
-    .with({ op: 'removeVariant' }, (e) => removeVariant(tree, e.generator, e.subject, e.variant))
-    .with({ op: 'renameVariant' }, (e) => renameVariant(tree, e.generator, e.subject, e.from, e.to))
+    .with({ op: 'writeStackScope' }, e => writeStackScope(tree, e.values, e.describedKeys))
+    .with({ op: 'addVariant' }, e => addVariant(tree, e.generator, e.subject, e.variant))
+    .with({ op: 'removeVariant' }, e => removeVariant(tree, e.generator, e.subject, e.variant))
+    .with({ op: 'renameVariant' }, e => renameVariant(tree, e.generator, e.subject, e.from, e.to))
     .exhaustive()
 }
 

--- a/packages/vite/src/filters.ts
+++ b/packages/vite/src/filters.ts
@@ -12,9 +12,9 @@
 // hub's generated models.
 
 import { match } from 'ts-pattern'
-import { z } from 'zod'
+import * as v from 'valibot'
 
-export const httpMethodSchema = z.enum([
+export const httpMethodSchema = v.picklist([
   'get',
   'post',
   'put',
@@ -24,33 +24,33 @@ export const httpMethodSchema = z.enum([
   'head',
   'trace'
 ])
-export type HttpMethod = z.infer<typeof httpMethodSchema>
+export type HttpMethod = v.InferOutput<typeof httpMethodSchema>
 
 /** One flat include/skip rule, validated at the HTTP boundary. */
-export const generatorFilterSchema = z.discriminatedUnion('scope', [
-  z.object({ scope: z.literal('all'), generator: z.string(), variants: z.array(z.string()) }),
-  z.object({
-    scope: z.literal('operation'),
-    generator: z.string(),
-    path: z.string(),
+export const generatorFilterSchema = v.variant('scope', [
+  v.object({ scope: v.literal('all'), generator: v.string(), variants: v.array(v.string()) }),
+  v.object({
+    scope: v.literal('operation'),
+    generator: v.string(),
+    path: v.string(),
     method: httpMethodSchema,
-    variants: z.array(z.string())
+    variants: v.array(v.string())
   }),
-  z.object({
-    scope: z.literal('model'),
-    generator: z.string(),
-    refName: z.string(),
-    variants: z.array(z.string())
+  v.object({
+    scope: v.literal('model'),
+    generator: v.string(),
+    refName: v.string(),
+    variants: v.array(v.string())
   })
 ])
-export type GeneratorFilter = z.infer<typeof generatorFilterSchema>
+export type GeneratorFilter = v.InferOutput<typeof generatorFilterSchema>
 
 /** Body of `POST /__skmtc/filters`: the full flat include + skip lists. */
-export const filtersWriteSchema = z.object({
-  include: z.array(generatorFilterSchema),
-  skip: z.array(generatorFilterSchema)
+export const filtersWriteSchema = v.object({
+  include: v.array(generatorFilterSchema),
+  skip: v.array(generatorFilterSchema)
 })
-export type FiltersWrite = z.infer<typeof filtersWriteSchema>
+export type FiltersWrite = v.InferOutput<typeof filtersWriteSchema>
 
 type OperationVariants = Record<string, Record<string, string[]>>
 type ModelVariants = Record<string, string[]>
@@ -74,15 +74,15 @@ export function toFilterEntries(filters: GeneratorFilter[]): FilterEntry[] {
 
   for (const filter of filters) {
     match(filter)
-      .with({ scope: 'all' }, (rule) => {
+      .with({ scope: 'all' }, rule => {
         wholeGenerators.push(rule.generator)
       })
-      .with({ scope: 'operation' }, (rule) => {
+      .with({ scope: 'operation' }, rule => {
         const paths = (operations[rule.generator] ??= {})
         const methods = (paths[rule.path] ??= {})
         methods[rule.method] = rule.variants
       })
-      .with({ scope: 'model' }, (rule) => {
+      .with({ scope: 'model' }, rule => {
         const refs = (models[rule.generator] ??= {})
         refs[rule.refName] = rule.variants
       })
@@ -135,13 +135,13 @@ export function fromFilterEntries(raw: unknown): GeneratorFilter[] {
         // Per-operation: `path -> method -> variant[]`.
         if (!isRecord(value)) continue
         for (const [methodKey, variants] of Object.entries(value)) {
-          const method = httpMethodSchema.safeParse(methodKey)
+          const method = v.safeParse(httpMethodSchema, methodKey)
           if (!method.success) continue
           rows.push({
             generator,
             scope: 'operation',
             path: subjectKey,
-            method: method.data,
+            method: method.output,
             variants: toStringArray(variants)
           })
         }

--- a/packages/vite/src/input-matcher.test.ts
+++ b/packages/vite/src/input-matcher.test.ts
@@ -5,14 +5,15 @@ import {
   classify,
   renderProbe,
   rootModelNameForSchemaPath,
+  toMisfitReason,
   toRelativeSpecifier,
   type MatcherSubject,
   type ProbeLayout
 } from './input-matcher.ts'
 
-// Type-check a self-contained probe string and return its error messages —
+// Type-check a self-contained probe string and return its diagnostics —
 // lib files come from disk (ts.sys), only the probe file is served in-memory.
-const typeErrorsOf = (source: string): string[] => {
+const diagnosticsOf = (source: string): ts.Diagnostic[] => {
   const fileName = '/probe.ts'
   const options: ts.CompilerOptions = {
     noEmit: true,
@@ -26,13 +27,27 @@ const typeErrorsOf = (source: string): string[] => {
     name === fileName
       ? ts.createSourceFile(fileName, source, ts.ScriptTarget.ES2020, true)
       : getSourceFile(name, languageVersion, onError, shouldCreate)
-  host.fileExists = (name) => name === fileName || ts.sys.fileExists(name)
-  host.readFile = (name) => (name === fileName ? source : ts.sys.readFile(name))
+  host.fileExists = name => name === fileName || ts.sys.fileExists(name)
+  host.readFile = name => (name === fileName ? source : ts.sys.readFile(name))
   const program = ts.createProgram([fileName], options, host)
   return ts
     .getPreEmitDiagnostics(program)
-    .filter((diagnostic) => diagnostic.file?.fileName === fileName)
-    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+    .filter(diagnostic => diagnostic.file?.fileName === fileName)
+}
+
+const typeErrorsOf = (source: string): string[] =>
+  diagnosticsOf(source).map(diagnostic =>
+    ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+  )
+
+/** Diagnostic line numbers of a compiled probe, matcher-style (0-based). */
+const errorLinesOf = (diagnostics: ts.Diagnostic[]): Set<number> => {
+  const lines = new Set<number>()
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.start === undefined || !diagnostic.file) continue
+    lines.add(diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start).line)
+  }
+  return lines
 }
 
 const operation = (path: string, method: string): MatcherSubject => ({
@@ -223,17 +238,21 @@ describe('renderProbe', () => {
     )
     expect(lines[layout.moduleTypeStartLine]).toContain('@hookform/lenses')
     expect(lines[layout.moduleTypeEndLine]).toContain('export type InputModule<F>')
-    expect(layout.segmentLines.map((line) => lines[line])).toEqual([
+    expect(layout.segmentLines.map(line => lines[line])).toEqual([
       `type __D0 = CreateApplicantModel['applicant']`,
       `type __D1 = NonNullable<__D0>['officeIds']`
     ])
-    expect(layout.importLines.map((line) => lines[line])).toEqual([
+    expect(layout.importLines.map(line => lines[line])).toEqual([
       `import { OfficeSelect as __C0 } from './src/inputs/OfficeSelect'`,
       `import { TextInput as __C1 } from './src/inputs/TextInput'`
     ])
-    expect(layout.cellLines.map((line) => lines[line])).toEqual([
+    expect(layout.cellLines.map(line => lines[line])).toEqual([
       `const __m0: true = (null as unknown as (typeof __C0 extends InputModule<__F> ? true : false));`,
       `const __m1: true = (null as unknown as (typeof __C1 extends InputModule<__F> ? true : false));`
+    ])
+    expect(layout.explainLines.map(line => lines[line])).toEqual([
+      `const __e0: InputModule<__F> = __C0;`,
+      `const __e1: InputModule<__F> = __C1;`
     ])
   })
 
@@ -354,5 +373,93 @@ describe('classify', () => {
       type: 'verdicts',
       verdicts: ['fit', 'unresolved']
     })
+  })
+
+  it('an explain-line error alone never changes a verdict', () => {
+    const layout = layoutFixture()
+    // Explain lines are for elaboration only — a diagnostic there without one
+    // on the boolean cell (e.g. the two formulations disagreeing on an `any`
+    // candidate) must not flip a fit to a misfit.
+    const errors = new Set([layout.explainLines[0]])
+    expect(classify(errors, layout)).toEqual({
+      type: 'verdicts',
+      verdicts: ['fit', 'fit']
+    })
+  })
+})
+
+// The whole point of the explain lines: the boolean cell's own diagnostic is
+// the useless `'false' is not assignable to 'true'`, while the explain line
+// carries the compiler's real elaboration — headline + nested WHY chain — as
+// structured data (no flattened blob, no probe-internal names).
+describe('misfit reasons', () => {
+  const misfitProbe = () => {
+    const layout = renderProbe({
+      modelName: 'M',
+      modelImportPath: './fixture',
+      moduleTypeSource: 'export type S<F> = (props: { value: F }) => unknown',
+      moduleTypeName: 'S',
+      segments: ['name'],
+      candidates: [{ exportName: 'NumberInput', importPath: './inputs/NumberInput' }]
+    })
+    // Swap the imports for inline declarations so the probe is self-contained:
+    // the model's `name` is a string, the candidate wants a number → misfit.
+    const source = layout.text
+      .replace(/^import type .*$/m, 'type M = { name: string }')
+      .replace(
+        /^import \{ NumberInput as __C0 \}.*$/m,
+        'const __C0 = (props: { value: number }): unknown => props.value'
+      )
+    return { layout, diagnostics: diagnosticsOf(source) }
+  }
+
+  it('classifies the candidate as a misfit and elaborates WHY on the explain line', () => {
+    const { layout, diagnostics } = misfitProbe()
+    expect(classify(errorLinesOf(diagnostics), layout)).toEqual({
+      type: 'verdicts',
+      verdicts: ['misfit']
+    })
+
+    const explainDiagnostic = diagnostics.find(
+      diagnostic =>
+        diagnostic.start !== undefined &&
+        diagnostic.file?.getLineAndCharacterOfPosition(diagnostic.start).line ===
+          layout.explainLines[0]
+    )
+    expect(explainDiagnostic).toBeDefined()
+    if (!explainDiagnostic) return
+
+    const sanitize = (text: string): string =>
+      text.replace(/__C0/g, 'NumberInput').replace(/\b__F\b/g, 'string')
+    const reason = toMisfitReason(explainDiagnostic, sanitize)
+
+    expect(reason.code).toBe(2322)
+    expect(reason.headline).toMatch(/is not assignable to type 'S<string>'/)
+    expect(reason.headline).not.toContain('__')
+    // The chain bottoms out at the actual cause.
+    expect(reason.reasons.at(-1)).toBe(`Type 'string' is not assignable to type 'number'.`)
+    expect(reason.reasons.join('\n')).not.toContain('__')
+  })
+
+  it('the boolean cell alone would explain nothing (the motivating gap)', () => {
+    const { layout, diagnostics } = misfitProbe()
+    const cellDiagnostic = diagnostics.find(
+      diagnostic =>
+        diagnostic.start !== undefined &&
+        diagnostic.file?.getLineAndCharacterOfPosition(diagnostic.start).line ===
+          layout.cellLines[0]
+    )
+    expect(cellDiagnostic).toBeDefined()
+    if (!cellDiagnostic) return
+    expect(ts.flattenDiagnosticMessageText(cellDiagnostic.messageText, '\n')).toBe(
+      `Type 'false' is not assignable to type 'true'.`
+    )
+  })
+
+  it('flattens a string-only diagnostic to a headline with no reasons', () => {
+    const [diagnostic] = diagnosticsOf(`const x: number = 'nope'\nexport {}`)
+    const reason = toMisfitReason(diagnostic, text => text)
+    expect(reason.headline).toBe(`Type 'string' is not assignable to type 'number'.`)
+    expect(reason.reasons).toEqual([])
   })
 })

--- a/packages/vite/src/input-matcher.ts
+++ b/packages/vite/src/input-matcher.ts
@@ -12,7 +12,7 @@
 // There is no fallback list: every outcome is a named verdict (`MatchOutcome`).
 
 import { join, relative } from 'node:path'
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 import type * as TS from 'typescript'
 
 export type MatcherSubject =
@@ -51,7 +51,7 @@ const firstContentSchema = (content: unknown): unknown => {
 
 const requestBodyRoot = (operation: Doc): unknown => {
   if (Array.isArray(operation.parameters)) {
-    const body = operation.parameters.find((p) => isRecord(p) && p.in === 'body')
+    const body = operation.parameters.find(p => isRecord(p) && p.in === 'body')
     if (isRecord(body) && isRecord(body.schema)) return body.schema // Swagger 2.0
   }
   if (isRecord(operation.requestBody)) return firstContentSchema(operation.requestBody.content) // OAS 3
@@ -76,7 +76,7 @@ const deref = (doc: Doc, schema: unknown, seen: Set<string> = new Set()): Doc | 
 const successResponseSchema = (operation: Doc): unknown => {
   if (!isRecord(operation.responses)) return undefined
   const code =
-    Object.keys(operation.responses).find((entry) => /^2\d\d$/.test(entry)) ??
+    Object.keys(operation.responses).find(entry => /^2\d\d$/.test(entry)) ??
     (isRecord(operation.responses.default) ? 'default' : undefined)
   if (code === undefined) return undefined
   const response = operation.responses[code]
@@ -179,6 +179,10 @@ export type ProbeLayout = {
   fieldTypeOffset: number
   importLines: number[]
   cellLines: number[]
+  /** One direct-assignment line per candidate. Its diagnostic (if any) carries
+   *  the WHY of a misfit as a structured message chain — the boolean cell line
+   *  stays the adjudicator, these lines are only ever read for explanation. */
+  explainLines: number[]
 }
 
 /**
@@ -235,6 +239,16 @@ export const renderProbe = (input: ProbeInput): ProbeLayout => {
     )
   })
 
+  // The boolean cell above reduces assignability to `false is not assignable to
+  // true` — correct for the verdict, useless as an explanation. A plain
+  // assignment makes the compiler elaborate the REAL reason chain ("types of
+  // property 'lens' are incompatible → …"), which `toMisfitReason` extracts.
+  const explainLines: number[] = []
+  candidates.forEach((_, index) => {
+    explainLines.push(lines.length)
+    lines.push(`const __e${index}: ${moduleTypeName}<__F> = __C${index};`)
+  })
+
   lines.push('export {}')
 
   const fieldTypeLineStart = lines
@@ -248,7 +262,8 @@ export const renderProbe = (input: ProbeInput): ProbeLayout => {
     segmentLines,
     fieldTypeOffset: fieldTypeLineStart + 'type '.length,
     importLines,
-    cellLines
+    cellLines,
+    explainLines
   }
 }
 
@@ -274,7 +289,7 @@ export const classify = (
   for (let line = layout.moduleTypeStartLine; line <= layout.moduleTypeEndLine; line++) {
     if (errorLines.has(line)) return { type: 'module-type-error' }
   }
-  const broken = layout.segmentLines.findIndex((line) => errorLines.has(line))
+  const broken = layout.segmentLines.findIndex(line => errorLines.has(line))
   if (broken !== -1) return { type: 'path-broken', segmentIndex: broken }
   const verdicts = layout.importLines.map((importLine, index): CandidateVerdict => {
     if (errorLines.has(importLine)) return 'unresolved'
@@ -283,7 +298,60 @@ export const classify = (
   return { type: 'verdicts', verdicts }
 }
 
+// --- Misfit reasons ---------------------------------------------------------------
+
+/**
+ * A misfit's WHY, as structured data (never a pre-rendered blob): the
+ * diagnostic's top message plus its nested elaboration chain, outermost first —
+ * the UI decides how to lay them out (headline, expected/received split,
+ * "why" list).
+ */
+export type MisfitReason = {
+  /** The TS diagnostic code of the failed assignment (e.g. 2322). */
+  code: number
+  /** The top-level message — `Type 'X' is not assignable to type 'Y'.` */
+  headline: string
+  /** The nested elaborations, depth-first: each step of the compiler's
+   *  reasoning down to the leaf cause. */
+  reasons: string[]
+}
+
+const flattenChain = (chain: TS.DiagnosticMessageChain, into: string[]): void => {
+  into.push(chain.messageText)
+  chain.next?.forEach(next => flattenChain(next, into))
+}
+
+/**
+ * Extract a `MisfitReason` from an explain-line diagnostic. The message chain
+ * is walked as DATA (no `flattenDiagnosticMessageText` blob), and every
+ * message is passed through `sanitize` so probe-internal names (`__C0`,
+ * `__F`) never leak into user-facing text.
+ */
+export const toMisfitReason = (
+  diagnostic: TS.Diagnostic,
+  sanitize: (text: string) => string
+): MisfitReason =>
+  match(diagnostic.messageText)
+    .returnType<MisfitReason>()
+    .with(P.string, text => ({
+      code: diagnostic.code,
+      headline: sanitize(text),
+      reasons: []
+    }))
+    .otherwise(chain => {
+      const reasons: string[] = []
+      chain.next?.forEach(next => flattenChain(next, reasons))
+      return {
+        code: chain.code,
+        headline: sanitize(chain.messageText),
+        reasons: reasons.map(sanitize)
+      }
+    })
+
 // --- The match ------------------------------------------------------------------
+
+/** A rejected candidate plus (when the compiler elaborated one) its reason. */
+export type MisfitCandidate = MatcherCandidate & { reason?: MisfitReason }
 
 /**
  * Every match resolves to a NAMED outcome — there is no fallback candidate
@@ -298,7 +366,7 @@ export type MatchOutcome =
       /** The resolved field type, printed by the project's compiler. */
       fieldType: string
       fits: MatcherCandidate[]
-      misfits: MatcherCandidate[]
+      misfits: MisfitCandidate[]
       unresolved: MatcherCandidate[]
     }
   | { type: 'path-broken'; modelName: string; brokenAt: { index: number; segment: string } }
@@ -350,7 +418,8 @@ const toWire = ({ exportName, exportPath }: MatcherCandidateSource): MatcherCand
  * (and where does it break), does each candidate resolve, does each fit.
  */
 export const matchInputs = (args: MatchArgs): MatchOutcome => {
-  const { skmtcRoot, viteRoot, basePath, schema, subject, schemaPath, candidates, moduleType } = args
+  const { skmtcRoot, viteRoot, basePath, schema, subject, schemaPath, candidates, moduleType } =
+    args
   const { modelImports, service } = args
   if (!isRecord(schema)) {
     return { type: 'unavailable', reason: 'The schema document could not be read.' }
@@ -408,16 +477,19 @@ export const matchInputs = (args: MatchArgs): MatchOutcome => {
     moduleTypeSource: moduleTypePart.source,
     moduleTypeName: moduleTypePart.name,
     segments,
-    candidates: candidates.map((candidate) => ({
+    candidates: candidates.map(candidate => ({
       exportName: candidate.exportName,
       importPath: stripExt(toRelativeSpecifier(viteRoot, join(skmtcRoot, candidate.filePath)))
     }))
   })
 
   const errorLines = new Set<number>()
+  const diagnosticAtLine = new Map<number, TS.Diagnostic>()
   for (const diagnostic of service.check(layout.text)) {
     if (diagnostic.start === undefined || !diagnostic.file) continue
-    errorLines.add(diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start).line)
+    const line = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start).line
+    errorLines.add(line)
+    if (!diagnosticAtLine.has(line)) diagnosticAtLine.set(line, diagnostic)
   }
 
   return match(classify(errorLines, layout))
@@ -444,15 +516,32 @@ export const matchInputs = (args: MatchArgs): MatchOutcome => {
         brokenAt: { index: segmentIndex, segment: segments[segmentIndex] }
       })
     )
-    .with(
-      { type: 'verdicts' },
-      ({ verdicts }): MatchOutcome => ({
+    .with({ type: 'verdicts' }, ({ verdicts }): MatchOutcome => {
+      const fieldType = service.fieldTypeAt(layout.fieldTypeOffset)
+      // Probe-internal names must not leak into user-facing text: `__C<n>` is
+      // the candidate's import alias, `__F` the field-type alias (it appears
+      // inside the printed target, e.g. `InputModule<__F>`).
+      const sanitize = (text: string): string =>
+        text
+          .replace(/__C(\d+)/g, (whole, digits: string) => {
+            const name = candidates[Number(digits)]?.exportName
+            return name ?? whole
+          })
+          .replace(/\b__F\b/g, fieldType === '' ? 'the field type' : fieldType)
+      const misfitAt = (index: number): MisfitCandidate => {
+        const diagnostic = diagnosticAtLine.get(layout.explainLines[index])
+        const wire = toWire(candidates[index])
+        return diagnostic ? { ...wire, reason: toMisfitReason(diagnostic, sanitize) } : wire
+      }
+      return {
         type: 'fits',
-        fieldType: service.fieldTypeAt(layout.fieldTypeOffset),
+        fieldType,
         fits: candidates.filter((_, index) => verdicts[index] === 'fit').map(toWire),
-        misfits: candidates.filter((_, index) => verdicts[index] === 'misfit').map(toWire),
+        misfits: verdicts.flatMap((verdict, index) =>
+          verdict === 'misfit' ? [misfitAt(index)] : []
+        ),
         unresolved: candidates.filter((_, index) => verdicts[index] === 'unresolved').map(toWire)
-      })
-    )
+      }
+    })
     .exhaustive()
 }

--- a/packages/vite/src/input-matcher.ts
+++ b/packages/vite/src/input-matcher.ts
@@ -342,7 +342,7 @@ export const toMisfitReason = (
       const reasons: string[] = []
       chain.next?.forEach(next => flattenChain(next, reasons))
       return {
-        code: chain.code,
+        code: diagnostic.code,
         headline: sanitize(chain.messageText),
         reasons: reasons.map(sanitize)
       }
@@ -484,12 +484,19 @@ export const matchInputs = (args: MatchArgs): MatchOutcome => {
   })
 
   const errorLines = new Set<number>()
+  // One diagnostic kept per line, for the explain-line reason extraction.
+  // When a line carries several, prefer the failed assignment (TS2322) — it
+  // holds the elaboration chain; whatever else shares the line does not.
+  const ASSIGNMENT_ERROR = 2322
   const diagnosticAtLine = new Map<number, TS.Diagnostic>()
   for (const diagnostic of service.check(layout.text)) {
     if (diagnostic.start === undefined || !diagnostic.file) continue
     const line = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start).line
     errorLines.add(line)
-    if (!diagnosticAtLine.has(line)) diagnosticAtLine.set(line, diagnostic)
+    const kept = diagnosticAtLine.get(line)
+    if (!kept || (kept.code !== ASSIGNMENT_ERROR && diagnostic.code === ASSIGNMENT_ERROR)) {
+      diagnosticAtLine.set(line, diagnostic)
+    }
   }
 
   return match(classify(errorLines, layout))

--- a/packages/vite/src/parse-request.test.ts
+++ b/packages/vite/src/parse-request.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import * as v from 'valibot'
+import { parseRequest } from './parse-request.ts'
+import { inputMatchesSchema } from './client-json.ts'
+
+describe('parseRequest', () => {
+  it('returns the parsed output on success', () => {
+    const body = {
+      subject: { type: 'model', refName: 'Pet' },
+      schemaPath: ['Model', 'name']
+    }
+    expect(parseRequest(inputMatchesSchema, body)).toEqual(body)
+  })
+
+  it('names the failing field with its dot path', () => {
+    const bad = {
+      subject: { type: 'model', refName: 'Pet' },
+      schemaPath: ['Model'],
+      generator: 42
+    }
+    expect(() => parseRequest(inputMatchesSchema, bad)).toThrow(/generator: /)
+  })
+
+  it('reports a nested path and collects every issue', () => {
+    const schema = v.object({
+      outer: v.object({ inner: v.string() }),
+      count: v.number()
+    })
+    let message = ''
+    try {
+      parseRequest(schema, { outer: { inner: 7 }, count: 'nope' })
+    } catch (error) {
+      message = error instanceof Error ? error.message : ''
+    }
+    expect(message).toContain('outer.inner: ')
+    expect(message).toContain('count: ')
+  })
+
+  it('falls back to the bare message when an issue has no path', () => {
+    expect(() => parseRequest(v.string(), 42)).toThrow(/Invalid type/)
+  })
+})

--- a/packages/vite/src/parse-request.ts
+++ b/packages/vite/src/parse-request.ts
@@ -1,0 +1,22 @@
+// Parse a request body against a valibot schema, throwing a message that
+// names every failing field. `v.parse`'s ValiError.message is just the first
+// issue's text (e.g. "Invalid type: Expected string but received undefined")
+// with no indication of WHICH field — useless in a 400 for a nested edit
+// payload. This collects all issues with their dot paths instead.
+
+import * as v from 'valibot'
+
+export const parseRequest = <TSchema extends v.GenericSchema>(
+  schema: TSchema,
+  input: unknown
+): v.InferOutput<TSchema> => {
+  const result = v.safeParse(schema, input)
+  if (result.success) return result.output
+  const details = result.issues
+    .map(issue => {
+      const path = v.getDotPath(issue)
+      return path === null ? issue.message : `${path}: ${issue.message}`
+    })
+    .join('; ')
+  throw new Error(details)
+}

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -9,6 +9,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import { join, resolve } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import * as v from 'valibot'
 import type { Connect, Plugin } from 'vite'
 import { runDescribe, runGenerate, type CliResult } from './skmtc-cli.ts'
 import {
@@ -169,7 +170,7 @@ const NON_LOCAL_HEADERS = [
 const isLocalRequest = (request: IncomingMessage): boolean => {
   const address = request.socket.remoteAddress
   if (address === undefined || !LOOPBACK_ADDRESSES.has(address)) return false
-  return NON_LOCAL_HEADERS.every((header) => request.headers[header] === undefined)
+  return NON_LOCAL_HEADERS.every(header => request.headers[header] === undefined)
 }
 
 const messageOf = (error: unknown): string =>
@@ -259,7 +260,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       // a field comes off the generator's moduleSelect declaration, read from
       // the (cached) describe descriptors.
       const state = new SourceState(root, viteRoot, options.project, {
-        resolveModuleType: async (generator) => {
+        resolveModuleType: async generator => {
           if (generator === undefined) return undefined
           const result = await describe()
           return result.ok ? moduleTypeFromDescribe(result.data, generator) : undefined
@@ -306,7 +307,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       }
       void refreshSchemaWatch()
 
-      server.watcher.on('change', (file) => {
+      server.watcher.on('change', file => {
         if (file === bundlePath || file === schemaPath) describeCache = null
         if (file === clientJsonFile) void refreshSchemaWatch()
         // Harness source changed → invalidate its cached virtual module + reload.
@@ -323,9 +324,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       // at resolve time, so a providers file APPEARING or DISAPPEARING needs a
       // re-resolve: invalidate both modules and reload the iframe. (Edits to an
       // existing providers file are ordinary HMR and need nothing from us.)
-      const providersFiles = new Set(
-        PROVIDERS_CANDIDATES.map((name) => join(viteRoot, 'src', name))
-      )
+      const providersFiles = new Set(PROVIDERS_CANDIDATES.map(name => join(viteRoot, 'src', name)))
       const onProvidersFileEvent = (file: string): void => {
         if (!providersFiles.has(file)) return
         for (const id of [PROVIDERS_RESOLVED_ID, HARNESS_RESOLVED_ID]) {
@@ -360,7 +359,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       const editHandler: Connect.NextHandleFunction = async (request, response) => {
         let edit
         try {
-          edit = enrichmentEditSchema.parse(await readJsonBody(request))
+          edit = v.parse(enrichmentEditSchema, await readJsonBody(request))
         } catch (error) {
           respondJson(response, 400, { error: `invalid edit: ${messageOf(error)}` })
           return
@@ -390,7 +389,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       const inputMatchesHandler: Connect.NextHandleFunction = async (request, response) => {
         let body
         try {
-          body = inputMatchesSchema.parse(await readJsonBody(request))
+          body = v.parse(inputMatchesSchema, await readJsonBody(request))
         } catch (error) {
           respondJson(response, 400, { error: `invalid request: ${messageOf(error)}` })
           return
@@ -530,7 +529,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       const filtersWriteHandler: Connect.NextHandleFunction = async (request, response) => {
         let filters
         try {
-          filters = filtersWriteSchema.parse(await readJsonBody(request))
+          filters = v.parse(filtersWriteSchema, await readJsonBody(request))
         } catch (error) {
           respondJson(response, 400, { error: `invalid filters: ${messageOf(error)}` })
           return

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -9,7 +9,6 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import { join, resolve } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import * as v from 'valibot'
 import type { Connect, Plugin } from 'vite'
 import { runDescribe, runGenerate, type CliResult } from './skmtc-cli.ts'
 import {
@@ -21,6 +20,7 @@ import {
   readClientJson,
   writeClientJson
 } from './client-json.ts'
+import { parseRequest } from './parse-request.ts'
 import { SourceState } from './source-state.ts'
 import { moduleTypeFromDescribe } from './descriptors.ts'
 import {
@@ -359,7 +359,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       const editHandler: Connect.NextHandleFunction = async (request, response) => {
         let edit
         try {
-          edit = v.parse(enrichmentEditSchema, await readJsonBody(request))
+          edit = parseRequest(enrichmentEditSchema, await readJsonBody(request))
         } catch (error) {
           respondJson(response, 400, { error: `invalid edit: ${messageOf(error)}` })
           return
@@ -389,7 +389,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       const inputMatchesHandler: Connect.NextHandleFunction = async (request, response) => {
         let body
         try {
-          body = v.parse(inputMatchesSchema, await readJsonBody(request))
+          body = parseRequest(inputMatchesSchema, await readJsonBody(request))
         } catch (error) {
           respondJson(response, 400, { error: `invalid request: ${messageOf(error)}` })
           return
@@ -529,7 +529,7 @@ export function skmtcPreview(options: SkmtcPreviewOptions): Plugin {
       const filtersWriteHandler: Connect.NextHandleFunction = async (request, response) => {
         let filters
         try {
-          filters = v.parse(filtersWriteSchema, await readJsonBody(request))
+          filters = parseRequest(filtersWriteSchema, await readJsonBody(request))
         } catch (error) {
           respondJson(response, 400, { error: `invalid filters: ${messageOf(error)}` })
           return

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,42 +387,14 @@ importers:
         specifier: ^3.0.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.20.5)(yaml@2.8.1)
 
-  packages/core:
-    dependencies:
-      '@deno/shim-deno':
-        specifier: ^0.19.2
-        version: 0.19.2
-      '@types/lodash-es':
-        specifier: 4.17.12
-        version: 4.17.12
-      graphql:
-        specifier: ^16.9.0
-        version: 16.14.2
-      lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
-      openapi-types:
-        specifier: ^12.1.3
-        version: 12.1.3
-      tiny-invariant:
-        specifier: 1.3.3
-        version: 1.3.3
-      valibot:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@6.0.3)
-    devDependencies:
-      '@types/node':
-        specifier: ^20.9.0
-        version: 20.19.13
-
   packages/vite:
     dependencies:
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: ^24.12.3
@@ -531,9 +503,6 @@ packages:
 
   '@deno/shim-deno@0.18.2':
     resolution: {integrity: sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==}
-
-  '@deno/shim-deno@0.19.2':
-    resolution: {integrity: sha512-q3VTHl44ad8T2Tw2SpeAvghdGOjlnLPDNO2cpOxwMrBE/PVas6geWpbpIgrM+czOCH0yejp0yi8OaTuB+NU40Q==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -2527,9 +2496,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@20.19.13':
-    resolution: {integrity: sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==}
-
   '@types/node@22.18.1':
     resolution: {integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==}
 
@@ -3867,10 +3833,6 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-
-  graphql@16.14.2:
-    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -6076,9 +6038,6 @@ packages:
   zod@4.1.8:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
     engines: {node: '>=12.7.0'}
@@ -6172,11 +6131,6 @@ snapshots:
   '@deno/shim-deno-test@0.5.0': {}
 
   '@deno/shim-deno@0.18.2':
-    dependencies:
-      '@deno/shim-deno-test': 0.5.0
-      which: 4.0.0
-
-  '@deno/shim-deno@0.19.2':
     dependencies:
       '@deno/shim-deno-test': 0.5.0
       which: 4.0.0
@@ -8339,10 +8293,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@20.19.13':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.18.1':
     dependencies:
       undici-types: 6.21.0
@@ -9425,7 +9375,7 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.35.0(jiti@2.5.1))
@@ -9445,7 +9395,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -9460,14 +9410,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9482,7 +9432,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10029,8 +9979,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
-
-  graphql@16.14.2: {}
 
   has-bigints@1.1.0: {}
 
@@ -12684,8 +12632,6 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.1.8: {}
-
-  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@18.3.24)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## What

Makes enrichment assignment errors explainable. The matcher's boolean probe cell reduces every misfit to `'false' is not assignable to 'true'` — correct for the verdict, useless as an explanation. This PR:

- **Adds one direct-assignment explain line per candidate** to the probe (`const __e0: InputModule<__F> = __C0`). Its diagnostic carries the compiler's real elaboration; the `DiagnosticMessageChain` is walked as data into `{ code, headline, reasons[] }`, sanitized of probe-internal names (`__C0` → export name, `__F` → the printed field type), and attached to each misfit candidate in the `fits` outcome as an optional `reason`.
- **Verdicts are untouched** — classification never reads explain lines, so a disagreement between the two formulations (e.g. an `any`-typed candidate) can't flip a verdict; pinned by a test.
- **Wire-compatible both ways** — `reason` is optional, so an old desktop ignores it and a new desktop falls back when it's absent.
- **Swaps zod for valibot** at the plugin's HTTP boundaries (enrichment edits, input-matches, filters), aligning with core's validation library; types now inferred via `v.InferOutput`. Net −54 lines.
- **Bumps to 0.6.0** so merge publishes the new wire field.

Desktop counterpart (renders headline as Expected/Received + why-chain): skmtc-hub PR on the same branch name.

## Testing

- 107/107 vitest, including an end-to-end test compiling a real misfit probe: asserts the cell line alone explains nothing while the explain line yields the full chain down to `Type 'string' is not assignable to type 'number'.`
- Clean `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)