### PR TITLE
docs: dead-link check (check 13); fix the 14 links it caught

### DIFF
--- a/deno/docs/README.md
+++ b/deno/docs/README.md
@@ -171,9 +171,9 @@ Pick the tree that matches your role; the shared layers work for both.
 ### Role-specific trees
 
 - **[`using/`](using/)** — installing, configuring, running, integrating; no generator code involved
-  - [Tutorials](using/tutorials/) · [How-to](using/how-to/) · [Recipes](using/recipes/)
+  - [Tutorials](using/README.md#tutorials) · [How-to](using/README.md#how-to-guides) · [Recipes](using/README.md#recipes)
 - **[`authoring/`](authoring/)** — authoring generators: cloning, customizing, writing new ones
-  - [Tutorials](authoring/tutorials/) · [How-to](authoring/how-to/) · [Recipes](authoring/recipes/)
+  - [Tutorials](authoring/README.md#tutorials) · [How-to](authoring/README.md#how-to-guides) · [Recipes](authoring/README.md#recipes)
 
 ### Shared layers
 
@@ -218,7 +218,7 @@ Per-generator reference: [`reference/stock-generators/`](reference/stock-generat
 
 **Are generators sandboxed?** Yes — `net: false`, `run: false` in the Worker. Can read env vars. See [`explanation/security-model.md`](explanation/security-model.md).
 
-**Is there a hosted version?** Yes — `skmtc generate` can route to a remote Sandbox API. See [`using/recipes/`](using/recipes/).
+**Is there a hosted version?** Yes — `skmtc generate` can route to a remote Sandbox API. See [the recipes](using/README.md#recipes).
 
 ---
 

--- a/deno/docs/concepts/README.md
+++ b/deno/docs/concepts/README.md
@@ -1,0 +1,32 @@
+# Concepts
+
+> Mental models shared by SKMTC users and generator authors. These
+> pages are routed just-in-time from the tutorials and how-to guides —
+> read the one a task links you to; this is not a syllabus.
+
+## Start here
+
+- [Definitions and files](definitions-and-files.md) — the
+  create-or-reuse mechanism that makes SKMTC composable, in one page
+- [The three phases](the-three-phases.md) — Parse → Generate → Render
+
+## Using SKMTC
+
+- [Projects and workspaces](projects-and-workspaces.md) — the on-disk model
+- [Clone vs install](clone-vs-install.md) — the customization gradient
+- [Enrichments](enrichments.md) — per-operation configuration
+- [The worker runtime](the-worker-runtime.md) — the sandbox model
+- [The manifest](the-manifest.md) — the run record
+
+## Authoring generators
+
+- [Generators as packages](generators-as-packages.md) — the package layout
+- [Projections and Snippets](projections-and-snippets.md) — the two-level DSL
+- [How generators produce output](how-generators-produce-output.md) — the pull-based model
+- [Composing output with Stringable](stringable-composition.md) — how templates compose
+- [Cross-generator coordination](cross-generator-coordination.md) — memoized composition
+- [Files, deduplication, and integrity](files-and-dedup.md) — the file object in depth
+- [The type system](the-type-system.md) — schema-to-value dispatch
+- [Variants](variants.md) — one source item, several artifacts
+- [The GraphQL pipeline](the-graphql-pipeline.md) — the SDL path
+- [Languages](languages.md) — where the target language enters

--- a/deno/docs/concepts/variants.md
+++ b/deno/docs/concepts/variants.md
@@ -339,7 +339,7 @@ Fold the variant axis into `toIdentifierName` / `toExportPath` — each
 variant needs its own cache key, and the Driver throws on a mismatch —
 and read the per-variant leaf off `this.settings.enrichments`.
 The canonical implementation is
-[`skmtc-generators/gen-shadcn-form`](../../../skmtc-generators/gen-shadcn-form/)
+[`skmtc-generators/gen-shadcn-form`](https://github.com/skmtc/skmtc-generators/tree/main/gen-shadcn-form)
 post-`@skmtc/core@0.5.0`.
 
 ## Cross-references

--- a/deno/docs/explanation/README.md
+++ b/deno/docs/explanation/README.md
@@ -1,0 +1,21 @@
+# Explanation
+
+> Design rationale — why SKMTC is built the way it is, the
+> alternatives considered, and the trade-offs accepted. For evaluators
+> deciding whether SKMTC fits, and for the curious after first
+> success.
+
+## Deciding whether to adopt
+
+- [Comparison to other tools](comparison-to-other-tools.md) — the landscape, and when to pick something else
+- [Why clone-to-customize](why-clone-to-customize.md) — the central bet, with its counter-cases
+- [Design philosophy](design-philosophy.md) — the principles behind the choices
+- [Status and roadmap](status-and-roadmap.md) — what to depend on today
+- [Security model](security-model.md) — the sandbox and its residual risks
+
+## Understanding the machine
+
+- [How idempotency works](how-idempotency-works.md) — the order-independence proof
+- [Why three phases](why-three-phases.md) — what combining phases would break
+- [Error handling philosophy](error-handling-philosophy.md) — lenient input, strict diagnostics
+- [The GraphQL asymmetry](the-graphql-asymmetry.md) — why GraphQL parses worker-side

--- a/deno/docs/reference/settings/README.md
+++ b/deno/docs/reference/settings/README.md
@@ -1,0 +1,7 @@
+# Settings reference
+
+> The `client.json` configuration surface.
+
+- [client.json schema](client-json-schema.md) — every key, with examples
+- [Enrichments shape](enrichments-shape.md) — the three routing shapes and the scope umbrella
+- [Source resolution](source-resolution.md) — how `source` is fetched, normalized, and path-resolved

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -73,6 +73,13 @@
  *      overview catalog, per-generator gen-*.md pages) must agree on
  *      the set.
  *
+ *  13. DEAD-LINK CHECK — every relative markdown link in the
+ *      reader-facing tree must resolve: `.md` targets must exist on
+ *      disk, and directory links must contain a README.md. The orphan
+ *      check (10) guards reachability; this guards resolution — a
+ *      reachable page can still carry a broken link (the class that
+ *      survived until an ad-hoc sweep caught it).
+ *
  *   exit 0 — all checks hold.
  *   exit 1 — one or more failed; each failure names file + expectation.
  *
@@ -1043,6 +1050,47 @@ if (surfaceProblems.length === 0) {
     `stock-generator surface sync: README table, overview catalog, and ` +
       `${generatorPages.size} reference pages agree`,
   );
+}
+
+// ---------------------------------------------------------------------
+// 13. Dead-link check — every relative markdown link in the reader
+//     tree must resolve. Reuses the file set loaded for checks 9/10.
+// ---------------------------------------------------------------------
+
+const deadLinks: string[] = []
+for (const [relPath, text] of readerFileTexts) {
+  const lines = text.split("\n")
+  lines.forEach((line, index) => {
+    for (const match of line.matchAll(/\]\(([^)\s]+?)(?:#[^)]*)?\)/g)) {
+      const target = match[1]
+      if (/^[a-z][a-z+]*:/.test(target)) continue // URL scheme
+      if (target.startsWith("#") || target === "") continue // same-page anchor
+
+      const fromDir = dirname(join(docsDir, relPath))
+      if (target.endsWith(".md")) {
+        try {
+          Deno.statSync(join(fromDir, target))
+        } catch {
+          deadLinks.push(`${relPath}:${index + 1} → ${target}`)
+        }
+      } else if (target.endsWith("/")) {
+        try {
+          Deno.statSync(join(fromDir, target, "README.md"))
+        } catch {
+          deadLinks.push(
+            `${relPath}:${index + 1} → ${target} (directory link with no README.md behind it)`,
+          )
+        }
+      }
+    }
+  })
+}
+
+deadLinks.forEach(link => fail(`dead link: ${link}`))
+if (deadLinks.length === 0) {
+  pass(
+    `dead-link check: all relative markdown links resolve across ${readerFileTexts.size} reader-facing files`,
+  )
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
Retro priority #2 from the journey program: the orphan BFS guards *reachability*, but nothing guarded link *resolution* — a reachable page could still carry a broken link (the class that let #61's leftovers survive until #73's ad-hoc sweep). Check 13 closes it: every relative `.md` link must resolve, and every directory link must have a README.md behind it.

**14 broken links caught on introduction** — all directory links, which the docs-site sync silently drops (link text kept, hyperlink removed):
- Root README tree bullets (`using/tutorials/` ×6, `using/recipes/` in the FAQ) → anchor links into the tree READMEs.
- `concepts/`, `explanation/`, `reference/settings/` had **no index page at all** → three small grouped README indexes (concepts grouped by journey tier — start-here / using / authoring; explanation by evaluate / understand-the-machine). These also improve repo-view navigation.
- `variants.md`'s relative link into the sibling skmtc-generators repo → GitHub URL.

Negative-tested (synthetic broken link → 1 FAIL; reverted surgically, not via whole-file checkout — retro entry #5 applied). All 15 checks green, baseline 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)