### PR TITLE
skmtc doctor: enrichment-warnings check against the last manifest

### DIFF
--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {

--- a/deno/cli/lib/doctor-headless.test.ts
+++ b/deno/cli/lib/doctor-headless.test.ts
@@ -101,6 +101,136 @@ Deno.test('runDoctor - warns on stale-schema manifest (friction #26)', async () 
     const manifestCheck = result.checks.find(c => c.id === 'project-manifest/stale-manifest')
     assertEquals(manifestCheck?.status, 'warning')
     assertStringIncludes(manifestCheck?.message ?? '', "doesn't match the current")
+
+    // The enrichment check must not double-report a broken manifest —
+    // it defers to project-manifest and skips.
+    const enrichmentCheck = result.checks.find(c => c.id === 'project-enrichments/stale-manifest')
+    assertEquals(enrichmentCheck?.status, 'skipped')
+  })
+})
+
+/**
+ * A minimal manifest that passes the current `manifestContent` schema.
+ * `enrichmentWarnings` is spread in per test — absent models a manifest
+ * written by a pre-0.28 core.
+ */
+const validManifest = (extra: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    deploymentId: 'run-1',
+    traceId: 'trace-1',
+    spanId: 'span-1',
+    files: {},
+    previews: {},
+    results: {},
+    parseIssues: [],
+    startAt: 0,
+    endAt: 0,
+    ...extra
+  })
+
+const writeProjectWithManifest = async (
+  tempRoot: string,
+  projectName: string,
+  manifestJson: string
+): Promise<void> => {
+  const projectPath = join(tempRoot, '.skmtc', projectName)
+  await ensureDir(join(projectPath, '.settings'))
+  await Deno.writeTextFile(join(projectPath, 'deno.json'), JSON.stringify({ imports: {} }))
+  await Deno.writeTextFile(
+    join(projectPath, '.settings', 'client.json'),
+    JSON.stringify({ settings: { basePath: './src' } })
+  )
+  await Deno.writeTextFile(join(projectPath, '.settings', 'manifest.json'), manifestJson)
+}
+
+Deno.test('runDoctor - surfaces warning-level enrichment warnings from the last manifest', async () => {
+  await withTempSkmtcRoot(async tempRoot => {
+    await writeProjectWithManifest(
+      tempRoot,
+      'enrichment-warn',
+      validManifest({
+        enrichmentWarnings: [
+          {
+            level: 'warning',
+            type: 'UNCONSUMED_ENRICHMENT',
+            path: ['@skmtc/gen-shadcn-form', '/pet', 'post'],
+            message:
+              "enrichment entry '@skmtc/gen-shadcn-form → /pet → post' was never consumed — no matching generator or subject in this run (did you mean '/pets'?)",
+            suggestion: '/pets'
+          },
+          {
+            level: 'info',
+            type: 'SKIPPED_GENERATOR_ENRICHMENT',
+            path: ['@skmtc/gen-msw'],
+            message:
+              "generator '@skmtc/gen-msw' is skipped in this run — its enrichments were not applied"
+          }
+        ]
+      })
+    )
+
+    const result = await runDoctor({ cliVersion: '0.1.5' })
+    const check = result.checks.find(c => c.id === 'project-enrichments/enrichment-warn')
+    assertEquals(check?.status, 'warning')
+    assertStringIncludes(check?.message ?? '', '1 enrichment warning(s)')
+    assertStringIncludes(check?.message ?? '', "did you mean '/pets'?")
+    assertStringIncludes(check?.hint ?? '', 'settings.enrichments')
+    // The full list (including info entries) rides `data` for agents.
+    const data = check?.data?.enrichmentWarnings
+    assertEquals(Array.isArray(data) && data.length === 2, true)
+  })
+})
+
+Deno.test('runDoctor - clean enrichmentWarnings reports ok', async () => {
+  await withTempSkmtcRoot(async tempRoot => {
+    await writeProjectWithManifest(
+      tempRoot,
+      'enrichment-clean',
+      validManifest({ enrichmentWarnings: [] })
+    )
+
+    const result = await runDoctor({ cliVersion: '0.1.5' })
+    const check = result.checks.find(c => c.id === 'project-enrichments/enrichment-clean')
+    assertEquals(check?.status, 'ok')
+  })
+})
+
+Deno.test('runDoctor - info-only enrichmentWarnings reports ok with a note', async () => {
+  await withTempSkmtcRoot(async tempRoot => {
+    await writeProjectWithManifest(
+      tempRoot,
+      'enrichment-info',
+      validManifest({
+        enrichmentWarnings: [
+          {
+            level: 'info',
+            type: 'SKIPPED_SUBJECT_ENRICHMENT',
+            path: ['@skmtc/gen-shadcn-form', '/pets', 'post', 'main'],
+            message:
+              "enrichment at '@skmtc/gen-shadcn-form → /pets → post → main' targets a skipped item — it was not applied in this run"
+          }
+        ]
+      })
+    )
+
+    const result = await runDoctor({ cliVersion: '0.1.5' })
+    const check = result.checks.find(c => c.id === 'project-enrichments/enrichment-info')
+    assertEquals(check?.status, 'ok')
+    assertStringIncludes(check?.message ?? '', '1 info note(s)')
+  })
+})
+
+Deno.test('runDoctor - manifest without enrichmentWarnings skips with a regenerate hint', async () => {
+  await withTempSkmtcRoot(async tempRoot => {
+    // No `enrichmentWarnings` at all — a manifest written by a core
+    // older than 0.28.0. The field is optional in the schema, so the
+    // manifest still validates; the check must say why it can't run.
+    await writeProjectWithManifest(tempRoot, 'enrichment-old-core', validManifest())
+
+    const result = await runDoctor({ cliVersion: '0.1.5' })
+    const check = result.checks.find(c => c.id === 'project-enrichments/enrichment-old-core')
+    assertEquals(check?.status, 'skipped')
+    assertStringIncludes(check?.message ?? '', 'predates enrichment warnings')
   })
 })
 

