### PR TITLE
chore: release @skmtc/core 0.27.0 + cascade (attribution)

### DIFF
--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,16 +1,16 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {
     "@/": "./",
     "@cliffy/command": "jsr:@cliffy/command@1.1.0",
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0",
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0",
     "@skmtc/convert": "jsr:@skmtc/convert@0.1.17",
-    "@skmtc/worker": "jsr:@skmtc/worker@0.3.46",
-    "@skmtc/worker/types": "jsr:@skmtc/worker@0.3.46/types",
-    "@skmtc/server": "jsr:@skmtc/server@0.2.57",
+    "@skmtc/worker": "jsr:@skmtc/worker@0.3.47",
+    "@skmtc/worker/types": "jsr:@skmtc/worker@0.3.47/types",
+    "@skmtc/server": "jsr:@skmtc/server@0.2.58",
     "chokidar": "npm:chokidar@^4.0.3",
     "ink": "npm:ink@^6.2.3",
     "@inkjs/ui": "npm:@inkjs/ui@^2.0.0",
@@ -23,11 +23,22 @@
   },
   "permissions": {
     "default": {
-      "read": ["*"],
-      "write": ["*"],
-      "env": ["*"],
-      "sys": ["homedir"],
-      "net": ["jsr.io", "skm.tc"]
+      "read": [
+        "*"
+      ],
+      "write": [
+        "*"
+      ],
+      "env": [
+        "*"
+      ],
+      "sys": [
+        "homedir"
+      ],
+      "net": [
+        "jsr.io",
+        "skm.tc"
+      ]
     }
   },
   "compilerOptions": {

--- a/deno/core/deno.json
+++ b/deno/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/core",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "license": "Apache-2.0",
   "imports": {
     "@/": "./",
@@ -68,9 +68,14 @@
     "noImplicitAny": true
   },
   "test": {
-    "exclude": [".scripts/build-node.ts"]
+    "exclude": [
+      ".scripts/build-node.ts"
+    ]
   },
   "publish": {
-    "exclude": ["anchors/spike-reanchor.ts", "anchors/spike-descend.ts"]
+    "exclude": [
+      "anchors/spike-reanchor.ts",
+      "anchors/spike-descend.ts"
+    ]
   }
 }

--- a/deno/lang-csharp/deno.json
+++ b/deno/lang-csharp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-csharp",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "license": "Apache-2.0",
   "exports": {
@@ -11,6 +11,6 @@
     "test": "deno test --allow-all"
   },
   "imports": {
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0"
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0"
   }
 }

--- a/deno/lang-go/deno.json
+++ b/deno/lang-go/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-go",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "Apache-2.0",
   "exports": {
@@ -10,6 +10,6 @@
     "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0"
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0"
   }
 }

--- a/deno/lang-kotlin/deno.json
+++ b/deno/lang-kotlin/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-kotlin",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "license": "Apache-2.0",
   "exports": {
@@ -11,6 +11,6 @@
     "test": "deno test --allow-all"
   },
   "imports": {
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0"
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0"
   }
 }

--- a/deno/lang-php/deno.json
+++ b/deno/lang-php/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-php",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "Apache-2.0",
   "exports": {
@@ -10,6 +10,6 @@
     "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0"
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0"
   }
 }

--- a/deno/lang-rust/deno.json
+++ b/deno/lang-rust/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-rust",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "Apache-2.0",
   "exports": {
@@ -10,6 +10,6 @@
     "publish": "deno publish --allow-slow-types --allow-dirty"
   },
   "imports": {
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0"
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0"
   }
 }

--- a/deno/lang-typescript/deno.json
+++ b/deno/lang-typescript/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-typescript",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts"
@@ -10,6 +10,6 @@
     "test": "deno test --allow-all"
   },
   "imports": {
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0"
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0"
   }
 }

--- a/deno/server/deno.json
+++ b/deno/server/deno.json
@@ -1,13 +1,13 @@
 {
   "name": "@skmtc/server",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts"
   },
   "imports": {
     "hono": "npm:hono@4.7.2",
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0",
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0",
     "@skmtc/convert": "jsr:@skmtc/convert@0.1.17"
   },
   "tasks": {

--- a/deno/worker/deno.json
+++ b/deno/worker/deno.json
@@ -1,17 +1,19 @@
 {
   "name": "@skmtc/worker",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts",
     "./types": "./types.ts"
   },
   "imports": {
-    "@skmtc/core": "jsr:@skmtc/core@0.26.0",
+    "@skmtc/core": "jsr:@skmtc/core@0.27.0",
     "openapi-types": "npm:openapi-types@^12.1.3"
   },
   "compilerOptions": {
-    "lib": ["deno.worker"]
+    "lib": [
+      "deno.worker"
+    ]
   },
   "tasks": {
     "publish": "deno publish --allow-slow-types --allow-dirty"


### PR DESCRIPTION
Version bumps only, produced by `deno task bump core --minor`. #66 merged without bumping the deno packages, so the merge-time `deno task release` had nothing to publish — the host-side attribution post-pass, formatted-coordinate sidecar emission, adapter re-anchor primitives, and formatter-detection hint are unreleased until this lands. Core takes the minor; the nine downstream `@skmtc/*` packages patch-bump with repinned imports, exactly what the release cascade would produce. Merging publishes via the Publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)