### PR TITLE
docs: core-export and stock-generator sync guards

### DIFF
--- a/deno/deno.json
+++ b/deno/deno.json
@@ -45,7 +45,7 @@
     "test:coverage": "deno test --allow-all --coverage=coverage",
     "coverage:report": "deno coverage coverage --lcov > coverage.lcov",
     "coverage:html": "deno coverage coverage --html",
-    "verify-docs": "deno run --allow-read docs/verify-docs.ts && deno run --allow-read --allow-run docs/friction-log/verify-catalog.ts && deno run --allow-read --allow-write --allow-run --allow-env docs/doc-test.ts"
+    "verify-docs": "deno run --allow-read --allow-run=deno docs/verify-docs.ts && deno run --allow-read --allow-run docs/friction-log/verify-catalog.ts && deno run --allow-read --allow-write --allow-run --allow-env docs/doc-test.ts"
   },
   "minimumDependencyAge": "0"
 }

--- a/deno/docs/reference/api/core-overview.md
+++ b/deno/docs/reference/api/core-overview.md
@@ -66,11 +66,11 @@ The building blocks generators use to produce code.
 | Class | Role | Reference |
 |-------|------|-----------|
 | `SnippetBase` | Root class for Snippets (anonymous helpers) and Projections | [SnippetBase](dsl-snippet-base.md) |
-| `Definition` | Wraps a Projection's value into `export const NAME =` | [Definition](dsl-definition.md) |
-| `Identifier` | Name + entity-type marker (`'variable'` vs `'type'`); the discriminator maps to `const` vs `type` declaration keywords | [Identifier](dsl-identifier.md) |
-| `Import` | Rendered `import { X } from '...'` statement | [Import](dsl-import.md) |
+| `DefinitionBase` | Wraps a producer's value with its identifier and generator key; rendering lives in the lang subclass (`TsDefinition`) | [Definition](dsl-definition.md) |
+| `IdentifierBase` | Neutral identifier data (name, typeName, exported); the per-language declaration type lives on the lang subclass (`TsIdentifier`) | [Identifier](dsl-identifier.md) |
+| `ImportBase` | Neutral import data; the rendered `import { X } from '...'` statement is the lang subclass (`TsImport`) | [Import](dsl-import.md) |
 | `ContentSettings` | Per-Projection bundle (identifier, exportPath, enrichments) | [ContentSettings](content-settings.md) |
-| `File` | Output file with imports, definitions, and metadata | [File](dsl-file.md) |
+| `FileBase` | Neutral output-file base (`CodeFileBase` for code files; the concrete `TsFile` lives in the lang package) | [File](dsl-file.md) |
 | `JsonFile` | Variant of File for JSON output | [JsonFile](dsl-file.md) |
 | `CustomValue` | Wraps raw strings as DSL values | [CustomValue](dsl-custom-value.md) |
 | `Inserted` | Marker class returned by `insertNormalizedModel` etc. | [Inserted](dsl-inserted.md) |
@@ -126,7 +126,6 @@ not a BaseSchema" discussion.
 | `GqlDocument` | Parsed GraphQL schema | [GqlDocument](gql-document.md) |
 | `GqlRegistry` | Looks up GraphQL types by name | [GqlDocument](gql-document.md) |
 | `GqlOperation` | A single GraphQL operation | [GqlDocument](gql-document.md) |
-| `GqlType` (union) | Set of GraphQL types (object, scalar, enum, etc.) | [GqlDocument](gql-document.md) |
 
 GraphQL parsing happens **worker-side** (unlike OAS, which is
 host-side). See [the worker runtime concept](../../concepts/the-worker-runtime.md)
@@ -139,8 +138,7 @@ The TypeScript-level utility types and interfaces.
 | Type | Purpose |
 |------|---------|
 | `IdentifierType` | `{ type: string; typeName?; exported? }` — the non-name identifier parts `toIdentifierType` returns; the per-language declaration vocabulary (`TsEntityType`, `'variable' \| 'type' \| 'class' \| 'interface' \| 'namespace'`) and its keyword mapping live in `@skmtc/lang-typescript` |
-| `ImportNameArg` | `string \| { name, alias?, type? }` — input to `register({ imports })` |
-| `GeneratedValue` | Base structural type for what `Definition` wraps |
+| `GeneratedValue` | Base structural type for what `DefinitionBase` wraps |
 | `Method` | HTTP method literal type |
 | `OasParameterLocation` | `'path' \| 'query' \| 'header' \| 'cookie'` |
 | `OasComponentType` | Union of all top-level OAS component classes |