--- a/deno/cli/lib/doctor-headless.ts
+++ b/deno/cli/lib/doctor-headless.ts
@@ -253,6 +253,7 @@ const checkProject = (projectName: string, ctx: CheckProjectContext): Check[] =>
   checks.push(checkProjectBundle(projectName, denoJsonPath, bundlePath))
   checks.push(checkProjectWorkerPin(projectName, denoJsonPath, join(projectPath, 'worker.ts')))
   checks.push(checkProjectManifest(projectName))
+  checks.push(checkProjectEnrichments(projectName))
   // Gen-maps (anchors) checks — all three short-circuit to `skipped`
   // when the project hasn't opted in, so they're free for users not
   // using the feature.
@@ -639,5 +640,95 @@ const checkProjectManifest = (projectName: string): Check => {
     id: `project-manifest/${projectName}`,
     status: 'ok',
     message: `Project "${projectName}" manifest.json is current.`
+  }
+}
+
+/**
+ * Static enrichment-address check against the last manifest. The
+ * generate-phase consumption audit (core 0.28.0+) records enrichment
+ * config the engine never consumed — typo'd generator ids, paths,
+ * methods, model names, schema-dropped keys — on
+ * `manifest.enrichmentWarnings`. Doctor surfaces those verdicts without
+ * re-running, so dead enrichment config is visible between runs.
+ *
+ * Only `warning`-level entries fail the check; `info` entries
+ * (enrichments on deliberately skipped items) are a routine state and
+ * keep the check `ok`. Manifest read problems are `skipped`, not
+ * re-reported — `project-manifest` owns those.
+ */
+const checkProjectEnrichments = (projectName: string): Check => {
+  const id = `project-enrichments/${projectName}`
+  const manifestPath = Manifest.toPath(projectName)
+
+  if (!existsSync(manifestPath)) {
+    return {
+      id,
+      status: 'skipped',
+      message: `Project "${projectName}" has no manifest yet — enrichment check skipped.`
+    }
+  }
+
+  let parsedJson: unknown
+  try {
+    parsedJson = JSON.parse(Deno.readTextFileSync(manifestPath))
+  } catch {
+    return {
+      id,
+      status: 'skipped',
+      message: `Project "${projectName}" manifest.json is unreadable — enrichment check skipped (see project-manifest).`
+    }
+  }
+
+  const validated = v.safeParse(manifestContent, parsedJson)
+  if (!validated.success) {
+    return {
+      id,
+      status: 'skipped',
+      message: `Project "${projectName}" manifest.json doesn't match the current schema — enrichment check skipped (see project-manifest).`
+    }
+  }
+
+  const warnings = validated.output.enrichmentWarnings
+
+  if (warnings === undefined) {
+    return {
+      id,
+      status: 'skipped',
+      message:
+        `Project "${projectName}" manifest predates enrichment warnings — ` +
+        `re-run \`skmtc generate ${projectName}\` with @skmtc/core 0.28+ to enable this check.`
+    }
+  }
+
+  const actionable = warnings.filter(warning => warning.level === 'warning')
+  const infoCount = warnings.length - actionable.length
+
+  if (actionable.length > 0) {
+    const preview = actionable
+      .slice(0, 3)
+      .map(warning => warning.message)
+      .join('; ')
+    const ellipsis = actionable.length > 3 ? '; …' : ''
+    return {
+      id,
+      status: 'warning',
+      message:
+        `Project "${projectName}" last generate reported ${actionable.length} ` +
+        `enrichment warning(s): ${preview}${ellipsis}`,
+      hint:
+        'Fix the flagged keys in `.settings/client.json#settings.enrichments`, then re-run ' +
+        '`skmtc generate`. Full list: `manifest.enrichmentWarnings` (warnings are also printed ' +
+        'by `skmtc generate`).',
+      data: { enrichmentWarnings: warnings }
+    }
+  }
+
+  return {
+    id,
+    status: 'ok',
+    message:
+      infoCount > 0
+        ? `Project "${projectName}" enrichments are clean (${infoCount} info note(s) about skipped items).`
+        : `Project "${projectName}" enrichments were all consumed on the last generate.`
   }
 }

