### PR TITLE
docs: stuck-journey polish — error routing, debug split, output-first generator pages

### DIFF
--- a/deno/docs/reader-lint-baseline.json
+++ b/deno/docs/reader-lint-baseline.json
@@ -67,9 +67,7 @@
     "reference/settings/enrichments-shape.md|link-to-internal-layer": 2,
     "reference/settings/source-resolution.md|line-number-citation": 1,
     "reference/settings/source-resolution.md|link-to-internal-layer": 1,
-    "reference/stock-generators/overview.md|link-to-internal-layer": 1,
-    "using/how-to/debug-failing-generation.md|line-number-citation": 1,
-    "using/how-to/debug-failing-generation.md|link-to-internal-layer": 1
+    "reference/stock-generators/overview.md|link-to-internal-layer": 1
   },
   "orphans": [
     "concepts/languages.md",

--- a/deno/docs/reference/error-codes.md
+++ b/deno/docs/reference/error-codes.md
@@ -8,6 +8,19 @@ The error model is described conceptually in
 [`concepts/error-handling-philosophy.md`](../concepts/error-handling-philosophy.md).
 This file is the lookup reference for specific codes.
 
+## Find your error
+
+| Where you saw it | What it looks like | Jump to |
+|---|---|---|
+| `manifest.parseIssues[].type` (OAS source) | `INVALID_SCHEMA`, `INVALID_DEPENDENCY_REF`, `MISSING_*_TYPE`, `UNEXPECTED_PROPERTY`, `INVALID_OPERATION`, … | [OAS parse-issue types](#oas-parse-issue-types) |
+| `manifest.parseIssues[].type` (GraphQL source) | `INVALID_TYPE_DEFINITION`, `SKIPPED_FIELD_ARGUMENTS`, `NESTED_LIST_LOSSY`, `DROPPED_DIRECTIVE`, … | [GraphQL parse-issue types](#graphql-parse-issue-types) |
+| Thrown on stderr during generate | `Registered definition mismatch: '<X>' in file '<Y>' …` | [Registered definition mismatch](#registered-definition-mismatch) |
+| Thrown on stderr during generate | `Max lookups reached` | [Max lookups reached](#max-lookups-reached) |
+| Thrown on stderr during generate | `Ref "<$ref>" not found` / `Ref type mismatch for "<$ref>"` | [Ref not found](#ref-ref-not-found) · [Ref type mismatch](#ref-type-mismatch-for-ref) |
+| During `skmtc bundle` or the bundle step of generate | `bundle.js is out of sync with deno.json` / `No matching export … for import` | [Generate-time errors](#generate-time-errors) |
+| Shell `$?` after a run | exit code `0` / `1` / `2` | [CLI exit codes](#cli-exit-codes) |
+| A location string like `paths:/users:post:…` | decoding where an issue occurred | [Issue location strings](#issue-location-strings) |
+
 ## Issue levels
 
 Three levels in the parse-issue stream:

--- a/deno/docs/reference/stock-generators/gen-arktype.md
+++ b/deno/docs/reference/stock-generators/gen-arktype.md
@@ -6,10 +6,6 @@ A model generator. The ArkType analog of `gen-zod` and `gen-valibot`.
 Use when your project prefers ArkType's TypeScript-syntax-mirroring
 DSL over method chains or pipes.
 
-## Source
-
-`skmtc-generators/gen-arktype/src/`
-
 ## What it generates
 
 For a `User` schema:
@@ -34,6 +30,10 @@ export const arktypeEntry = toModelEntry({
   }
 })
 ```
+
+## Source
+
+`skmtc-generators/gen-arktype/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-express.md
+++ b/deno/docs/reference/stock-generators/gen-express.md
@@ -7,10 +7,6 @@ server stub that matches your spec. Demonstrates the
 **shared-singleton pattern** with `tiny-invariant` for instance
 narrowing.
 
-## Source
-
-`skmtc-generators/gen-express/src/`
-
 ## What it generates
 
 Per operation, a registration on a shared `app` Projection:
@@ -33,6 +29,10 @@ app.post('/users', (req, res) => {
 ```
 
 All routes accumulate on a single `app` instance per output file.
+
+## Source
+
+`skmtc-generators/gen-express/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-msw.md
+++ b/deno/docs/reference/stock-generators/gen-msw.md
@@ -6,10 +6,6 @@ An operation generator that demonstrates the **shared-aggregate
 pattern**: one Projection per operation contributes a route, and
 all routes converge into a single `routesList` Projection per file.
 
-## Source
-
-`skmtc-generators/gen-msw/src/`
-
 ## What it generates
 
 Per operation, a `MockRoute`:
@@ -30,6 +26,10 @@ export const toRoutesList = (deps: { ... }) => [
 
 The `toRoutesList` factory accepts dependencies (typically your
 mock data store) and returns the array MSW expects.
+
+## Source
+
+`skmtc-generators/gen-msw/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-shadcn-form.md
+++ b/deno/docs/reference/stock-generators/gen-shadcn-form.md
@@ -8,14 +8,6 @@ The most architecturally interesting stock generator. Demonstrates
 references Zod schemas (from `gen-zod`), a mutation hook (from
 `gen-tanstack-query-*-zod`), and select/table sub-components.
 
-## Source
-
-`skmtc-generators/gen-shadcn-form/src/`
-
-Key files: `ShadcnForm.ts` (the main Projection), `schemaToField.ts`
-(per-schema-shape field-component dispatch), `FormFields.ts`,
-`FormLabel.ts`, `fields/` (per-input-type renderers).
-
 ## What it generates
 
 Per supported operation (POST/PUT/PATCH with object request body):
@@ -35,6 +27,14 @@ export const CreateUserForm = () => {
   )
 }
 ```
+
+## Source
+
+`skmtc-generators/gen-shadcn-form/src/`
+
+Key files: `ShadcnForm.ts` (the main Projection), `schemaToField.ts`
+(per-schema-shape field-component dispatch), `FormFields.ts`,
+`FormLabel.ts`, `fields/` (per-input-type renderers).
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-shadcn-select.md
+++ b/deno/docs/reference/stock-generators/gen-shadcn-select.md
@@ -8,10 +8,6 @@ another resource (e.g., "office" on a contact form, sourced from
 `GET /offices`). Pairs with `gen-shadcn-form`'s
 `fields[].references` enrichment.
 
-## Source
-
-`skmtc-generators/gen-shadcn-select/src/`
-
 ## What it generates
 
 Per supported operation, a React select component:
@@ -26,6 +22,10 @@ export const OfficeSelect = ({ value, onChange }) => {
   )
 }
 ```
+
+## Source
+
+`skmtc-generators/gen-shadcn-select/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-shadcn-table.md
+++ b/deno/docs/reference/stock-generators/gen-shadcn-table.md
@@ -8,10 +8,6 @@ filter (GET + list response), different output (table rather than
 select dropdown). Use for inventory-style screens that display
 many items.
 
-## Source
-
-`skmtc-generators/gen-shadcn-table/src/`
-
 ## What it generates
 
 Per supported operation, a table component:
@@ -41,6 +37,10 @@ export const UsersTable = () => {
   )
 }
 ```
+
+## Source
+
+`skmtc-generators/gen-shadcn-table/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-supabase-hono.md
+++ b/deno/docs/reference/stock-generators/gen-supabase-hono.md
@@ -6,10 +6,6 @@ An operation generator. The Hono-and-Supabase counterpart to
 `gen-express`. Same shared-singleton pattern, different framework
 and runtime target.
 
-## Source
-
-`skmtc-generators/gen-supabase-hono/src/`
-
 ## What it generates
 
 A Hono app with per-operation routes:
@@ -31,6 +27,10 @@ app.post('/users', async (c) => {
   return c.json({ ...body, id: 'TODO' }, 201)
 })
 ```
+
+## Source
+
+`skmtc-generators/gen-supabase-hono/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-tanstack-query-fetch-zod.md
+++ b/deno/docs/reference/stock-generators/gen-tanstack-query-fetch-zod.md
@@ -8,10 +8,6 @@ request/response validation. The most-cloned client generator —
 because the fetch wrapper, error handling, and base URL conventions
 are almost always team-specific.
 
-## Source
-
-`skmtc-generators/gen-tanstack-query-fetch-zod/src/`
-
 ## What it generates
 
 Per operation:
@@ -34,6 +30,10 @@ export const useCreateUser = () =>
 The `user`/`userBody` Zod schemas come from `gen-zod` via
 `insertNormalizedModel` — both generators share a single registered
 schema.
+
+## Source
+
+`skmtc-generators/gen-tanstack-query-fetch-zod/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-tanstack-query-supabase-zod.md
+++ b/deno/docs/reference/stock-generators/gen-tanstack-query-supabase-zod.md
@@ -8,10 +8,6 @@ An operation generator. The Supabase-transport variant of
 the variation is in the Projection's `toString()` (Supabase
 client calls instead of `fetch`).
 
-## Source
-
-`skmtc-generators/gen-tanstack-query-supabase-zod/src/`
-
 ## What it generates
 
 Per operation, hooks that call the Supabase Postgrest client:
@@ -23,6 +19,10 @@ export const useGetUsers = () =>
     queryFn: () => supabase.from('users').select('*').then(({ data }) => userListSchema.parse(data))
   })
 ```
+
+## Source
+
+`skmtc-generators/gen-tanstack-query-supabase-zod/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-typescript.md
+++ b/deno/docs/reference/stock-generators/gen-typescript.md
@@ -6,10 +6,6 @@ A model generator (one Projection per schema component). Produces
 `type` aliases — not interfaces, not classes — so the output
 composes cleanly with structural-typing-heavy codebases.
 
-## Source
-
-`skmtc-generators/gen-typescript/src/`
-
 ## What it generates
 
 For a `User` schema:
@@ -26,6 +22,10 @@ Per OAS-schema-variant TS classes (`TsObject`, `TsArray`,
 `TsString`, etc.) handle the dispatch. The `toTsValue` function in
 `src/Ts.ts` is the central switch from `OasSchema.type` to the
 right TS class.
+
+## Source
+
+`skmtc-generators/gen-typescript/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-valibot.md
+++ b/deno/docs/reference/stock-generators/gen-valibot.md
@@ -6,10 +6,6 @@ A model generator. The Valibot analog of `gen-zod`. Same entry
 shape, different library. Use when your project standardizes on
 Valibot for its tree-shaking advantages or its functional API.
 
-## Source
-
-`skmtc-generators/gen-valibot/src/`
-
 ## What it generates
 
 For a `User` schema:
@@ -37,6 +33,10 @@ export const valibotEntry = toModelEntry({
 
 All variation lives in `ValibotProjection` and the per-variant
 classes.
+
+## Source
+
+`skmtc-generators/gen-valibot/src/`
 
 ## Key decisions
 

--- a/deno/docs/reference/stock-generators/gen-zod.md
+++ b/deno/docs/reference/stock-generators/gen-zod.md
@@ -6,10 +6,6 @@ A model generator. Produces `export const userBody = z.object({...})`
 runtime schemas — the validation counterpart to `gen-typescript`'s
 static types. Most production setups run them together.
 
-## Source
-
-`skmtc-generators/gen-zod/src/`
-
 ## What it generates
 
 For a `User` schema:
@@ -28,6 +24,10 @@ Per-variant classes (`ZodObject`, `ZodArray`, `ZodString`,
 `ZodInteger`, `ZodNumber`, `ZodBoolean`, `ZodUnion`, `ZodVoid`,
 `ZodUnknown`) handle the dispatch. The recursive structure mirrors
 `OasSchema`.
+
+## Source
+
+`skmtc-generators/gen-zod/src/`
 
 ## Key decisions
 

--- a/deno/docs/skills/skmtc-debug/SKILL.md
+++ b/deno/docs/skills/skmtc-debug/SKILL.md
@@ -403,6 +403,44 @@ for '<METHOD> <path>' — peer has no enrichments configured. Only
    `core/dsl/operation/oas/OasOperationDriver.test.ts` →
    "Variant validation".
 
+### Scenario H: `TypeError: this.context.X is not a function` (workspace fallback to JSR)
+
+**Symptom:** a runtime exception like `TypeError:
+this.context.insertNormalizedModel is not a function` (any context
+method) during `skmtc generate`, while `bundle.js` visibly contains a
+similar-but-differently-spelled method (`insertNormalisedModel` vs
+`insertNormalizedModel`, `toRefName` vs `getRefName`).
+
+**Cause:** two `@skmtc/core` versions in one bundle — a workspace
+member silently fell back to the JSR-published version:
+
+1. `@skmtc/worker` pins `@skmtc/core` with an exact version (for
+   example `@skmtc/core@0.4.0`).
+2. The local workspace member declares a different version (for
+   example `0.4.4`).
+3. Deno's workspace resolution rejects the mismatch and silently
+   fetches the worker's exact-pinned core from JSR. The bundle then
+   contains one `GenerateContext` from the worker's core and another
+   from the generators' core; at runtime `this.context` is the wrong
+   one.
+
+**Diagnostic path:**
+
+```bash
+grep -i "Workspace member" .skmtc/<project>/.settings/error-logs.txt
+```
+
+The fallback emits `Warning: Workspace member '@skmtc/core@X' was not
+used because it did not match '@skmtc/core@Y'` — and it surfaces ONLY
+in `error-logs.txt`: bundle doesn't print it, generate doesn't
+mention it, `doctor` doesn't currently flag it. The log file is the
+authoritative diagnostic.
+
+**Fix:** align the worker's expected `@skmtc/core` version with the
+workspace — upgrade the worker to a ranged pin (`^0.4`) or pin the
+workspace member to the worker's exact version. One core copy in the
+bundle → the method exists at runtime.
+
 ## 7. Anti-patterns specific to debugging
 
 The defaults to override when in debug mode:

--- a/deno/docs/using/how-to/debug-failing-generation.md
+++ b/deno/docs/using/how-to/debug-failing-generation.md
@@ -8,6 +8,11 @@
 Generation didn't produce the files you expected, the files have
 unexpected contents, or the CLI exited non-zero.
 
+One thing to trust from the start: a failed item never kills the
+run. Everything unaffected still generates, and the manifest names
+exactly what was skipped or errored and why. This page is about
+reading that account.
+
 ## Prerequisites
 
 - A SKMTC project with the generator(s) installed.
@@ -129,79 +134,6 @@ Two common causes:
    didn't `skmtc bundle`, the old bundle is used. `skmtc doctor`
    flags this.
 
-#### `TypeError: this.context.X is not a function` (workspace fallback to JSR)
-
-You see a runtime exception of the form `TypeError:
-this.context.insertNormalizedModel is not a function` (or any other
-context method) during `skmtc generate`, and `bundle.js` visibly
-contains a similar-but-spelled-differently method (e.g.,
-`insertNormalisedModel` vs `insertNormalizedModel`, or `toRefName`
-vs `getRefName`). The bundle ran something, but the runtime says
-the method doesn't exist.
-
-This is almost always **two `@skmtc/core` versions in the same
-bundle** — the result of a workspace member silently falling back to
-the JSR-published version. Mechanics:
-
-1. `@skmtc/worker` pins `@skmtc/core` with an *exact* version, e.g.,
-   `"@skmtc/core@0.4.0"`.
-2. Your local workspace member declares a different version, e.g.,
-   `@skmtc/core@0.4.4`.
-3. Deno's workspace resolution checks `0.4.4` against the exact-pin
-   `0.4.0`, doesn't match, and **silently fetches `@skmtc/core@0.4.0`
-   from JSR for the worker's transitive use**. The bundle ends up
-   containing one `GenerateContext` from the worker (JSR-pinned core)
-   and another from the generators (compiled against the local
-   workspace core). When the generator calls
-   `this.context.someMethod`, `this.context` is the worker's
-   GenerateContext at runtime — the wrong one.
-
-Diagnose:
-
-```bash
-cat .skmtc/<project>/.settings/error-logs.txt | grep -i "Workspace member"
-```
-
-The fallback emits a line like:
-
-```
-Warning: Workspace member '@skmtc/core@0.4.4' was not used because
-it did not match '@skmtc/core@0.4.0'
-    at https://jsr.skmtc.dev/@skmtc/worker/0.2.0/mod.ts:1:58
-```
-
-The warning surfaces only in `error-logs.txt` — the `bundle` command
-doesn't print it on stdout, the generate run doesn't mention it, and
-`doctor` doesn't currently surface it as an error. The log file is
-the authoritative diagnostic.
-
-Fix: bring the worker's expected `@skmtc/core` version in line with
-the workspace, either by upgrading the worker to a version with a
-ranged pin (`^0.4`) or by pinning the workspace member to the
-worker's exact-pinned version. The bundle then includes only one
-copy of `GenerateContext` and the method exists at runtime.
-
-#### Same-name collision (Driver throws; bare register silent)
-
-Two generators produce a definition with the same `(identifier.name,
-exportPath)`. Behavior depends on the insertion path:
-
-- **Driver path** (`insertModel` / `insertOperation` /
-  `insertNormalizedModel`): the second writer throws
-  `Registered definition mismatch: '<name>' in file '<exportPath>'.
-  Cached key '<key>' does not match new key '<key>'`. Loud failure
-  via `affirmDefinition`.
-- **Bare `register({ definitions })`**: first writer wins; second
-  is silently discarded. No warning logged.
-
-Symptoms:
-- *Driver path:* generation aborts with the mismatch error — look
-  at the file and key in the message to identify the colliding
-  generators.
-- *Bare register:* a file is missing content you expected. Confirm
-  by checking each generator's output independently (uninstall the
-  others temporarily).
-
 ## Verification
 
 After the fix, regenerate and confirm:
@@ -226,5 +158,3 @@ After the fix, regenerate and confirm:
 - [Error codes reference](../../reference/error-codes.md)
 - [`skmtc doctor` reference](../../reference/cli/doctor.md)
 - [`skmtc agent-context` reference](../../reference/cli/agent-context.md)
-- [`skmtc-debug` skill](../../skills/skmtc-debug/SKILL.md) —
-  broader debugging operational guidance


### PR DESCRIPTION
Step 7 of the docs learning-journey program: the stuck-user moment, plus the evaluate-stage page order.

**`reference/error-codes.md`** — new "Find your error" routing table at the top. A user arrives holding a literal string; the page interleaved two lookup modalities (parse-issue codes in `manifest.parseIssues` vs thrown stderr messages) with no router. The table maps *where you saw it* → the section that decodes it (issue codes, thrown messages, bundle-step errors, exit codes, location strings).

**`using/how-to/debug-failing-generation.md`** — the audit's worst using-tree leak (score 3, 2× the length of any sibling). The user half stays (json/stderr capture, parseIssues, per-file results, missing-flag, no-output, wrong-output, module-not-found). The two authoring-side incident write-ups move out:
- workspace-fallback-to-JSR → **new Scenario H in the skmtc-debug skill** (was uncovered there; error-logs.txt is the authoritative diagnostic)
- same-name collision → dropped; already Scenario E in the skill, and the error string is in error-codes.md
- the direct link to the agent-facing skill is gone from the reader page
- the opening now states the parse-fails-open trust point: one bad item never kills the run; the manifest accounts for everything (aha #8 asserted where the stuck reader needs it)

**All 12 `reference/stock-generators/gen-*.md`** — `## What it generates` now precedes `## Source`. A deciding user evaluates output; a repo path was the first thing on every page.

**Merge-order note:** after #58, rebase + `--update-reader-baseline` (removes one baselined skills-link violation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)