### PR TITLE
docs: tutorial batch — stage the flagship payoff, fix the enrichment shape

### DIFF
--- a/deno/docs/using/tutorials/01-your-first-generation.md
+++ b/deno/docs/using/tutorials/01-your-first-generation.md
@@ -82,6 +82,9 @@ skmtc generate petstore
 The engine fetches the spec, runs `gen-zod` against each schema
 component, and writes the artifacts to `src/generated/`.
 
+If the remote fetch fails (offline, proxy), download the spec to a
+file and use the local-path form from Step 4.
+
 ## Step 6: Read the output
 
 ```bash

--- a/deno/docs/using/tutorials/02-multiple-generators.md
+++ b/deno/docs/using/tutorials/02-multiple-generators.md
@@ -82,7 +82,6 @@ Try swapping the install order:
 ```bash
 skmtc remove petstore @skmtc/gen-zod
 skmtc remove petstore @skmtc/gen-typescript
-skmtc install @skmtc/gen-tanstack-query-fetch-zod petstore  # already installed
 skmtc install @skmtc/gen-typescript petstore
 skmtc install @skmtc/gen-zod petstore
 skmtc generate petstore
@@ -90,6 +89,62 @@ skmtc generate petstore
 
 The output is **identical**. Generator order doesn't matter — see
 [how idempotency works](../../explanation/how-idempotency-works.md).
+
+## Step 5: Change the schema and watch the fan-out
+
+So far the schema has been a remote URL. Make it local so you can
+edit it. From the workspace root:
+
+```bash
+curl -o openapi.json https://petstore3.swagger.io/api/v3/openapi.json
+```
+
+Point `source` at the file in `.skmtc/petstore/.settings/client.json`
+(relative paths resolve against the workspace root):
+
+```jsonc
+{ "source": "./openapi.json" }
+```
+
+Now add a field. In `openapi.json`, find
+`components.schemas.Pet.properties` and add:
+
+```jsonc
+"nickname": { "type": "string" }
+```
+
+Regenerate and look for it:
+
+```bash
+skmtc generate petstore
+grep -rn "nickname" src/generated/
+```
+
+Every file that spells out `Pet`'s shape updated in one regenerate —
+the type gained a field and the validator gained a rule — while the
+hook files that import them stayed consistent without changing. This
+is the property you'll lean on daily: edit the schema, regenerate,
+and everything derived from it agrees.
+
+## Step 6 (optional): break the schema on purpose
+
+While the schema is local, see what a bad item costs. In
+`openapi.json`, change any `"$ref"` to point at a schema that doesn't
+exist — for example `"#/components/schemas/DoesNotExist"` — and
+regenerate:
+
+```bash
+skmtc generate petstore --json > out.json
+jq '.manifest.parseIssues' out.json
+```
+
+The run completes. Unaffected files regenerate as normal; the broken
+item and everything that depended on it are pruned rather than
+mis-generated, and `parseIssues` names the casualty
+(`INVALID_DEPENDENCY_REF`) with its location. One bad schema never
+kills the run — the manifest always tells you exactly what it cost.
+
+Undo the edit and regenerate before moving on.
 
 ## What just happened
 
@@ -104,6 +159,11 @@ generators changed nothing.
 How that works — files as keyed maps, insert as create-or-reuse — is
 one short page:
 [Definitions and files](../../concepts/definitions-and-files.md).
+
+Steps 5 and 6 showed the two properties this buys you day to day: a
+schema edit fans out to every derived artifact in one regenerate, and
+a schema mistake narrows the output instead of killing the run, with
+the manifest naming exactly what was skipped.
 
 ## Next steps
 