--- a/deno/docs/reference/cli/doctor.md
+++ b/deno/docs/reference/cli/doctor.md
@@ -59,6 +59,7 @@ For each project under `.skmtc/<project>/`:
 | `project-core-pin/<project>` | The project's `@skmtc/core` import pin matches the CLI's |
 | `project-bundle/<project>` | If the project has at least one *local* generator import, `bundle.js` exists. Pure JSR projects return `ok` with `hasLocalGenerator: false` (no bundle needed). |
 | `project-manifest/<project>` | `manifest.json` (if present) parses and matches the schema the current `@skmtc/core` expects |
+| `project-enrichments/<project>` | The last generate's `manifest.enrichmentWarnings` has no `warning`-level entries — dead enrichment config (typo'd generator ids, paths, methods, model names; schema-dropped keys) surfaces here between runs. `info` entries (enrichments on deliberately skipped items) keep the check `ok`. Skips when the manifest is missing, broken (deferred to `project-manifest`), or written by a core older than 0.28.0. |
 
 The exact set of checks evolves over time. Run `skmtc doctor` itself
 to see the current battery.
@@ -268,6 +269,27 @@ The on-disk `manifest.json` is malformed or has drifted from the
 schema the current `@skmtc/core` expects. The runtime tolerates a
 stale manifest but cleanup of previous artifacts will be skipped
 on the next run. Run `skmtc generate <project>` to rewrite it.
+
+### Enrichment warnings from the last run
+
+```
+○ project-enrichments/my-api    WARN
+    Project "my-api" last generate reported 1 enrichment warning(s):
+    enrichment entry '@skmtc/gen-shadcn-form → /pet → post' was never
+    consumed — no matching generator or subject in this run
+    (did you mean '/pets'?)
+```
+
+The last generate's consumption audit found enrichment config the
+engine never read — a typo'd routing key or an entry orphaned by
+schema evolution — or leaf keys the generator's schema silently
+dropped. Fix the flagged keys in
+`.settings/client.json#settings.enrichments` and re-run
+`skmtc generate <project>`. The full structured list (including
+`info` entries) is in the check's `data.enrichmentWarnings` and in
+`manifest.enrichmentWarnings` — see
+[the manifest format](../manifest-format.md) for the
+`EnrichmentWarning` shape.
 
 ## See also
 


### PR DESCRIPTION
Adds `project-enrichments/<project>` to `skmtc doctor` — the optional static enrichment-address check left open by the enrichment-validation arc (#84).

The generate-phase consumption audit persists its verdicts on `manifest.enrichmentWarnings`; doctor now reads that field so dead enrichment config is visible between runs, not just at generate time:

- **`warning`** when the last generate reported any `warning`-level entries (unconsumed addressing, unknown generator ids, schema-dropped keys). The first three messages appear inline; the full structured list (including `info` entries) rides `data.enrichmentWarnings` for agents. Hint points at `.settings/client.json#settings.enrichments`.
- **`ok`** when the list is empty, or contains only `info` entries (enrichments on deliberately skipped items) — those get a count in the message but never fail the check, matching the CLI text-output policy from #84.
- **`skipped`** when the manifest is missing or broken (deferred to `project-manifest` — no double reporting) or when it predates core 0.28.0 (`enrichmentWarnings` absent), with a regenerate hint.

Docs: new row in the per-project checks table and a remediation section in `reference/cli/doctor.md`.

Versions: cli 0.9.30 → 0.9.31 (patch; no dependents).

Verification: full `deno task check` green — all doc-sync checks hold, 2996 tests (5 new/extended doctor tests: warning surfacing with `data` payload, clean ok, info-only ok, pre-0.28 skip, broken-manifest deferral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)