### PR TITLE
Export the input matcher for external hosts (@skmtc/vite/matcher)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "homepage": "https://skm.tc",
   "bugs": "https://github.com/skmtc/skmtc/issues",
   "license": "Apache-2.0",
@@ -29,6 +29,10 @@
     "./wire": {
       "types": "./dist/wire.d.mts",
       "default": "./dist/wire.mjs"
+    },
+    "./matcher": {
+      "types": "./dist/matcher.d.mts",
+      "default": "./dist/matcher.mjs"
     }
   },
   "scripts": {

--- a/packages/vite/src/matcher.test.ts
+++ b/packages/vite/src/matcher.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import * as matcher from './matcher.ts'
+
+// The subpath's contract with external hosts (the preview container
+// harness): behavior is covered by source-state.test.ts / input-matcher.test.ts;
+// this pins the exported SURFACE so a refactor can't silently drop what a
+// host imports.
+describe('matcher subpath surface', () => {
+  it('exports what a harness host needs', () => {
+    expect(typeof matcher.SourceState).toBe('function')
+    expect(typeof matcher.matchInputs).toBe('function')
+    expect(typeof matcher.moduleTypeFromDescribe).toBe('function')
+    expect(typeof matcher.runDescribe).toBe('function')
+    expect(typeof matcher.runGenerate).toBe('function')
+  })
+})

--- a/packages/vite/src/matcher.ts
+++ b/packages/vite/src/matcher.ts
@@ -1,0 +1,26 @@
+// The server-side input matcher, exported for hosts OTHER than this plugin —
+// concretely the skmtc-hub preview container's harness, which mounts the same
+// `POST /input-matches` next to the project's real node_modules. NODE-ONLY:
+// unlike `./wire` (schemas the browser bundles), this graph reaches the
+// filesystem, spawns the skmtc CLI, and loads the project's TypeScript — do
+// not import it from browser code.
+//
+// The pieces:
+// - `SourceState` — the per-project cache that owns the TS language service,
+//   the schema/candidates/gen-map reads and the match memo; hosts construct
+//   one per project root, `attach()` a watcher, call `match()`, and signal
+//   `onGenerateSuccess()` after a regenerate.
+// - `runDescribe` + `moduleTypeFromDescribe` — the describe-based
+//   `resolveModuleType` a host wires into `SourceStateOptions` when a local
+//   bundle exists; a remote-mode host (no bundle) resolves the deployed
+//   stack's `/descriptors` instead and maps it through the same helper shape.
+
+export { SourceState, type MatchRequest, type SourceStateOptions } from './source-state.ts'
+export {
+  matchInputs,
+  type MatchArgs,
+  type MatcherService,
+  type MatcherSubject
+} from './input-matcher.ts'
+export { moduleTypeFromDescribe } from './descriptors.ts'
+export { runDescribe, runGenerate, type CliResult } from './skmtc-cli.ts'

--- a/packages/vite/tsdown.config.ts
+++ b/packages/vite/tsdown.config.ts
@@ -13,8 +13,11 @@ import { defineConfig } from 'tsdown'
 // `wire` is its own entry so browser consumers (the desktop SPA) can import
 // the wire schemas via `@skmtc/vite/wire` without pulling the node-only
 // plugin graph into their bundle.
+//
+// `matcher` is the inverse: the node-only matcher machinery for non-plugin
+// hosts (the preview container harness) — never for browsers.
 export default defineConfig({
-  entry: ['src/index.ts', 'src/enrichment-leaf.ts', 'src/wire.ts'],
+  entry: ['src/index.ts', 'src/enrichment-leaf.ts', 'src/wire.ts', 'src/matcher.ts'],
   format: 'esm',
   dts: true,
   clean: true,


### PR DESCRIPTION
## What

Phase 1 of skmtc-hub's `notes/plan-2026-07-12-spa-server-side-input-matcher.md` — retiring the hub SPA's browser-side matcher (`oas-to-ts.ts` + `@typescript/ata`) in favour of the same server-side matcher the desktop uses, hosted in the preview container.

- New `./matcher` subpath exporting `SourceState` (+ `MatchRequest`/`SourceStateOptions`), `matchInputs`, `runDescribe`/`runGenerate`, and `moduleTypeFromDescribe` — everything the container harness needs to mount `POST /input-matches` next to the project's real `node_modules`.
- Node-only by design (filesystem, CLI spawn, project TypeScript) — the inverse of `./wire`; the browser-safety test on wire is unaffected (still zero `node:` imports in `dist/wire.mjs`).
- Surface pinned by `matcher.test.ts`; behavior remains covered by `source-state.test.ts` / `input-matcher.test.ts`.
- Bump `0.9.0` — merge publishes.

Next: the harness mounts the endpoint (skmtc-hub, Phase 2), including the remote-mode `/descriptors` fallback the Phase 0 probes surfaced (local `skmtc describe` needs a bundle; `serverUrl` projects have none).

## Testing

127/127 vitest, clean `tsc --noEmit`, build emits `dist/matcher.{mjs,d.mts}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)