### PR TITLE
fix(cli): pass --minimum-dependency-age=0 to the bundle subprocess

### DIFF
--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {

--- a/deno/cli/lib/create-bundle.ts
+++ b/deno/cli/lib/create-bundle.ts
@@ -27,8 +27,23 @@ export const createBundle = async ({ project }: CreateBundleArgs): Promise<strin
 
   await project.createWorker()
 
+  // --minimum-dependency-age=0 disables the dependency-age holdback
+  // (enforced by default from Deno 2.9) for the bundle's own
+  // resolution. @skmtc/* publishes on every merge, so the newest
+  // generator/worker versions are always younger than the default
+  // cutoff — without the flag, `deno bundle` on Deno ≥ 2.9 rejects a
+  // freshly released stack with the misleading
+  // `Do not know how to load path: deno:jsr:…`. Same rationale as the
+  // installer's flag on `deno install` (skmtc-hub/apps/install).
+  // The flag parses from Deno 2.6 (a no-op before the 2.9 gate) and is
+  // an unknown-argument error on ≤ 2.5, so gate on the running Deno's
+  // version — the subprocess resolves `deno` from PATH, the same
+  // binary running this code in the supported setups.
+  const [major, minor] = Deno.version.deno.split('.').map(Number)
+  const ageArgs = major > 2 || (major === 2 && minor >= 6) ? ['--minimum-dependency-age=0'] : []
+
   const command = new Deno.Command('deno', {
-    args: ['bundle', '-o', fileName, 'worker.ts'],
+    args: ['bundle', ...ageArgs, '-o', fileName, 'worker.ts'],
     cwd: projectPath,
     stdout: 'piped',
     stderr: 'piped'


### PR DESCRIPTION
Closes the last break in the fresh-user path (friction-log 2026-07-12 entry 6).

**Problem:** Deno 2.9 enforces a dependency-age holdback by default. `@skmtc/*` publishes on every merge, so the newest versions are *always* younger than the cutoff — `skmtc install`/`bundle` on Deno ≥ 2.9 rejects a freshly released stack with the misleading `Do not know how to load path: deno:jsr:…`. (The gate has a second failure mode on plain `deno install`: silent downgrade to the newest version outside the window — the installer already guards that with the same flag; this PR covers the bundle subprocess, the one uncovered spot.)

**Fix:** `createBundle` passes `--minimum-dependency-age=0` to `deno bundle`, gated on the running Deno's version — the flag parses from 2.6 (no-op before the 2.9 gate) and is an unknown-argument error on ≤ 2.5 (verified per-version on standalone binaries: 2.5.4 rejects, 2.6.2/2.7.2/2.8.x accept).

**Verified live:** fresh `skmtc init` + install of the just-published stack (worker 0.3.48 / core 0.28.0 / gens 0.2.4) on deno 2.9.2 — unpatched CLI 0.9.31 fails at the bundle step; this branch's CLI bundles (998KB) and generates correct output with no manual flags.

cli bumped 0.9.31 → 0.9.32 via `deno task bump`; CI publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)