### PR TITLE
fix(cli): lazy-load oxc-parser so generate doesn't need --allow-ffi by default

### DIFF
--- a/deno/cli/CLAUDE.md
+++ b/deno/cli/CLAUDE.md
@@ -121,7 +121,7 @@ Use `deno compile`, **not** `deno install`:
 
 ```bash
 deno compile --no-check \
-  --allow-read --allow-write --allow-net --allow-env --allow-run=deno,sh --allow-sys=homedir \
+  --allow-read --allow-write --allow-net --allow-env --allow-run=deno,sh --allow-sys=homedir --allow-ffi \
   --unstable-worker-options \
   --config /path/to/skmtc/deno/cli/deno.json \
   --include /path/to/skmtc/deno/cli \
@@ -130,8 +130,15 @@ deno compile --no-check \
 ```
 
 The scoped permissions (instead of `-A`) match the published install: skmtc
-needs read/write/net/env, spawns only `deno` + `sh`, and `homedir` to find
-the workspace root — no FFI, no remote imports. `--unstable-worker-options`
+needs read/write/net/env, spawns only `deno` + `sh`, `homedir` to find the
+workspace root, and `ffi` for `oxc-parser`'s native binding — no remote
+imports. `--allow-ffi` is only exercised when a project has
+`settings.anchors.enabled` (or `--anchors`): `generate-local.ts` dynamically
+imports `@skmtc/core/Anchors/oxc` on that path only, so most runs never touch
+it, but the permission still has to be granted up front for compiled/installed
+binaries (unlike `deno run`, they can't prompt at runtime). Without it, a
+project that enables anchors fails with `NotCapable: Requires ffi access to
+".../@oxc-parser/binding-*/parser.*.node"`. `--unstable-worker-options`
 **must** be passed here: `cli/deno.json` carries no `unstable` field, so
 without it the compiled binary fails the first `generate` on
 `Worker.deno.permissions`. (For a throwaway dev run, `deno run --allow-all`

--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.33",
+  "version": "0.9.34",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {

--- a/deno/cli/lib/generate-local.ts
+++ b/deno/cli/lib/generate-local.ts
@@ -3,7 +3,6 @@ import { GenerateArtifacts } from '@/lib/generate-artifacts.ts'
 import { writeGeneratedFiles, type WriteGeneratedFilesResult } from '@/lib/write-generated-files.ts'
 import type { ClientSettings } from '@skmtc/core/Settings'
 import { reanchorSidecar, upgradeSidecar, writeSidecars } from '@skmtc/core/Anchors'
-import { oxcAdapter } from '@skmtc/core/Anchors/oxc'
 import { toResolvedArtifactPath } from '@skmtc/core'
 import { type GenerationStats, toGenerationStats } from '@/lib/generationStats.ts'
 import type { FileType } from '@/lib/types.ts'
@@ -156,6 +155,13 @@ export const generateLocal = async ({
       //    spans to the FORMATTED text so the written sidecar describes
       //    the file as it exists on disk.
       // Artifacts are keyed by resolved path; sidecar `f` is `@/`-aliased.
+      //
+      // `oxcAdapter` is imported dynamically, here, rather than at module
+      // scope: it pulls in `npm:oxc-parser`'s native binding, which needs
+      // `--allow-ffi` and is otherwise unused (and unwanted) on every
+      // generate run that never asked for anchors/attribution — matching
+      // the worker's own stance (it never imports oxc at all).
+      const { oxcAdapter } = await import('@skmtc/core/Anchors/oxc')
       const sidecarArtifacts = new Set<string>()
       const realignedArtifacts = new Set<string>()
       const upgradedSidecars = Object.fromEntries(


### PR DESCRIPTION
## Summary
- `generate-local.ts` imported `oxcAdapter` (backed by `npm:oxc-parser`'s native binding) at module scope, so every `skmtc generate` run loaded it eagerly — even for projects with no `anchors`/attribution configured, the common case. Once the CLI is compiled/installed with scoped permissions (no `-A`), that native binding load requires `--allow-ffi`, so `generate` crashed with `NotCapable` regardless of whether attribution was ever requested.
- `oxcAdapter` is now dynamically imported only inside the `if (sidecars && generationMap)` branch — i.e. only when the run actually enabled anchors — matching the worker's existing stance (it never imports oxc at all, falling back to `parser: undefined`).
- Also updates the documented local-install compile recipe in `cli/CLAUDE.md` to include `--allow-ffi`, since attribution is a real supported feature and compiled/installed binaries can't prompt for permissions at runtime the way `deno run` can.
- Bumps `@skmtc/cli` 0.9.33 → 0.9.34 (patch); CI's `Publish` workflow releases it automatically on merge to main.

## Test plan
- [x] `deno task check` (workspace type-check + doc-sync gate + full test suite, 2,982 tests) — green
- [x] Compiled a binary **without** `--allow-ffi` (the pre-fix recipe) and confirmed `generate` now succeeds against a real project with no anchors config (previously crashed)
- [x] Compiled a second binary **with** `--allow-ffi` and confirmed `generate` against a project with `anchors.enabled: true` still correctly produces sidecars (1,112 `.skm.json` files + `_map.ndjson`)
- [x] Confirmed the remaining combination (anchors enabled, `--allow-ffi` not granted) still fails with the same clear, actionable error — not a regression, just the genuinely-required case
- [x] Pre-push hook re-ran the full check suite before this branch was pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)