@@ -162,7 +160,7 @@ The TypeScript-level utility types and interfaces.
 | Helper | Purpose |
 |--------|---------|
 | `tryParseAt(ctx, key, valibotSchema, value)` | Lenient parse with fail-open behavior — see [error handling philosophy](../../concepts/error-handling-philosophy.md) |
-| `removeErroredItems` | One-hop pruning of items whose dependencies failed to parse |
+| `removeErroredItems()` (method on `ParseContext`) | One-hop pruning of items whose dependencies failed to parse |
 
 ## Stack trail and tracing
 

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read
+#!/usr/bin/env -S deno run --allow-read --allow-run=deno
 /**
  * Mechanical doc/skill-chain sync checks — the regression guard for the
  * drift class the friction reviews keep finding (old C8 → C15: the
@@ -61,10 +61,22 @@
  *      pinned in reader-lint-baseline.json with the same
  *      regression/ratchet contract.
  *
+ *  11. CORE-EXPORT SYNC — every symbol named in the first column of a
+ *      reference/api/core-overview.md table row must be a real export
+ *      of core/mod.ts (resolved via `deno doc --json`, so wildcard
+ *      re-exports count). Catches the rename/delete drift class
+ *      (pre-0.8 names like `Definition` surviving in the index).
+ *      One-directional by design: the overview is a curated index,
+ *      not an exhaustive export list.
+ *  12. STOCK-GENERATOR SURFACE SYNC — the three doc surfaces that list
+ *      stock generators (root README table, stock-generators
+ *      overview catalog, per-generator gen-*.md pages) must agree on
+ *      the set.
+ *
  *   exit 0 — all checks hold.
  *   exit 1 — one or more failed; each failure names file + expectation.
  *
- * Usage:  deno run --allow-read deno/docs/verify-docs.ts
+ * Usage:  deno run --allow-read --allow-run=deno deno/docs/verify-docs.ts
  *         deno run --allow-read --allow-write deno/docs/verify-docs.ts \
  *           --update-reader-baseline   # rewrite reader-lint-baseline.json
  *                                      # to the current violation set
@@ -889,6 +901,148 @@ if (updateReaderBaseline) {
       )
     }
   }
+}
+
+// ---------------------------------------------------------------------
+// 11. Core-export sync — table-leading symbols in core-overview.md must
+//     be real exports of core/mod.ts. `deno doc --json` resolves the
+//     wildcard re-exports; the extraction walks every `symbols` array
+//     so minor format shifts across deno versions stay survivable.
+// ---------------------------------------------------------------------
+
+const coreDocCommand = new Deno.Command("deno", {
+  args: ["doc", "--json", join(denoDir, "core", "mod.ts")],
+  stdout: "piped",
+  stderr: "piped",
+});
+const coreDocResult = await coreDocCommand.output();
+
+if (!coreDocResult.success) {
+  fail(
+    "core-export sync: `deno doc --json core/mod.ts` failed — " +
+      new TextDecoder().decode(coreDocResult.stderr).slice(0, 200),
+  );
+} else {
+  const collectSymbolNames = (value: unknown, into: Set<string>): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) collectSymbolNames(item, into);
+      return;
+    }
+    if (value === null || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if (Array.isArray(record.symbols)) {
+      for (const symbol of record.symbols) {
+        const name = (symbol as Record<string, unknown>).name;
+        if (typeof name === "string") into.add(name);
+      }
+    }
+    for (const child of Object.values(record)) {
+      collectSymbolNames(child, into);
+    }
+  };
+
+  const coreExports = new Set<string>();
+  collectSymbolNames(
+    JSON.parse(new TextDecoder().decode(coreDocResult.stdout)),
+    coreExports,
+  );
+
+  if (coreExports.size === 0) {
+    fail(
+      "core-export sync: extracted zero symbols from `deno doc --json` — " +
+        "the extraction needs updating for this deno version",
+    );
+  } else {
+    const coreOverviewText = await Deno.readTextFile(
+      join(docsDir, "reference", "api", "core-overview.md"),
+    );
+    const staleRows = [
+      ...coreOverviewText.matchAll(/^\| `([A-Za-z][A-Za-z0-9_]*)`/gm),
+    ]
+      .map((match) => match[1])
+      .filter((name) => !coreExports.has(name));
+
+    staleRows.forEach((name) =>
+      fail(
+        `core-export sync: core-overview.md table row names \`${name}\`, ` +
+          `which core/mod.ts does not export — rename the row to the ` +
+          `current symbol or remove it`,
+      )
+    );
+    if (staleRows.length === 0) {
+      pass(
+        `core-export sync: all core-overview table symbols exist among ` +
+          `${coreExports.size} core/mod.ts exports`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------
+// 12. Stock-generator surface sync — the root README table, the
+//     stock-generators overview catalog, and the per-generator pages
+//     must list the same generator set.
+// ---------------------------------------------------------------------
+
+const rootReadmeText = await Deno.readTextFile(join(docsDir, "README.md"));
+const stockOverviewText = await Deno.readTextFile(
+  join(docsDir, "reference", "stock-generators", "overview.md"),
+);
+
+const readmeGenerators = new Set(
+  [...rootReadmeText.matchAll(/^\| `@skmtc\/(gen-[a-z-]+)`/gm)].map((m) =>
+    m[1]
+  ),
+);
+const overviewGenerators = new Set(
+  [...stockOverviewText.matchAll(/\((gen-[a-z-]+)\.md\)/g)].map((m) => m[1]),
+);
+const generatorPages = new Set<string>();
+for await (
+  const entry of Deno.readDir(join(docsDir, "reference", "stock-generators"))
+) {
+  const match = entry.name.match(/^(gen-[a-z-]+)\.md$/);
+  if (match) generatorPages.add(match[1]);
+}
+
+const surfaceProblems: string[] = [];
+for (const generator of generatorPages) {
+  if (!readmeGenerators.has(generator)) {
+    surfaceProblems.push(
+      `stock-generator sync: ${generator} has a reference page but is ` +
+        `missing from the root README stock-generators table`,
+    );
+  }
+  if (!overviewGenerators.has(generator)) {
+    surfaceProblems.push(
+      `stock-generator sync: ${generator} has a reference page but is ` +
+        `missing from stock-generators/overview.md`,
+    );
+  }
+}
+for (const generator of readmeGenerators) {
+  if (!generatorPages.has(generator)) {
+    surfaceProblems.push(
+      `stock-generator sync: root README lists ${generator} but ` +
+        `reference/stock-generators/${generator}.md does not exist`,
+    );
+  }
+}
+for (const generator of overviewGenerators) {
+  if (!generatorPages.has(generator)) {
+    surfaceProblems.push(
+      `stock-generator sync: overview.md links ${generator}.md, which ` +
+        `does not exist`,
+    );
+  }
+}
+
+surfaceProblems.forEach(fail);
+if (surfaceProblems.length === 0) {
+  pass(
+    `stock-generator surface sync: README table, overview catalog, and ` +
+      `${generatorPages.size} reference pages agree`,
+  );
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
The two prevention guards from the accuracy remediation plan — the "prevention over grinding" alternative to hand-fixing `reference/api` signatures that re-rot.

**Check 11 — core-export sync.** Every symbol in the first column of a `core-overview.md` table row must be a real `core/mod.ts` export, resolved via `deno doc --json` (so the 146 wildcard re-exports count). Deliberately one-directional: the overview is a curated index (~40 major symbols of 536 exports), so "every export must be documented" would be the wrong contract — but "every documented symbol must exist" catches the rename/delete rot class.

**Check 12 — stock-generator surface sync.** Root README table ↔ overview catalog ↔ per-generator pages must agree on the set. (Generator *source* lives in the sibling skmtc-generators repo, outside this CI's reach — so this guards the three doc surfaces against each other; it would have caught the missing eject/adopt/merge/status catalog entries' analog.)

**Check 11 immediately caught seven stale rows** in core-overview:
- `Definition` / `Identifier` / `Import` / `File` → the `*Base` classes with corrected descriptions (pre-0.8 names; the concrete `Ts*` classes live in lang-typescript — descriptions also fixed, e.g. `Identifier` claimed an entity-type marker core no longer carries)
- `GqlType`, `ImportNameArg` → dropped (no longer exist anywhere)
- `removeErroredItems` → now shown as the `ParseContext` method it is

Negative-tested both checks in both directions (synthetic stale symbol → FAIL; phantom README generator → 2 FAILs, both directions named). `verify-docs` gains `--allow-run=deno` in the task for the subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)