### PR TITLE
docs: canonical-owner dedups; reword llms.md links

### DIFF
--- a/deno/docs/authoring/how-to/add-a-field-type.md
+++ b/deno/docs/authoring/how-to/add-a-field-type.md
@@ -23,24 +23,16 @@ file upload, etc.).
 Form generators have a `src/fields/` subdirectory with one
 Snippet per field type:
 
-```ts
-// src/fields/DatePickerInput.ts
-import type { GenerateContextType } from '@skmtc/core'
-import { TsSnippet } from '@skmtc/lang-typescript'
-
-type Args = {
-  context: GenerateContextType
-  destinationPath: string
-  fieldName: string
-}
-
+```ts fragment
+// src/fields/DatePickerInput.ts — the shape every field Snippet follows
 export class DatePickerInput extends TsSnippet {
   #fieldName: string
 
   constructor(args: Args) {
     super({ context: args.context })
     this.#fieldName = args.fieldName
-
+    // the Snippet registers its OWN import — presence of the field
+    // implies presence of the import
     this.register({
       destinationPath: args.destinationPath,
       imports: { '@/components/DatePicker': ['DatePicker'] }
@@ -52,6 +44,10 @@ export class DatePickerInput extends TsSnippet {
   }
 }
 ```
+
+The complete class — imports, `Args` type, and the dispatch wiring —
+is in the [custom form field renderer recipe](../recipes/custom-form-field-renderer.md),
+which walks this exact example end to end.
 
 The Snippet's `toString()` produces just the JSX for one field.
 

--- a/deno/docs/concepts/refs-and-resolution.md
+++ b/deno/docs/concepts/refs-and-resolution.md
@@ -243,27 +243,7 @@ for that address-bridging step.
 
 ## Cascade pruning
 
-At end-of-parse, `removeErroredItems` walks both maps:
-
-```ts
-for (const [refKey, errors] of this.#refErrors) {
-  for (const error of errors) {
-    const consumers = this.#refConsumers.get(refKey) ?? []
-    for (const stackTrail of consumers) {
-      const removed = oasState.oasDocument.removeItem(stackTrail)
-      if (removed) {
-        this.issues.push({
-          type: 'INVALID_DEPENDENCY_REF',
-          level: 'error',
-          location: stackTrail.toString(),
-          ...
-        })
-      }
-    }
-  }
-}
-```
-
+At end-of-parse, `removeErroredItems` walks both maps together.
 For each failed schema, every consumer (anything that `$ref`-ed it)
 is pruned from the parsed document. Each pruning logs an
 `INVALID_DEPENDENCY_REF` issue at the consumer's location.

--- a/deno/docs/concepts/the-three-phases.md
+++ b/deno/docs/concepts/the-three-phases.md
@@ -134,39 +134,14 @@ A throw inside `toSchemaV3` becomes a `level: 'error'` `ParseIssue`, and the key
 is skipped in the output map.
 
 **Tier 2 — cascade pruning via `removeErroredItems`.** During the walk, every
-`$ref` consumer is recorded in `ParseContext.#refConsumers`. When a parse error
-happens at a component position, the error is recorded in
-`ParseContext.#refErrors` keyed by the same ref. After the walk finishes:
-
-```ts
-for (const [refKey, errors] of this.#refErrors) {
-  for (const error of errors) {
-    const consumers = this.#refConsumers.get(refKey) ?? []
-    for (const stackTrail of consumers) {
-      const removed = oasState.oasDocument.removeItem(stackTrail)
-      if (removed) {
-        this.issues.push({
-          protocol: 'oas',
-          level: 'error',
-          type: 'INVALID_DEPENDENCY_REF',
-          location: stackTrail.toString(),
-          ...
-        })
-      }
-    }
-  }
-}
-```
-
-So if `User` fails to parse and `Operation X` referenced `User`, `Operation X`
-is removed from `oasDocument.operations` with an `INVALID_DEPENDENCY_REF` issue.
-The downstream Generate phase sees a smaller document with all surviving items
-guaranteed valid.
-
-The cascade is one hop deep by current design — transitive pruning of
-consumers-of-pruned-consumers is a known limitation, partially mitigated by the
-fact that `resolve()` on a now-missing ref will throw at generate time, which
-`#runOasOperationGenerator` catches as a per-operation error.
+`$ref` consumer is recorded; when a component fails to parse, everything that
+referenced it is pruned from the document with an `INVALID_DEPENDENCY_REF`
+issue at the consumer's location. The downstream Generate phase sees a smaller
+document with all surviving items guaranteed valid. The cascade is one hop
+deep by design; a transitive consumer fails later, at generate time, as a
+per-operation error. The mechanism in full — the two maps, the pruning walk,
+and the implementation choices it rests on — is in
+[error handling philosophy](../explanation/error-handling-philosophy.md#tier-2-cross-ref-via-removeerroreditems).
 
 ### Type-inference fallbacks
 

--- a/deno/docs/explanation/design-philosophy.md
+++ b/deno/docs/explanation/design-philosophy.md
@@ -264,4 +264,3 @@ The asymmetry encodes the model: engine is the *platform* (stable, contributor-f
 - [The GraphQL asymmetry](the-graphql-asymmetry.md) — building on the structuredClone substrate
 - [Security model](security-model.md) — worker sandboxing
 - [Comparison to other tools](comparison-to-other-tools.md) — how these principles differ from other codegen tools
-- [Operational principles in `llms.md`](../llms.md#operational-principles-for-proposing-changes) — the LLM-facing condensation of these principles as anti-pattern overrides

--- a/deno/docs/explanation/how-idempotency-works.md
+++ b/deno/docs/explanation/how-idempotency-works.md
@@ -251,10 +251,9 @@ purity. The cache would then miss inconsistently — sometimes
 hitting, sometimes missing, depending on what state had been
 mutated when.
 
-Anti-pattern; the operational principles in
-[`llms.md`](../llms.md) call this out explicitly. Generator
-authors should treat `toIdentifierName` and `toExportPath` as pure
-functions of their inputs.
+This is an anti-pattern: generator authors should treat
+`toIdentifierName` and `toExportPath` as pure functions of their
+inputs.
 
 ### Memoization can't work if `toString()` is non-pure
 

--- a/deno/docs/explanation/why-three-phases.md
+++ b/deno/docs/explanation/why-three-phases.md
@@ -83,8 +83,7 @@ target).
 The Render phase notably does **not** run Prettier or any other
 formatter. The pipeline renders unformatted (but syntactically
 valid) TypeScript; consumers run their own formatter as a
-post-generation step. (See [the operational principles in
-llms.md](../llms.md) for the load-bearing fact.)
+post-generation step.
 
 ## What's lost by combining phases
 

--- a/deno/docs/reference/glossary.md
+++ b/deno/docs/reference/glossary.md
@@ -741,6 +741,5 @@ function.
 
 - [Vocabulary cheat-sheet](../concepts/vocabulary-cheat-sheet.md) — the analogue table for core terms
 - [The three phases](../concepts/the-three-phases.md) — fuller treatment of most terms here
-- [llms.md](../llms.md) — consolidated operational reference
 - [Manifest format](manifest-format.md)
 - [Error codes](error-codes.md)

--- a/deno/docs/reference/settings/source-resolution.md
+++ b/deno/docs/reference/settings/source-resolution.md
@@ -212,14 +212,10 @@ The CLI:
    `{ type: 'gql', sdl: '...' }`
 4. The worker parses the SDL using the GraphQL runtime
 
-The reason: `graphql.parse()` produces an AST with class instances
-that **`structuredClone` cannot transfer**. Cloning a parsed AST
-across the worker boundary would either strip prototypes (breaking
-the AST) or throw. Keeping the SDL as a string sidesteps the issue
-— parsing happens *inside* the worker where the AST stays.
-
-See [the worker runtime concept](../../concepts/the-worker-runtime.md)
-for the broader reasoning.
+The reason — GraphQL's parsed AST carries class instances that
+`structuredClone` cannot transfer, so the SDL crosses as a string and
+parsing happens inside the worker — is covered in full in
+[the GraphQL asymmetry](../../explanation/the-graphql-asymmetry.md).
 
 ## Remote sources
 


### PR DESCRIPTION
Workstream items 1 + 5: the remaining canonical-owner dedups from the journey program's §9c table, plus the docs-site punchlist §2.

**Cascade pruning** — the `removeErroredItems` code block appeared verbatim in three pages. Canonical home is now `explanation/error-handling-philosophy.md` (the dedicated error page after #79's demotion). `the-three-phases` keeps a summary paragraph + anchor link; `refs-and-resolution` keeps its two-maps description (ref infrastructure is that page's subject) and links out for the walk. The block now exists exactly once in the corpus.

**structuredClone/GraphQL-AST story** — `source-resolution` re-derived it in full; now one sentence + link to `the-graphql-asymmetry` (canonical). `why-three-phases` was already properly scoped and linked — untouched.

**DatePicker duplication** — the recipe is canonical (complete worked example); the `add-a-field-type` how-to keeps an annotated sketch that teaches the shape (with the registers-its-own-import habit called out inline) and links the recipe for the full class.

**llms.md links (punchlist §2)** — all four reader-page links into `llms.md` (excluded from the public site) reworded to stand alone or dropped. Zero remain.

Baseline unchanged at 0/0; full verify-docs suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)