--- a/deno/docs/using/tutorials/03-customize-with-enrichments.md
+++ b/deno/docs/using/tutorials/03-customize-with-enrichments.md
@@ -34,13 +34,16 @@ For `gen-shadcn-form`, the shape is roughly:
   "submitLabel": "string",
   "fields": [
     {
-      "id": "string",         // matches a property name in the request body schema
+      // binds this entry to a request-body property — the path IS the join key
+      "moduleSelect": { "schemaPath": ["name"] },
       "label": "string",
       "placeholder": "string"
     }
   ]
 }
 ```
+
+All keys are optional — provide only what you override.
 
 The full schema is documented at [gen-shadcn-form's reference](../../reference/stock-generators/gen-shadcn-form.md).
 
@@ -55,7 +58,7 @@ Edit `.skmtc/petstore/.settings/client.json`:
 
 ```jsonc
 {
-  "source": "https://petstore3.swagger.io/api/v3/openapi.json",
+  "source": "./openapi.json",
   "settings": {
     "basePath": "src/generated",
     "enrichments": {
@@ -90,6 +93,12 @@ operation generators — the override sits under the `variant` key
 [enrichments shape reference](../../reference/settings/enrichments-shape.md)
 for all three routing shapes.
 
+Two validation behaviors worth knowing before you edit: a
+wrongly-typed value (a number where `title` expects a string) fails
+the run with a validation error naming the path — but an unknown key
+is silently ignored. If a customization doesn't land, check the key
+spelling and the routing path first.
+
 ## Step 3: Regenerate
 
 ```bash
@@ -114,23 +123,17 @@ name". Other operations use the form generator's defaults
 
 ## What just happened
 
-`client.json#settings.enrichments` is read by the engine and
-routed to each generator instance. The `toOasOperationProjectionBase`
-factory looks up
-`enrichments[generatorId][operation.path][operation.method][variant]`
-for the current operation and validates the result against the
-generator's Valibot schema. The validated `{ subject, generator,
-stack }` umbrella lands on the Projection as
-`this.settings.enrichments` — read your per-operation config off its
-`subject` scope:
+Your `client.json` entry was routed to the form generator by the
+path `[generatorId][path][method][variant]` and validated against
+the shape the generator declares. Where you provided a value (the
+`title` for `POST /pet`), it overrode the generator's default; where
+you didn't, the defaults applied — which is why the other operations'
+forms are unchanged. Configuration reached generated output without
+you touching any code.
 
-```ts
-const { title, submitLabel } = this.settings.enrichments.subject ?? {}
-return `<Form><h2>${title ?? defaultTitle}</h2>...<Button>${submitLabel ?? 'Submit'}</Button></Form>`
-```
-
-When you provided a `title` for `POST /pet`, it landed there. When
-you didn't (for other operations), the `??` defaults kicked in.
+How enrichments are declared and routed — including what generator
+authors do on the other side of this contract — is the
+[enrichments concept](../../concepts/enrichments.md).
 
 ## Next steps
 


### PR DESCRIPTION
The tutorial batch deferred from the learning-journey program, now unblocked by the merged PRs.

**Tutorial 02 — the flagship aha, staged.** The one-schema→five-files fan-out was asserted in the README and staged in the full-stack recipe (#65), but never in the tutorial path. New Step 5: make the schema local (`curl` + `source: ./openapi.json` — relative resolution verified against source-resolution.md: workspace-root relative), add `nickname` to `Pet`, regenerate, `grep -rn nickname src/generated/`. Phrasing is layout-agnostic and honest: files that spell out Pet's shape change; importers stay consistent without changing. New optional Step 6 stages parse-fails-open: break a `$ref`, regenerate, the run completes and `parseIssues` names the casualty (`INVALID_DEPENDENCY_REF`). Also drops the reorder experiment's self-contradicting `install # already installed` line.

**Tutorial 03 — the staging-killer accuracy fix.** Step 1 taught `{ id, label, placeholder }`; Step 2's own example used `moduleSelect.schemaPath`. **Verified against `gen-shadcn-form/src/enrichments.ts`**: there is no `id` — `moduleSelect` (with `schemaPath` as the join key) is the real shape, so Step 1 now teaches it. Plus:
- `source` line consistent with tutorial 02's local-schema end state.
- A validation note verified against the actual `v.parse`/`v.object` semantics in `toOasOperationProjectionBase`: **wrongly-typed values fail loudly naming the path, but unknown keys are silently ignored** — the note tells readers to check spelling first when a customization doesn't land.
- Recap rewritten reader-facing (no more `toOasOperationProjectionBase` + Projection code in the using tree).

**Tutorial 01** — one-line fetch-failure fallback nudge.

⚠️ **Product observation from the verification** (for the backlog, not this PR): because enrichment schemas are plain `v.object`, a misspelled enrichment key is *silently ignored* — the most common config typo produces no signal anywhere. `v.strictObject` (or a warn pass over unknown keys) would turn that into the loud, path-naming error users expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)