### PR TITLE
docs: stage the aha payoff beats (recipe, CI, dev loop)

### DIFF
--- a/deno/docs/authoring/tutorials/02-authoring-a-model-generator.md
+++ b/deno/docs/authoring/tutorials/02-authoring-a-model-generator.md
@@ -251,6 +251,10 @@ skmtc dev my-project
 Watch mode. Re-runs generation on each source change. Faster
 than `skmtc bundle && skmtc generate` for iteration.
 
+Leave it running for the rest of your authoring work — every save
+regenerates. This loop is how generator authoring is meant to feel:
+edit TypeScript, save, read the new output.
+
 Make a change to `SchemaMeta.toString()`, save, and watch the
 output update. Verify via:
 

--- a/deno/docs/authoring/tutorials/03-authoring-an-operation-generator.md
+++ b/deno/docs/authoring/tutorials/03-authoring-an-operation-generator.md
@@ -263,6 +263,8 @@ skmtc dev my-project
 ```
 
 Edit, save, watch output update. Verify with `cat src/generated/pets/getPetById.curl.ts`.
+Leave `dev` running whenever you're editing a generator — the
+edit-save-read loop is the normal way to work.
 
 ## What just happened
 

--- a/deno/docs/using/how-to/use-in-ci-cd.md
+++ b/deno/docs/using/how-to/use-in-ci-cd.md
@@ -103,6 +103,12 @@ git diff --exit-code src/generated/
 If the diff is non-empty, the committed output is stale — fail
 the build and prompt the developer to regenerate.
 
+This check is also where committed generated output pays off in
+review: a schema change shows up as an ordinary, readable diff in
+the pull request, so your API contract change is reviewed in the
+same place as the code that motivated it. Generated code you can't
+diff is a black box; this is the opposite.
+
 ## Troubleshooting
 
 - **Schema URL unreachable in CI** — The CI environment may have

--- a/deno/docs/using/recipes/full-stack-typescript-app.md
+++ b/deno/docs/using/recipes/full-stack-typescript-app.md
@@ -4,6 +4,12 @@
 > one OpenAPI document — the standard SKMTC combination for a
 > TypeScript/React app.
 
+This recipe exists for one moment: add a field to the schema,
+regenerate, and watch the type, the validator, and the form update
+together while everything that imports them stays consistent. The
+last section stages that moment; the rest builds the stack that
+makes it possible.
+
 ## What you'll build
 
 A `src/generated/` tree containing:
@@ -171,6 +177,25 @@ const worker = setupWorker(...toRoutesList({ store: yourMockStore }))
   search/list UI components that pair with it.
 - **Add a table.** Install `@skmtc/gen-shadcn-table` for list-GET
   operations.
+
+## The payoff: change the schema
+
+Add one field to a schema component in your OpenAPI document — say
+`nickname: { type: string }` on `Pet` — and regenerate:
+
+```bash
+skmtc generate <project>
+git diff --stat src/generated/
+```
+
+The diff touches every file that spells out `Pet`'s shape: the type
+gains a field, the validator gains a rule, the form gains an input.
+The hooks and mocks that import those definitions stay consistent
+without changing, because they reference the shared artifacts rather
+than duplicating them (see
+[cross-generator coordination](../../concepts/cross-generator-coordination.md)).
+One schema edit, one regenerate, a fully consistent stack — this
+property is what the recipe exists to demonstrate.
 
 ## Source
 


### PR DESCRIPTION
Step 8 (partial) of the docs learning-journey program. The audit found the docs *assert* SKMTC's payoff moments persuasively but rarely *stage* them — the reader should see the proof in their own terminal. The conflict-free subset:

- **Full-stack recipe** — now declares its reason for existing in the opening and stages the flagship moment at the end: add `nickname` to `Pet`, regenerate, `git diff --stat` — type gains a field, validator gains a rule, form gains an input, and the hooks/mocks that import them stay consistent *without changing* (that last part is the honest mechanics, and teaches the shared-definition model better than a vague "five files update").
- **CI/CD how-to** — the drift check now names its payoff: schema changes become ordinary reviewable diffs in the PR. Turns a compliance-flavored page into a selling moment.
- **Authoring tutorials 02/03** — `skmtc dev` was used as a verification step but the loop itself was never named; now: "leave it running — edit TypeScript, save, read the new output."

**Deferred to post-merge** (files owned by #56/#59): tutorial 02's add-field beat, tutorial 03's deliberate-typo beat (blocked on its step-1/step-2 shape fix), the break-the-schema staged beat, and concept openings led by the violated prior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)