### PR TITLE
docs: enrichment warnings (Phase D) + enrichments user/author split

### DIFF
--- a/deno/docs/authoring/how-to/add-enrichment-options.md
+++ b/deno/docs/authoring/how-to/add-enrichment-options.md
@@ -175,6 +175,299 @@ Adding new optional enrichment fields is **always safe**. Old
 they just don't get the new behavior. Removing or changing
 existing fields is a breaking change.
 
+## The umbrella in depth
+
+### How enrichments are declared
+
+Each generator declares ONE **composite** schema covering all three scopes —
+`v.object({ subject, generator, stack })` — in `gen-x/src/enrichments.ts`. Each
+member describes the leaf at that scope; unused scopes are declared
+`v.undefined()`:
+
+```ts
+// gen-shadcn-form/src/enrichments.ts
+import * as v from "valibot";
+import { lensInputModuleType, moduleSelect } from "@skmtc/core";
+
+export const formFieldItem = v.object({
+  // `moduleSelect` is the field binding: `schemaPath` (the join key) plus an
+  // optional consumer component bound to the field's lens.
+  moduleSelect: v.pipe(moduleSelect(lensInputModuleType), v.title("Input")),
+  label: v.optional(v.string()),
+  placeholder: v.optional(v.string()),
+  references: v.optional(v.string()),
+});
+
+// The subject-scoped leaf — the per-operation form override.
+export const formSchema = v.optional(
+  v.object({
+    title: v.optional(v.string()),
+    description: v.optional(v.string()),
+    submitLabel: v.optional(v.string()),
+    fields: v.optional(v.array(formFieldItem)),
+  }),
+);
+
+// The three-scope enrichment umbrella. This generator only consumes the
+// subject scope; `generator` / `stack` are unused (declared `v.undefined()`).
+export const enrichmentSchema = v.object({
+  subject: formSchema,
+  generator: v.undefined(),
+  stack: v.undefined(),
+});
+
+export type EnrichmentSchema = v.InferOutput<typeof enrichmentSchema>;
+export const toEnrichmentSchema = () => enrichmentSchema;
+```
+
+`toEnrichmentSchema` is **required** on both the entry factory and the
+projection-base config — it's what lets the engine assemble and parse the
+umbrella cast-free (see
+[how routing works](#how-routing-works-at-generate-time)). It's wired in both
+places:
+
+```ts
+// gen-shadcn-form/src/mod.ts
+export const ShadcnFormEntry = toOasOperationEntry<EnrichmentSchema>({
+  id: denoJson.name,
+  toEnrichmentSchema,
+  // ...
+});
+```
+
+```ts
+// gen-shadcn-form/src/base.ts
+export const ShadcnFormBase = toTsOasOperationProjectionBase<EnrichmentSchema>({
+  id: denoJson.name,
+  toEnrichmentSchema,
+  // ...
+});
+```
+
+A generator with **no enrichments at any scope** declares core's
+`emptyEnrichmentSchema` (every member `v.undefined()`) instead of hand-rolling
+the umbrella:
+
+```ts
+// gen-typescript/src/enrichments.ts
+import { type EmptyEnrichments, emptyEnrichmentSchema } from "@skmtc/core";
+
+export const toEnrichmentSchema = () => emptyEnrichmentSchema;
+
+export type EnrichmentSchema = EmptyEnrichments;
+```
+
+This declaration is the canonical source of truth for what enrichment fields the
+generator accepts. **To know what payload a generator's enrichments take, read
+its `enrichments.ts`.**
+
+
+### How enrichments are consumed
+
+Inside a Projection, the validated three-scope umbrella is available as
+`this.settings.enrichments`. Read the scope you want — `.subject`, `.generator`,
+or `.stack` — each typed (and `undefined` when the generator declares nothing
+for that scope):
+
+```ts
+// gen-shadcn-form/src/ShadcnForm.ts
+override toString(): string {
+  const { title, description, submitLabel } = this.settings.enrichments.subject ?? {}
+
+  return `(${this.parameter}) => {
+    return (
+      <Form>
+        ${title ? `<h2>${title}</h2>` : ''}
+        ${description ? `<p>${description}</p>` : ''}
+        ${this.fields}
+        <Button>${submitLabel || 'Submit'}</Button>
+      </Form>
+    )
+  }`
+}
+```
+
+The enrichments are pre-validated by the engine using the generator's declared
+composite Valibot schema, so the Projection can assume the shape is correct.
+Unknown keys are stripped silently; missing optional keys arrive as `undefined`.
+
+#### Reading scopes outside a Projection
+
+`this.settings.enrichments` only exists where there's a `ContentSettings` — i.e.
+inside a Projection. The `generator` and `stack` scopes are run-constants, so
+they're often needed elsewhere: in `transform`, in `isSupported`, in an
+accumulator snippet. From those contexts (anywhere holding a `context`), read
+them with the helper readers from `@skmtc/core`:
+
+```ts fragment
+import { toGeneratorEnrichment, toStackEnrichment } from "@skmtc/core";
+
+// generator-scoped leaf — context.settings.enrichments[id]._generator
+const genConfig = toGeneratorEnrichment(context, id, generatorSchema);
+
+// stack-scoped leaf — context.settings.enrichments._stack
+const stackConfig = toStackEnrichment(context, stackSchema);
+```
+
+The return type is inferred from the schema you pass — no cast. Each reader
+looks up by a known reserved key and never enumerates, so a generator can't trip
+over the reserved keys. (There is no `subject` reader here: the subject scope is
+per-item and is resolved by the engine into `ContentSettings`.)
+
+
+## Design guidance
+
+### Enrichments aren't a filter — don't gate `isSupported` on them
+
+A common authoring mistake on opt-in generators (forms, tables, page shells) is
+to write `isSupported` so it returns `true` only when the operation has the
+generator's enrichment payload. That makes "having an enrichment" the on/off
+switch.
+
+```ts
+// ❌ Wrong — enrichment doubles as the on/off switch
+isSupported({ context, operation }) {
+  return getEnrichment(context, operation) !== undefined
+}
+
+// ✅ Right — declare capability; let client.json gate intent
+isSupported({ operation }) {
+  return ['post', 'put', 'patch'].includes(operation.method) &&
+    operation.requestBody?.resolve()?.toSchema()?.resolve().type === 'object'
+}
+```
+
+Two reasons to avoid the wrong form:
+
+1. **`isSupported` declares capability, not user intent.** A generator that
+   _could_ produce output for `POST` with a JSON body should say so. Whether the
+   user _wants_ it to is a configuration concern.
+2. **Enrichment is for customizing shape, not selecting set.** Once enrichment
+   doubles as the switch, you can't have an enrichment with all-default values —
+   you have to invent a sentinel. Code smell.
+
+The right control for "only run for these operations" is the **`include`
+allow-list** (or `.skip` deny-list) in `client.json#settings`, applied _outside_
+the generator. See
+[`using/how-to/skip-or-include-operations.md`](../../using/how-to/skip-or-include-operations.md).
+
+
+### Extensions vs enrichments: who owns it, and how often does it change?
+
+Two places per-field metadata can live:
+
+- **OpenAPI `x-*` extensions** — written into the schema document itself,
+  exposed on every `Oas*` variant as
+  `extensionFields?: Record<string, unknown>`. Travel with the schema through
+  Parse untouched.
+- **Enrichments** — declared per-generator in `enrichments.ts`, supplied by the
+  consumer in `.settings/client.json`.
+
+Pick along two axes:
+
+|                                 | Stable data (rarely changes)                                                           | Volatile data (changes independently of schema)                                                      |
+| ------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **You author the schema**       | OpenAPI extension — the data ships with the schema and every consumer gets it for free | Enrichment — keep the volatile bit in `client.json` where it's a local edit, not a schema re-publish |
+| **You only consume the schema** | Enrichment — you can't edit the upstream document anyway                               | Enrichment                                                                                           |
+
+Why the asymmetry: editing an extension means changing the schema document (and,
+if it's published, re-shipping it). Editing an enrichment is a config change in
+the consumer's `client.json`. So extensions earn their keep when the data is
+_stable enough_ that the re-publish cadence is fine, and _universal enough_ that
+every consumer wants the same value.
+
+```yaml
+# Schema-author + stable: canonical display label
+components:
+  schemas:
+    Customer:
+      type: object
+      properties:
+        firstName:
+          type: string
+          x-label: "Given name"
+```
+
+```ts
+// In a generator: read the extension off the parsed schema
+const label = resolved.properties?.["firstName"]?.extensionFields?.["x-label"];
+```
+
+```ts
+// Schema-consumer + volatile: which list endpoint backs this field today
+// → consumer's enrichment in client.json, NOT an extension
+{
+  "@scope/gen-shadcn-form": {
+    "/customers": {
+      "post": { "fields": [{ "id": "officeId", "references": "GetOffices" }] }
+    }
+  }
+}
+```
+
+Cross-generator wiring (the operation-reference protocol — see
+[cross-generator coordination](../../concepts/cross-generator-coordination.md#pattern-operation-reference-consumer-chosen-peer))
+is always volatile by nature, so it always lives in the consumer's enrichment.
+
+A common smell when you _do_ own the schema: declaring an enrichment field that
+just mirrors a stable schema property — display labels, canonical descriptions,
+formats. Move it to an extension and the data stays with the schema, surviving
+any consumer's `client.json` edits.
+
+
+### AI-driven enrichments — `EnrichmentRequest`
+
+A second enrichment path exists for cases where the _generator_ wants to
+_request_ an enrichment value rather than wait for the user to author one. The
+shape (`core/types/EnrichmentRequest.ts`):
+
+```ts
+type EnrichmentRequest<EnrichmentType> = {
+  prompt: string;
+  enrichmentSchema: v.BaseSchema<
+    EnrichmentType,
+    EnrichmentType,
+    v.BaseIssue<unknown>
+  >;
+  content: string;
+};
+```
+
+A generator can implement `toEnrichmentRequest(refName)` on its entry config.
+The function returns either a request descriptor (prompt + schema + content to
+feed an LLM) or `undefined` to skip. Tooling that integrates with an LLM fulfils
+the request, validates the response against the schema, and persists the result
+into `client.json` as if the user had authored it.
+
+The flow:
+
+```
+generator.toEnrichmentRequest(refName)         → { prompt, schema, content }
+                ↓
+host AI tooling calls LLM with prompt + content
+                ↓
+LLM response parsed against schema
+                ↓
+result written into client.json#enrichments[generatorId][refName]
+                ↓
+next run consumes the result like a user-authored enrichment
+```
+
+Two ways this fits with the wider model:
+
+- The leaf shape is still owned by the generator (same Valibot schema). The AI
+  path doesn't bypass validation — it just defers the _author_ of the leaf from
+  "the user" to "an LLM constrained by the schema."
+- The wire format is the same `client.json` slice. Tooling that doesn't fulfil
+  requests ignores them; the project still works with whatever user-authored
+  enrichments are present.
+
+This is a deferred-fill pattern. It suits enrichments where the value is
+_derivable_ from the schema (a sensible default label, a sample value, a
+description) but you'd rather not hand-author hundreds of them across a large
+API.
+
+
 ## Related
 
 - [Enrichments concept](../../concepts/enrichments.md)

--- a/deno/docs/concepts/enrichments.md
+++ b/deno/docs/concepts/enrichments.md
@@ -81,102 +81,6 @@ never iterate enrichments themselves. They read each scope by known key through
 the typed umbrella (`ContentSettings`) or the helper readers (everywhere else),
 so they can't trip over the reserved keys.
 
-### Enrichments aren't a filter — don't gate `isSupported` on them
-
-A common authoring mistake on opt-in generators (forms, tables, page shells) is
-to write `isSupported` so it returns `true` only when the operation has the
-generator's enrichment payload. That makes "having an enrichment" the on/off
-switch.
-
-```ts
-// ❌ Wrong — enrichment doubles as the on/off switch
-isSupported({ context, operation }) {
-  return getEnrichment(context, operation) !== undefined
-}
-
-// ✅ Right — declare capability; let client.json gate intent
-isSupported({ operation }) {
-  return ['post', 'put', 'patch'].includes(operation.method) &&
-    operation.requestBody?.resolve()?.toSchema()?.resolve().type === 'object'
-}
-```
-
-Two reasons to avoid the wrong form:
-
-1. **`isSupported` declares capability, not user intent.** A generator that
-   _could_ produce output for `POST` with a JSON body should say so. Whether the
-   user _wants_ it to is a configuration concern.
-2. **Enrichment is for customizing shape, not selecting set.** Once enrichment
-   doubles as the switch, you can't have an enrichment with all-default values —
-   you have to invent a sentinel. Code smell.
-
-The right control for "only run for these operations" is the **`include`
-allow-list** (or `.skip` deny-list) in `client.json#settings`, applied _outside_
-the generator. See
-[`using/how-to/skip-or-include-operations.md`](../using/how-to/skip-or-include-operations.md).
-
-### Extensions vs enrichments: who owns it, and how often does it change?
-
-Two places per-field metadata can live:
-
-- **OpenAPI `x-*` extensions** — written into the schema document itself,
-  exposed on every `Oas*` variant as
-  `extensionFields?: Record<string, unknown>`. Travel with the schema through
-  Parse untouched.
-- **Enrichments** — declared per-generator in `enrichments.ts`, supplied by the
-  consumer in `.settings/client.json`.
-
-Pick along two axes:
-
-|                                 | Stable data (rarely changes)                                                           | Volatile data (changes independently of schema)                                                      |
-| ------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| **You author the schema**       | OpenAPI extension — the data ships with the schema and every consumer gets it for free | Enrichment — keep the volatile bit in `client.json` where it's a local edit, not a schema re-publish |
-| **You only consume the schema** | Enrichment — you can't edit the upstream document anyway                               | Enrichment                                                                                           |
-
-Why the asymmetry: editing an extension means changing the schema document (and,
-if it's published, re-shipping it). Editing an enrichment is a config change in
-the consumer's `client.json`. So extensions earn their keep when the data is
-_stable enough_ that the re-publish cadence is fine, and _universal enough_ that
-every consumer wants the same value.
-
-```yaml
-# Schema-author + stable: canonical display label
-components:
-  schemas:
-    Customer:
-      type: object
-      properties:
-        firstName:
-          type: string
-          x-label: "Given name"
-```
-
-```ts
-// In a generator: read the extension off the parsed schema
-const label = resolved.properties?.["firstName"]?.extensionFields?.["x-label"];
-```
-
-```ts
-// Schema-consumer + volatile: which list endpoint backs this field today
-// → consumer's enrichment in client.json, NOT an extension
-{
-  "@scope/gen-shadcn-form": {
-    "/customers": {
-      "post": { "fields": [{ "id": "officeId", "references": "GetOffices" }] }
-    }
-  }
-}
-```
-
-Cross-generator wiring (the operation-reference protocol — see
-[cross-generator coordination](cross-generator-coordination.md#pattern-operation-reference-consumer-chosen-peer))
-is always volatile by nature, so it always lives in the consumer's enrichment.
-
-A common smell when you _do_ own the schema: declaring an enrichment field that
-just mirrors a stable schema property — display labels, canonical descriptions,
-formats. Move it to an extension and the data stays with the schema, surviving
-any consumer's `client.json` edits.
-
 ## Core owns the hierarchy; the generator owns the leaf
 
 The design fact that explains everything else on this page: core's top-level
@@ -306,142 +210,6 @@ leaf value's shape is whatever the generator's Valibot schema declares — see
 [enrichments-shape reference](../reference/settings/enrichments-shape.md) for
 the actual routing details and complete examples.
 
-## How enrichments are declared
-
-Each generator declares ONE **composite** schema covering all three scopes —
-`v.object({ subject, generator, stack })` — in `gen-x/src/enrichments.ts`. Each
-member describes the leaf at that scope; unused scopes are declared
-`v.undefined()`:
-
-```ts
-// gen-shadcn-form/src/enrichments.ts
-import * as v from "valibot";
-import { lensInputModuleType, moduleSelect } from "@skmtc/core";
-
-export const formFieldItem = v.object({
-  // `moduleSelect` is the field binding: `schemaPath` (the join key) plus an
-  // optional consumer component bound to the field's lens.
-  moduleSelect: v.pipe(moduleSelect(lensInputModuleType), v.title("Input")),
-  label: v.optional(v.string()),
-  placeholder: v.optional(v.string()),
-  references: v.optional(v.string()),
-});
-
-// The subject-scoped leaf — the per-operation form override.
-export const formSchema = v.optional(
-  v.object({
-    title: v.optional(v.string()),
-    description: v.optional(v.string()),
-    submitLabel: v.optional(v.string()),
-    fields: v.optional(v.array(formFieldItem)),
-  }),
-);
-
-// The three-scope enrichment umbrella. This generator only consumes the
-// subject scope; `generator` / `stack` are unused (declared `v.undefined()`).
-export const enrichmentSchema = v.object({
-  subject: formSchema,
-  generator: v.undefined(),
-  stack: v.undefined(),
-});
-
-export type EnrichmentSchema = v.InferOutput<typeof enrichmentSchema>;
-export const toEnrichmentSchema = () => enrichmentSchema;
-```
-
-`toEnrichmentSchema` is **required** on both the entry factory and the
-projection-base config — it's what lets the engine assemble and parse the
-umbrella cast-free (see
-[how routing works](#how-routing-works-at-generate-time)). It's wired in both
-places:
-
-```ts
-// gen-shadcn-form/src/mod.ts
-export const ShadcnFormEntry = toOasOperationEntry<EnrichmentSchema>({
-  id: denoJson.name,
-  toEnrichmentSchema,
-  // ...
-});
-```
-
-```ts
-// gen-shadcn-form/src/base.ts
-export const ShadcnFormBase = toTsOasOperationProjectionBase<EnrichmentSchema>({
-  id: denoJson.name,
-  toEnrichmentSchema,
-  // ...
-});
-```
-
-A generator with **no enrichments at any scope** declares core's
-`emptyEnrichmentSchema` (every member `v.undefined()`) instead of hand-rolling
-the umbrella:
-
-```ts
-// gen-typescript/src/enrichments.ts
-import { type EmptyEnrichments, emptyEnrichmentSchema } from "@skmtc/core";
-
-export const toEnrichmentSchema = () => emptyEnrichmentSchema;
-
-export type EnrichmentSchema = EmptyEnrichments;
-```
-
-This declaration is the canonical source of truth for what enrichment fields the
-generator accepts. **To know what payload a generator's enrichments take, read
-its `enrichments.ts`.**
-
-## How enrichments are consumed
-
-Inside a Projection, the validated three-scope umbrella is available as
-`this.settings.enrichments`. Read the scope you want — `.subject`, `.generator`,
-or `.stack` — each typed (and `undefined` when the generator declares nothing
-for that scope):
-
-```ts
-// gen-shadcn-form/src/ShadcnForm.ts
-override toString(): string {
-  const { title, description, submitLabel } = this.settings.enrichments.subject ?? {}
-
-  return `(${this.parameter}) => {
-    return (
-      <Form>
-        ${title ? `<h2>${title}</h2>` : ''}
-        ${description ? `<p>${description}</p>` : ''}
-        ${this.fields}
-        <Button>${submitLabel || 'Submit'}</Button>
-      </Form>
-    )
-  }`
-}
-```
-
-The enrichments are pre-validated by the engine using the generator's declared
-composite Valibot schema, so the Projection can assume the shape is correct.
-Unknown keys are stripped silently; missing optional keys arrive as `undefined`.
-
-### Reading scopes outside a Projection
-
-`this.settings.enrichments` only exists where there's a `ContentSettings` — i.e.
-inside a Projection. The `generator` and `stack` scopes are run-constants, so
-they're often needed elsewhere: in `transform`, in `isSupported`, in an
-accumulator snippet. From those contexts (anywhere holding a `context`), read
-them with the helper readers from `@skmtc/core`:
-
-```ts fragment
-import { toGeneratorEnrichment, toStackEnrichment } from "@skmtc/core";
-
-// generator-scoped leaf — context.settings.enrichments[id]._generator
-const genConfig = toGeneratorEnrichment(context, id, generatorSchema);
-
-// stack-scoped leaf — context.settings.enrichments._stack
-const stackConfig = toStackEnrichment(context, stackSchema);
-```
-
-The return type is inferred from the schema you pass — no cast. Each reader
-looks up by a known reserved key and never enumerates, so a generator can't trip
-over the reserved keys. (There is no `subject` reader here: the subject scope is
-per-item and is resolved by the engine into `ContentSettings`.)
-
 ## How routing works at generate time
 
 For each Projection the engine builds:
@@ -491,57 +259,32 @@ Adding enrichments to a stock generator (to expose what users have been
 hardcoding) is a reasonable upstream contribution. Adding enrichments to a
 clone-then-published fork is fine for project- local needs.
 
-## AI-driven enrichments — `EnrichmentRequest`
+## Validation and warnings
 
-A second enrichment path exists for cases where the _generator_ wants to
-_request_ an enrichment value rather than wait for the user to author one. The
-shape (`core/types/EnrichmentRequest.ts`):
+Three loud layers validate enrichments: a structurally invalid block
+fails at CLI load, a wrongly-typed value in a reached leaf fails that
+item's generation (the run completes; the manifest records the error
+with the path), and a declared variant block missing `main` throws.
 
-```ts
-type EnrichmentRequest<EnrichmentType> = {
-  prompt: string;
-  enrichmentSchema: v.BaseSchema<
-    EnrichmentType,
-    EnrichmentType,
-    v.BaseIssue<unknown>
-  >;
-  content: string;
-};
-```
+What those layers cannot see is *addressing* — a typo'd generator id,
+path, method, or model name makes the lookup miss silently, and an
+unknown leaf key is stripped before the generator sees it. The engine
+audits both after every run and reports on
+`manifest.enrichmentWarnings` (also printed as an "Enrichment
+warnings" block in CLI output):
 
-A generator can implement `toEnrichmentRequest(refName)` on its entry config.
-The function returns either a request descriptor (prompt + schema + content to
-feed an LLM) or `undefined` to skip. Tooling that integrates with an LLM fulfils
-the request, validates the response against the schema, and persists the result
-into `client.json` as if the user had authored it.
+| Type | Level | Meaning |
+|---|---|---|
+| `UNCONSUMED_ENRICHMENT` | warning | A configured routing path no lookup consumed — typo'd path/method/model name, or an entry orphaned by spec evolution |
+| `UNKNOWN_GENERATOR_ID` | warning | A top-level key matching no generator in the run |
+| `UNKNOWN_ENRICHMENT_KEY` | warning | A leaf key the generator's schema does not declare (with a nearest-key suggestion: `submitLabl` → did you mean `submitLabel`?) |
+| `SKIPPED_SUBJECT_ENRICHMENT` | info | Addressed correctly, but the subject is excluded by `skip`/`include` |
+| `SKIPPED_GENERATOR_ENRICHMENT` | info | The whole generator is skipped while enrichments for it exist |
 
-The flow:
-
-```
-generator.toEnrichmentRequest(refName)         → { prompt, schema, content }
-                ↓
-host AI tooling calls LLM with prompt + content
-                ↓
-LLM response parsed against schema
-                ↓
-result written into client.json#enrichments[generatorId][refName]
-                ↓
-next run consumes the result like a user-authored enrichment
-```
-
-Two ways this fits with the wider model:
-
-- The leaf shape is still owned by the generator (same Valibot schema). The AI
-  path doesn't bypass validation — it just defers the _author_ of the leaf from
-  "the user" to "an LLM constrained by the schema."
-- The wire format is the same `client.json` slice. Tooling that doesn't fulfil
-  requests ignores them; the project still works with whatever user-authored
-  enrichments are present.
-
-This is a deferred-fill pattern. It suits enrichments where the value is
-_derivable_ from the schema (a sensible default label, a sample value, a
-description) but you'd rather not hand-author hundreds of them across a large
-API.
+Warnings never affect output — generation stays fail-open. If a
+customization silently doesn't land, this is the first place to look:
+`jq '.manifest.enrichmentWarnings' out.json`. Full shape:
+[manifest format](../reference/manifest-format.md#enrichmentwarnings).
 
 ## Common patterns
 
@@ -609,10 +352,12 @@ knowledge of specific operations.
 
 ### Are enrichments validated?
 
-Yes. Each generator's `toEnrichmentSchema()` returns a Valibot schema that the
-engine uses to validate the user's input. Unknown fields are stripped silently;
-missing optional fields are `undefined`; type mismatches surface as parse
-errors.
+Yes, at three levels. A structurally invalid `enrichments` block fails
+at CLI load (`ConfigValidationError`). A wrongly-typed value in a leaf
+the routing reaches fails that item's generation — the run completes,
+the manifest records the error, and the message names the path. And
+since `@skmtc/core@0.28.0`, the addressing layer warns too: see
+"Validation and warnings" above.
 
 ### Can I extend a stock generator's enrichments without cloning?
 
@@ -663,6 +408,14 @@ same routing shape (same projection-base factory) **and** the same generator
 `id`, the existing enrichments still land. If you change the `id` (which you
 typically do when you republish), update the `client.json` keys to match the new
 id.
+
+## Declaring and consuming enrichments (authors)
+
+Declaring the Valibot schema, reading the parsed umbrella off
+`this.settings.enrichments`, the extensions-vs-enrichments decision,
+and the AI-driven `EnrichmentRequest` surface all live in the
+authoring guide:
+[add enrichment options](../authoring/how-to/add-enrichment-options.md).
 
 ## Further reading
 

--- a/deno/docs/reference/error-codes.md
+++ b/deno/docs/reference/error-codes.md
@@ -18,6 +18,7 @@ This file is the lookup reference for specific codes.
 | Thrown on stderr during generate | `Max lookups reached` | [Max lookups reached](#max-lookups-reached) |
 | Thrown on stderr during generate | `Ref "<$ref>" not found` / `Ref type mismatch for "<$ref>"` | [Ref not found](#ref-ref-not-found) · [Ref type mismatch](#ref-type-mismatch-for-ref) |
 | During `skmtc bundle` or the bundle step of generate | `bundle.js is out of sync with deno.json` / `No matching export … for import` | [Generate-time errors](#generate-time-errors) |
+| `manifest.enrichmentWarnings[].type` or the "Enrichment warnings" output block | `UNCONSUMED_ENRICHMENT`, `UNKNOWN_ENRICHMENT_KEY`, … | [Enrichment warnings](#enrichment-warnings) |
 | Shell `$?` after a run | exit code `0` / `1` / `2` | [CLI exit codes](#cli-exit-codes) |
 | A location string like `paths:/users:post:…` | decoding where an issue occurred | [Issue location strings](#issue-location-strings) |
 
@@ -293,6 +294,12 @@ the same `exportPath`. Collision.
 - Edit its `toIdentifierName` to add a discriminating prefix or suffix
   (e.g., `useCreateUsers` → `useCreateUsersMutation`).
 
+A configuration cause to check before debugging generator code: a
+stray variant key beside `main` in the enrichments block (for
+example a misspelled variant name) fans out an extra variant, and on
+a generator whose naming ignores the variant this surfaces as a key
+mismatch. Check `client.json` variant keys first.
+
 ### `Max lookups reached`
 
 **Full message:** `Max lookups reached`
@@ -365,6 +372,45 @@ skmtc doctor --json
 
 The `project-core-pin/<project>` check identifies the mismatch and
 provides the canonical fix in its `hint` field.
+
+## Enrichment warnings
+
+Reported on `manifest.enrichmentWarnings` (and as an "Enrichment
+warnings" block in CLI output) after every run — the audit of
+enrichment config that did not do what you intended. Warn-level and
+fail-open: output is never affected. Each entry carries a `path` (the
+routing key sequence under `client.json#settings.enrichments`), a
+message, and — for near-miss key typos — a `suggestion`.
+
+### `UNCONSUMED_ENRICHMENT` — warning
+
+A configured routing path that no engine lookup consumed: a typo'd
+path, method, or model name, or an entry orphaned when the schema
+evolved. Remediation: fix the routing key, or delete the entry if the
+subject no longer exists.
+
+### `UNKNOWN_GENERATOR_ID` — warning
+
+A top-level enrichments key that matches no generator in the run.
+Remediation: fix the id, or install the generator it targets.
+
+### `UNKNOWN_ENRICHMENT_KEY` — warning
+
+A leaf key the generator's enrichment schema does not declare — the
+schema strips it before the generator sees it. The message suggests
+the nearest declared key when one is close. Remediation: fix the
+spelling, or check the generator's reference page for the declared
+shape.
+
+### `SKIPPED_SUBJECT_ENRICHMENT` — info
+
+The entry is addressed correctly, but its operation or model is
+excluded by `skip`/`include`. Legitimate during temporary skips;
+delete the entry if the skip is permanent.
+
+### `SKIPPED_GENERATOR_ENRICHMENT` — info
+
+The whole generator is skipped while enrichments for it exist.
 
 ## CLI exit codes
 

--- a/deno/docs/using/how-to/configure-enrichments.md
+++ b/deno/docs/using/how-to/configure-enrichments.md
@@ -110,6 +110,10 @@ either:
 
 ## Troubleshooting
 
+- **A customization silently doesn't land** — check
+  `manifest.enrichmentWarnings` (`jq '.manifest.enrichmentWarnings'`):
+  typo'd keys and routing paths warn there, with suggestions.
+
 - **Enrichments silently ignored** — Most likely a key-path typo.
   Run `skmtc agent-context --json | jq '.projects[] |
   .settings.enrichmentsConfigured'` to confirm `client.json`

--- a/deno/docs/using/how-to/debug-failing-generation.md
+++ b/deno/docs/using/how-to/debug-failing-generation.md
@@ -59,6 +59,18 @@ incomplete. Common sources: missing required fields, unresolvable
 If `diagnostics` is empty, the parse phase succeeded — the issue
 is downstream.
 
+### Check enrichment warnings
+
+```bash
+jq '.manifest.enrichmentWarnings' generate-output.json
+```
+
+If a customization silently didn't land, this is where the engine
+says why: typo'd routing keys, unknown enrichment keys (with
+nearest-key suggestions), and entries orphaned by schema changes all
+surface here. See the
+[enrichment warnings reference](../../reference/error-codes.md#enrichment-warnings).
+
 ### Check per-operation results in the manifest
 
 ```bash

--- a/deno/docs/using/tutorials/03-customize-with-enrichments.md
+++ b/deno/docs/using/tutorials/03-customize-with-enrichments.md
@@ -95,9 +95,10 @@ for all three routing shapes.
 
 Two validation behaviors worth knowing before you edit: a
 wrongly-typed value (a number where `title` expects a string) fails
-the run with a validation error naming the path — but an unknown key
-is silently ignored. If a customization doesn't land, check the key
-spelling and the routing path first.
+that operation's generation — the run completes, and the manifest
+records the error with the path. A misspelled key can't fail
+anything (the schema ignores unknown keys), so the engine warns
+about it instead — step 5 shows that warning in action.
 
 ## Step 3: Regenerate
 
@@ -120,6 +121,26 @@ The form's `<h2>` text is now "Add a new pet", the submit button
 reads "Add to inventory", and the `name` field's label is "Pet
 name". Other operations use the form generator's defaults
 (derived from the OAS path and verb).
+
+## Step 5: Typo a key on purpose
+
+Misspell one override and watch the engine catch it. In
+`client.json`, change `"submitLabel"` to `"submitLabl"` and
+regenerate:
+
+```bash
+skmtc generate petstore --json > out.json
+jq '.manifest.enrichmentWarnings' out.json
+```
+
+The run completes (warnings never affect output), and the manifest
+names the problem — an `UNKNOWN_ENRICHMENT_KEY` warning carrying the
+full routing path and a suggestion (`submitLabl` → did you mean
+`submitLabel`?). The same block prints as "Enrichment warnings" in
+the normal command output. Typos in the routing keys (a wrong path or
+method) surface the same way, as `UNCONSUMED_ENRICHMENT`.
+
+Fix the key back and regenerate before moving on.
 
 ## What just happened
 

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -33,8 +33,8 @@
  *      reference/cli/<command>.md page; every reference/cli page and
  *      every row of the skill's command table names a command that is
  *      still registered.
- *   7. PARSE-ISSUE SYNC — every member of the OasIssueType and
- *      GqlIssueType unions has a `### \`CODE\`` entry in
+ *   7. PARSE-ISSUE SYNC — every member of the OasIssueType,
+ *      GqlIssueType, and EnrichmentWarningType unions has a `### \`CODE\`` entry in
  *      reference/error-codes.md, every documented code is still in a
  *      union, and every issue level the source emits is documented.
  *   8. CLIENT-SETTINGS SYNC — every key of the clientSettings and
@@ -564,6 +564,10 @@ const oasIssueMembers = parseUnionMembers(
   await Deno.readTextFile(join(denoDir, 'core', 'context', 'generateTypes.ts')),
   'OasIssueType'
 )
+const enrichmentWarningMembers = parseUnionMembers(
+  await Deno.readTextFile(join(denoDir, 'core', 'enrichments', 'EnrichmentWarning.ts')),
+  'EnrichmentWarningType'
+)
 const parseIssueText = await Deno.readTextFile(join(denoDir, 'core', 'context', 'ParseIssue.ts'))
 const gqlIssueMembers = parseUnionMembers(parseIssueText, 'GqlIssueType')
 
@@ -576,7 +580,7 @@ if (oasIssueMembers.length === 0 || gqlIssueMembers.length === 0) {
   )
 } else {
   let issueSyncFailures = 0
-  const unionMembers = new Set([...oasIssueMembers, ...gqlIssueMembers])
+  const unionMembers = new Set([...oasIssueMembers, ...gqlIssueMembers, ...enrichmentWarningMembers])
 
   for (const code of unionMembers) {
     if (!errorCodesText.includes(`### \`${code}\``)) {


### PR DESCRIPTION
The docs follow-up to #84 (core 0.28.0's `manifest.enrichmentWarnings`), combined with the last deferred item from the learning-journey program — the enrichments concept split — since both rewrite the same page.

**Phase D:**
- `concepts/enrichments.md` — new **Validation and warnings** section: the five warning types, fail-open semantics, the `jq` entry point.
- `reference/error-codes.md` — **Enrichment warnings** section with per-type remediations + a routing-table row; **verify-docs check 7 extended** so `EnrichmentWarningType` syncs both directions against source (29 codes guarded).
- **Tutorial 03**: the "fails the run" claim is corrected (verified against the dispatch `try/catch`: a wrong-typed value errors *that item*; the run completes) — closing retro entry #1. New **step 5 stages the deliberate-typo aha**: misspell `submitLabel`, regenerate, read the `UNKNOWN_ENRICHMENT_KEY` warning with its nearest-key suggestion. This beat was designed in the aha audit but couldn't honestly ship until the warnings existed.
- Debug how-to: `enrichmentWarnings` as a first check; configure-enrichments troubleshooting pointer.
- Phantom-variant docs entry (decision C): the Registered-definition-mismatch reference now names the stray-variant-key config cause.

**The split (deferred item 2):** the author-facing halves of the enrichments concept (declaring the schema, consuming the umbrella, extensions-vs-enrichments, the isSupported anti-filter, `EnrichmentRequest`) move verbatim into `authoring/how-to/add-enrichment-options.md` — the designated canonical authoring page. The concept drops 3,438 → 2,393 words with a single audience, ending the last dual-audience page from the audit.

All 15 verify-docs checks green; baseline 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)