### PR TITLE
fix: restore packages/core lockfile importer (unblocks npm publish of core 0.27.0)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,34 @@ importers:
         specifier: ^3.0.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.1)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.20.5)(yaml@2.8.1)
 
+  packages/core:
+    dependencies:
+      '@deno/shim-deno':
+        specifier: ^0.19.2
+        version: 0.19.2
+      '@types/lodash-es':
+        specifier: 4.17.12
+        version: 4.17.12
+      graphql:
+        specifier: ^16.9.0
+        version: 16.14.2
+      lodash-es:
+        specifier: 4.17.21
+        version: 4.17.21
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
+      tiny-invariant:
+        specifier: 1.3.3
+        version: 1.3.3
+      valibot:
+        specifier: 1.1.0
+        version: 1.1.0(typescript@6.0.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.9.0
+        version: 20.19.43
+
   packages/vite:
     dependencies:
       oxc-parser:
@@ -509,6 +537,9 @@ packages:
 
   '@deno/shim-deno@0.18.2':
     resolution: {integrity: sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==}
+
+  '@deno/shim-deno@0.19.2':
+    resolution: {integrity: sha512-q3VTHl44ad8T2Tw2SpeAvghdGOjlnLPDNO2cpOxwMrBE/PVas6geWpbpIgrM+czOCH0yejp0yi8OaTuB+NU40Q==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -2659,6 +2690,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
   '@types/node@22.18.1':
     resolution: {integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==}
 
@@ -3996,6 +4030,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -6318,6 +6356,11 @@ snapshots:
       '@deno/shim-deno-test': 0.5.0
       which: 4.0.0
 
+  '@deno/shim-deno@0.19.2':
+    dependencies:
+      '@deno/shim-deno-test': 0.5.0
+      which: 4.0.0
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -8541,7 +8584,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 24.13.2
 
   '@types/lodash-es@4.17.12':
     dependencies:
@@ -8558,6 +8601,10 @@ snapshots:
   '@types/minimatch@5.1.2': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.18.1':
     dependencies:
@@ -8618,7 +8665,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.18.1
+      '@types/node': 24.13.2
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
@@ -10245,6 +10292,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  graphql@16.14.2: {}
 
   has-bigints@1.1.0: {}
 


### PR DESCRIPTION
The Publish run for #72 released the JSR cascade fine but failed the `Publish @skmtc/core to npm` step: `pnpm install --filter @skmtc/core --frozen-lockfile` rejects because the lockfile lost the `packages/core` importer. Root cause: `packages/core` is dnt-generated and gitignored, so any `pnpm install` executed without a local core build (as on the oxfmt-adoption branch in #66) silently prunes its entry.

Fix: lockfile regenerated with the dnt build present — the CI command now passes locally. Merging re-runs Publish; the npm if-behind guard picks up the stranded `@skmtc/core` 0.27.0.

Possible follow-up (not in this PR): have the workflow run the dnt build before the frozen install, or commit a minimal `packages/core/package.json`, so a stale-importer lockfile can't strand npm publishes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)