### PR TITLE
fix(cli): remove edit protection — generated files are engine-owned again

### DIFF
--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {

--- a/deno/cli/lib/status-headless.test.ts
+++ b/deno/cli/lib/status-headless.test.ts
@@ -174,7 +174,7 @@ Deno.test('statusHeadless - files without a lock entry are unverified', async ()
   }
 })
 
-Deno.test('statusHeadless - edited files spared from pruning surface as orphaned', async () => {
+Deno.test('statusHeadless - stale files are pruned even when edited', async () => {
   const { tempDir, skmtcRootPath, manifestPath } = await toWorkspace('my-api')
   const originalCwd = Deno.cwd()
   try {
@@ -188,7 +188,9 @@ Deno.test('statusHeadless - edited files spared from pruning surface as orphaned
 
       Deno.writeTextFileSync(join(tempDir, 'src/old.ts'), 'export const old = 1 // keep\n')
 
-      // Next generate no longer produces old.ts — the prune spares it.
+      // Next generate no longer produces old.ts — generated files are
+      // engine-owned, so the prune deletes it, edit included, and status
+      // has nothing to report for it.
       writeGeneratedFiles({
         manifestPath,
         artifacts: { 'src/new.ts': 'export const fresh = 1\n' },
@@ -203,9 +205,9 @@ Deno.test('statusHeadless - edited files spared from pruning surface as orphaned
         skmtcRootPath
       })
 
-      assertEquals(result.orphaned, ['src/old.ts'])
+      assertEquals(result.orphaned, [])
       assertEquals(result.counts, { clean: 1, modified: 0, missing: 0, unverified: 0, ejected: 0 })
-      assertEquals(result.clean, false)
+      assertEquals(result.clean, true)
     })
   } finally {
     Deno.chdir(originalCwd)

--- a/deno/cli/lib/write-generated-files.test.ts
+++ b/deno/cli/lib/write-generated-files.test.ts
@@ -4,6 +4,7 @@ import { readGeneratedLock, toGeneratedLockPath } from '@/lib/generated-lock.ts'
 import { manifestContent } from '@skmtc/core/Manifest'
 import * as v from 'valibot'
 import { join } from '@std/path/join'
+import { existsSync } from '@std/fs/exists'
 
 // Helper to create a valid manifest structure
 const createManifest = (files: Record<string, unknown>) => ({
@@ -395,14 +396,15 @@ Deno.test('writeGeneratedFiles - rewrites a file whose content changed', async (
   }
 })
 
-// --- writeGeneratedFiles: edit detection + protect -------------------------
-// The prime invariant of the override/eject arc: `generate` never destroys a
-// hand edit. The writer classifies every on-disk artifact against the
-// generated lock (`.settings/generated.lock.json`) before overwriting or
-// pruning; a file whose content matches neither the recorded formatted hash
-// nor the formatter-drift resolution is left untouched and reported.
+// --- writeGeneratedFiles: engine ownership ---------------------------------
+// Generated files are engine-owned: every run converges the on-disk tree to
+// this run's render, hand edits included. The lock is a write-avoidance
+// cache only (byte-identical and unchanged-formatted skips keep mtimes
+// stable) — it never blocks an overwrite, and `protectedPaths` is always
+// empty. Ejection (`settings.ejected`) is the one sanctioned way to own a
+// file.
 
-/** Runs a test body with console.error captured (protect warnings land on stderr). */
+/** Runs a test body with console.error captured (formatter warnings land on stderr). */
 const withCapturedErrors = async (
   body: (errors: string[]) => Promise<void> | void
 ): Promise<void> => {
@@ -416,7 +418,7 @@ const withCapturedErrors = async (
   }
 }
 
-Deno.test('writeGeneratedFiles - protects a hand-edited file from overwrite', async () => {
+Deno.test('writeGeneratedFiles - overwrites a hand-edited file', async () => {
   const tempDir = await Deno.makeTempDir()
   const originalCwd = Deno.cwd()
   try {
@@ -432,7 +434,8 @@ Deno.test('writeGeneratedFiles - protects a hand-edited file from overwrite', as
         manifest
       })
 
-      // The user edits the generated file by hand.
+      // The user edits the generated file by hand — generated files are
+      // engine-owned, so the next run overwrites the edit.
       Deno.writeTextFileSync(artifactPath, 'export const a = 1 // patched by hand\n')
 
       const result = writeGeneratedFiles({
@@ -441,18 +444,12 @@ Deno.test('writeGeneratedFiles - protects a hand-edited file from overwrite', as
         manifest
       })
 
-      assertEquals(Deno.readTextFileSync(artifactPath), 'export const a = 1 // patched by hand\n')
-      assertEquals(result.protectedPaths, ['out.ts'])
-      assertStringIncludes(errors.join('\n'), 'manual edits')
-
-      // The protection is stable: a third run still refuses to clobber.
-      const again = writeGeneratedFiles({
-        manifestPath,
-        artifacts: { 'out.ts': 'export const a = 3\n' },
-        manifest
-      })
-      assertEquals(Deno.readTextFileSync(artifactPath), 'export const a = 1 // patched by hand\n')
-      assertEquals(again.protectedPaths, ['out.ts'])
+      assertEquals(Deno.readTextFileSync(artifactPath), 'export const a = 2\n')
+      assertEquals(result.protectedPaths, [])
+      assertEquals(
+        errors.filter(msg => msg.includes('manual edits')),
+        []
+      )
     })
   } finally {
     Deno.chdir(originalCwd)
@@ -460,7 +457,7 @@ Deno.test('writeGeneratedFiles - protects a hand-edited file from overwrite', as
   }
 })
 
-Deno.test('writeGeneratedFiles - protects a hand-edited stale file from deletion', async () => {
+Deno.test('writeGeneratedFiles - prunes a stale file even when hand-edited', async () => {
   const tempDir = await Deno.makeTempDir()
   const originalCwd = Deno.cwd()
   try {
@@ -478,20 +475,21 @@ Deno.test('writeGeneratedFiles - protects a hand-edited stale file from deletion
 
       Deno.writeTextFileSync(oldPath, 'export const old = 1 // keep me\n')
 
-      // Next run no longer produces old.ts — normally it would be pruned.
+      // Next run no longer produces old.ts — it is pruned regardless of the
+      // edit. Ejection is the sanctioned way to keep a generated file.
       const result = writeGeneratedFiles({
         manifestPath,
         artifacts: { 'new.ts': 'export const fresh = 1\n' },
         manifest: manifestFor('new.ts')
       })
 
-      assertEquals(Deno.readTextFileSync(oldPath), 'export const old = 1 // keep me\n')
+      assertEquals(existsSync(oldPath), false)
       assertEquals(Deno.readTextFileSync(newPath), 'export const fresh = 1\n')
-      assertEquals(result.protectedPaths, ['old.ts'])
+      assertEquals(result.protectedPaths, [])
 
-      // The spared file keeps its lock entry so future runs can still classify it.
+      // The pruned file's lock entry is dropped with it.
       const lock = readGeneratedLock(toGeneratedLockPath(manifestPath))
-      assertEquals(typeof lock?.files['old.ts']?.canonicalHash, 'string')
+      assertEquals(lock?.files['old.ts'], undefined)
     })
   } finally {
     Deno.chdir(originalCwd)
@@ -499,7 +497,7 @@ Deno.test('writeGeneratedFiles - protects a hand-edited stale file from deletion
   }
 })
 
-Deno.test('writeGeneratedFiles - reverting an edit resumes generation', async () => {
+Deno.test('writeGeneratedFiles - overwrites pre-existing untracked files and seeds the lock', async () => {
   const tempDir = await Deno.makeTempDir()
   const originalCwd = Deno.cwd()
   try {
@@ -509,52 +507,9 @@ Deno.test('writeGeneratedFiles - reverting an edit resumes generation', async ()
       const artifactPath = join(tempDir, 'out.ts')
       const manifest = manifestFor('out.ts')
 
-      writeGeneratedFiles({
-        manifestPath,
-        artifacts: { 'out.ts': 'export const a = 1\n' },
-        manifest
-      })
-      Deno.writeTextFileSync(artifactPath, 'export const a = 99\n')
-
-      const protectedRun = writeGeneratedFiles({
-        manifestPath,
-        artifacts: { 'out.ts': 'export const a = 2\n' },
-        manifest
-      })
-      assertEquals(protectedRun.protectedPaths, ['out.ts'])
-
-      // The user reverts their edit — the file matches the last generated
-      // content again, so generation resumes.
-      Deno.writeTextFileSync(artifactPath, 'export const a = 1\n')
-
-      const resumedRun = writeGeneratedFiles({
-        manifestPath,
-        artifacts: { 'out.ts': 'export const a = 2\n' },
-        manifest
-      })
-      assertEquals(resumedRun.protectedPaths, [])
-      assertEquals(Deno.readTextFileSync(artifactPath), 'export const a = 2\n')
-    })
-  } finally {
-    Deno.chdir(originalCwd)
-    await Deno.remove(tempDir, { recursive: true })
-  }
-})
-
-Deno.test('writeGeneratedFiles - seeds the lock for pre-existing untracked files', async () => {
-  const tempDir = await Deno.makeTempDir()
-  const originalCwd = Deno.cwd()
-  try {
-    Deno.chdir(tempDir)
-    await withCapturedErrors(() => {
-      const manifestPath = join(tempDir, 'manifest.json')
-      const artifactPath = join(tempDir, 'out.ts')
-      const manifest = manifestFor('out.ts')
-
-      // A pre-lock project: the file exists on disk but no lock tracks it.
-      // Migration contract: the first run behaves as before (overwrite) and
-      // seeds the lock; edit detection activates from the next run.
-      Deno.writeTextFileSync(artifactPath, 'export const a = 0 // pre-feature content\n')
+      // No lock yet (fresh clone / first run): the file is overwritten and
+      // the lock is seeded for the write-avoidance skips.
+      Deno.writeTextFileSync(artifactPath, 'export const a = 0 // pre-existing content\n')
 
       const first = writeGeneratedFiles({
         manifestPath,
@@ -564,18 +519,8 @@ Deno.test('writeGeneratedFiles - seeds the lock for pre-existing untracked files
       assertEquals(first.protectedPaths, [])
       assertEquals(Deno.readTextFileSync(artifactPath), 'export const a = 1\n')
 
-      Deno.writeTextFileSync(artifactPath, 'export const a = 1 // edited after seeding\n')
-
-      const second = writeGeneratedFiles({
-        manifestPath,
-        artifacts: { 'out.ts': 'export const a = 2\n' },
-        manifest
-      })
-      assertEquals(second.protectedPaths, ['out.ts'])
-      assertEquals(
-        Deno.readTextFileSync(artifactPath),
-        'export const a = 1 // edited after seeding\n'
-      )
+      const lock = readGeneratedLock(toGeneratedLockPath(manifestPath))
+      assertEquals(typeof lock?.files['out.ts']?.canonicalHash, 'string')
     })
   } finally {
     Deno.chdir(originalCwd)
@@ -633,7 +578,7 @@ Deno.test('writeGeneratedFiles - formats written files and stays quiet on unchan
   }
 })
 
-Deno.test('writeGeneratedFiles - a formatter config change is not an edit', async () => {
+Deno.test('writeGeneratedFiles - a formatter config change converges after the repo reformat', async () => {
   const tempDir = await Deno.makeTempDir()
   const originalCwd = Deno.cwd()
   try {
@@ -650,24 +595,32 @@ Deno.test('writeGeneratedFiles - a formatter config change is not an edit', asyn
       })
       assertEquals(Deno.readTextFileSync(artifactPath), formattedDouble)
 
-      // The user changes their formatter config and reformats the repo —
-      // every generated file's bytes change without any hand edit.
-      Deno.writeTextFileSync(artifactPath, formattedSingle)
+      // Config change alone, render and disk untouched: the unchanged-render
+      // skip still applies — the file keeps the old style for now (lazy).
+      Deno.utimeSync(artifactPath, PAST, PAST)
+      const lazy = writeGeneratedFiles({
+        manifestPath,
+        artifacts: { 'out.ts': canonical },
+        manifest,
+        clientSettings: { formatter: 'deno fmt --options-single-quote' }
+      })
+      assertEquals(lazy.protectedPaths, [])
+      assertEquals(Deno.statSync(artifactPath).mtime?.getTime(), PAST.getTime())
 
+      // The user reformats the repo under the new config (the usual next
+      // step): disk no longer matches the recorded state, so the next run
+      // rewrites and re-formats — converging on the new style.
+      Deno.writeTextFileSync(artifactPath, formattedSingle)
       const rerun = writeGeneratedFiles({
         manifestPath,
         artifacts: { 'out.ts': canonical },
         manifest,
         clientSettings: { formatter: 'deno fmt --options-single-quote' }
       })
-
-      // Re-formatting the stored canonical baseline under the CURRENT config
-      // reproduces the disk content, so the file is clean — not protected,
-      // not rewritten.
       assertEquals(rerun.protectedPaths, [])
       assertEquals(Deno.readTextFileSync(artifactPath), formattedSingle)
 
-      // And the resolution is recorded: the next run compares cheaply again.
+      // The new formatted state is recorded: the next run skips the write.
       Deno.utimeSync(artifactPath, PAST, PAST)
       const third = writeGeneratedFiles({
         manifestPath,
@@ -684,7 +637,7 @@ Deno.test('writeGeneratedFiles - a formatter config change is not an edit', asyn
   }
 })
 
-Deno.test('writeGeneratedFiles - a real edit is detected through the formatter', async () => {
+Deno.test('writeGeneratedFiles - a hand edit under a formatter is overwritten', async () => {
   const tempDir = await Deno.makeTempDir()
   const originalCwd = Deno.cwd()
   try {
@@ -702,8 +655,8 @@ Deno.test('writeGeneratedFiles - a real edit is detected through the formatter',
         clientSettings
       })
 
-      // A semantic edit in the formatted file — formatter-drift resolution
-      // must NOT explain this away.
+      // A semantic edit in the formatted file — overwritten and re-formatted
+      // on the next run like any other divergence.
       const edited = `${formattedDouble}export const b = 2;\n`
       Deno.writeTextFileSync(artifactPath, edited)
 
@@ -714,8 +667,8 @@ Deno.test('writeGeneratedFiles - a real edit is detected through the formatter',
         clientSettings
       })
 
-      assertEquals(rerun.protectedPaths, ['out.ts'])
-      assertEquals(Deno.readTextFileSync(artifactPath), edited)
+      assertEquals(rerun.protectedPaths, [])
+      assertEquals(Deno.readTextFileSync(artifactPath), formattedDouble)
     })
   } finally {
     Deno.chdir(originalCwd)
@@ -762,51 +715,11 @@ Deno.test('writeGeneratedFiles - formatter failure degrades gracefully', async (
   }
 })
 
-Deno.test('writeGeneratedFiles - warnOnProtected: false protects silently', async () => {
-  const tempDir = await Deno.makeTempDir()
-  const originalCwd = Deno.cwd()
-  try {
-    Deno.chdir(tempDir)
-    await withCapturedErrors(errors => {
-      const manifestPath = join(tempDir, 'manifest.json')
-      const artifactPath = join(tempDir, 'out.ts')
-      const manifest = manifestFor('out.ts')
-
-      writeGeneratedFiles({
-        manifestPath,
-        artifacts: { 'out.ts': 'export const a = 1\n' },
-        manifest
-      })
-      Deno.writeTextFileSync(artifactPath, 'export const a = 1 // mine\n')
-
-      // Watch mode: protection still applies, but the multi-line stderr
-      // warning is suppressed — dev prints its own one-line status.
-      const result = writeGeneratedFiles({
-        manifestPath,
-        artifacts: { 'out.ts': 'export const a = 2\n' },
-        manifest,
-        warnOnProtected: false
-      })
-
-      assertEquals(result.protectedPaths, ['out.ts'])
-      assertEquals(Deno.readTextFileSync(artifactPath), 'export const a = 1 // mine\n')
-      assertEquals(
-        errors.filter(msg => msg.includes('manual edits')),
-        []
-      )
-    })
-  } finally {
-    Deno.chdir(originalCwd)
-    await Deno.remove(tempDir, { recursive: true })
-  }
-})
-
 // --- writeGeneratedFiles: ejected files ------------------------------------
 // An ejected file (client.json#settings.ejected, suffix-less export
 // paths) is user-owned: the engine still renders it (drift input), but
 // the host never writes it, never deletes it, and marks it in the
-// manifest. Distinct from `protected` — ejection is declared intent,
-// not a detected edit.
+// manifest. Ejection is declared intent — the one way to own a file.
 
 Deno.test('writeGeneratedFiles - never writes or deletes an ejected file', async () => {
   const tempDir = await Deno.makeTempDir()

--- a/deno/cli/lib/write-generated-files.ts
+++ b/deno/cli/lib/write-generated-files.ts
@@ -18,7 +18,6 @@ import {
   writeGeneratedLock
 } from '@/lib/generated-lock.ts'
 import { runFormatter } from '@/lib/formatter.ts'
-import { classifyDiskFile, type EditDetectionContext } from '@/lib/edit-detection.ts'
 import { classifyEjectedFile } from '@/lib/ejection-state.ts'
 
 /**
@@ -48,15 +47,6 @@ type DeletePreviousArtifactsArgs = {
    *  basePath, or called without settings), dirs aren't pruned. */
   clientSettings?: ClientSettings
   /**
-   * Edit-detection context. When absent (legacy callers), pruning
-   * behaves as before: every stale manifest path is deleted. When
-   * present, a stale file classified as hand-edited is left in place
-   * and reported through `onProtected`.
-   */
-  detection?: EditDetectionContext
-  /** Receives the artifact path of every stale-but-edited file spared from deletion. */
-  onProtected?: (artifactPath: string) => void
-  /**
    * Artifact-space paths of ejected (user-owned) files — never
    * deleted, regardless of manifest state. Defaults to the set derived
    * from `clientSettings.ejected`.
@@ -69,8 +59,6 @@ export const deletePreviousArtifacts = ({
   incomingPaths,
   manifestPath,
   clientSettings,
-  detection,
-  onProtected,
   ejectedArtifactPaths = toEjectedArtifactPaths(clientSettings)
 }: DeletePreviousArtifactsArgs): void => {
   if (!existsSync(manifestPath)) {
@@ -106,26 +94,6 @@ export const deletePreviousArtifacts = ({
       }
 
       const absolutePath = join(skmtcRootPath, '..', path)
-
-      // A stale artifact the user has edited is theirs now — deleting
-      // it would destroy their work. Leave it and let the caller report.
-      const lockEntry = detection?.lock?.files[path]
-      if (detection && lockEntry && existsSync(absolutePath)) {
-        // Nothing renders this path this run (it's stale) — no fresh
-        // content to disambiguate a formatter-config change from an
-        // edit, so a hash mismatch here is always classified edited.
-        const { edited } = classifyDiskFile({
-          absolutePath,
-          lockEntry,
-          detection,
-          freshCanonicalContent: undefined
-        })
-
-        if (edited) {
-          onProtected?.(path)
-          continue
-        }
-      }
 
       Deno.removeSync(absolutePath)
       deletedAbsPaths.push(absolutePath)
@@ -183,10 +151,9 @@ type WriteGeneratedFilesArgs = {
    *  and formatter-aware edit detection. */
   clientSettings?: ClientSettings
   /**
-   * Suppress the multi-line stderr warning for protected files. Watch
-   * mode sets this — re-announcing the same protected files on every
-   * rebuild is alarm fatigue; `dev` prints its own one-line status
-   * instead. Protection itself is unaffected.
+   * No-op, retained for caller compatibility. Edit protection (and its
+   * stderr warning) was removed: generated files are engine-owned and
+   * overwritten on every run.
    */
   warnOnProtected?: boolean
 }
@@ -195,10 +162,9 @@ export type WriteGeneratedFilesResult = {
   manifest: ManifestContent
   artifacts: Record<string, string>
   /**
-   * Artifact paths that were NOT written (or deleted) this run because
-   * the on-disk file no longer matches what the previous run produced —
-   * i.e. the user hand-edited it. The prime invariant: `generate`
-   * never destroys a hand edit.
+   * Always empty. Edit protection was removed — generated files are
+   * engine-owned and overwritten on every run. The field is retained
+   * so the `--json` result shape stays stable for consumers.
    */
   protectedPaths: string[]
   /**
@@ -223,8 +189,7 @@ export const writeGeneratedFiles = ({
   manifestPath,
   artifacts,
   manifest,
-  clientSettings,
-  warnOnProtected = true
+  clientSettings
 }: WriteGeneratedFilesArgs): WriteGeneratedFilesResult => {
   const skmtcRootPath = toRootPath()
   const appRoot = resolve(skmtcRootPath, '..')
@@ -232,13 +197,6 @@ export const writeGeneratedFiles = ({
   const lockPath = toGeneratedLockPath(manifestPath)
   const lock = readGeneratedLock(lockPath)
 
-  const detection: EditDetectionContext = {
-    lock,
-    formatterCommand: clientSettings?.formatter,
-    appRoot
-  }
-
-  const protectedPaths: string[] = []
   const ejectedArtifactPaths = toEjectedArtifactPaths(clientSettings)
 
   // Suffixed twins of ejected files. A correctly-versioned engine maps
@@ -267,9 +225,7 @@ export const writeGeneratedFiles = ({
     incomingPaths: Object.keys(artifacts ?? {}),
     manifestPath,
     skmtcRootPath,
-    clientSettings,
-    detection,
-    onProtected: path => protectedPaths.push(path)
+    clientSettings
   })
 
   // Mark ejected entries before the manifest lands on disk, so every
@@ -328,72 +284,35 @@ export const writeGeneratedFiles = ({
       continue
     }
 
-    const lockEntry = lock?.files[artifactPath]
+    // Render output is deterministic, so skipping byte-identical
+    // rewrites keeps mtimes stable for file-watch consumers (Vite
+    // HMR, `skmtc dev`).
+    const diskContent = Deno.readTextFileSync(absolutePath)
 
-    if (!lockEntry) {
-      // Untracked file (first run with edit detection, or a fresh
-      // clone without the lock): preserve the pre-lock behavior —
-      // changed-only overwrite — and seed a lock entry so the NEXT
-      // run can tell edits apart. Render output is deterministic, so
-      // skipping byte-identical rewrites also keeps mtimes stable for
-      // file-watch consumers (Vite HMR, `skmtc dev`).
-      const diskContent = Deno.readTextFileSync(absolutePath)
-
-      if (diskContent === content) {
-        nextLockFiles[artifactPath] = {
-          canonicalHash,
-          formattedHash: canonicalHash
-        }
-        continue
-      }
-
-      Deno.writeTextFileSync(absolutePath, content)
-      pendingWrites.push({
-        artifactPath,
-        absolutePath,
+    if (diskContent === content) {
+      nextLockFiles[artifactPath] = {
         canonicalHash,
-        content
-      })
+        formattedHash: canonicalHash
+      }
       continue
     }
 
-    // This run's fresh canonical render for `artifactPath` is `content`
-    // — already in memory, no cache needed. It's only an exact stand-in
-    // for "what was rendered last time" when the canonical output is
-    // unchanged (the branch below): if the schema also changed this
-    // run, a formatter-config change on an otherwise-untouched file can
-    // misclassify as edited here, since there's no way to recover what
-    // the OLD canonical render looked like. That fails safe — the file
-    // is protected, never destroyed — and resolves itself next run.
-    const { edited, driftResolvedFormattedHash } = classifyDiskFile({
-      absolutePath,
-      lockEntry,
-      detection,
-      freshCanonicalContent: content
-    })
+    // Unchanged render whose on-disk bytes are exactly what the
+    // post-write formatter left last time → no write. This is a pure
+    // cache-validity check (same render in, same formatted bytes on
+    // disk); any other disk state — hand edits included — is
+    // overwritten below. Generated files are engine-owned.
+    const lockEntry = lock?.files[artifactPath]
 
-    if (edited) {
-      // The prime invariant: never destroy a hand edit. Keep the old
-      // lock entry — it is what the user's edit was made against, and
-      // what a future eject resolves from.
-      protectedPaths.push(artifactPath)
+    if (
+      lockEntry &&
+      lockEntry.canonicalHash === canonicalHash &&
+      toContentHash(diskContent) === lockEntry.formattedHash
+    ) {
       nextLockFiles[artifactPath] = lockEntry
       continue
     }
 
-    if (canonicalHash === lockEntry.canonicalHash) {
-      // Unchanged render output on a clean file → no write (keeps
-      // mtimes stable). Record the drift-resolved formatted hash when
-      // a formatter-config change was detected so subsequent runs
-      // compare cheaply again.
-      nextLockFiles[artifactPath] = {
-        canonicalHash: lockEntry.canonicalHash,
-        formattedHash: driftResolvedFormattedHash ?? lockEntry.formattedHash
-      }
-      continue
-    }
-
-    // Changed render output on a clean file → overwrite.
     Deno.writeTextFileSync(absolutePath, content)
     pendingWrites.push({ artifactPath, absolutePath, canonicalHash, content })
   }
@@ -423,15 +342,6 @@ export const writeGeneratedFiles = ({
     nextLockFiles[artifactPath] = {
       canonicalHash,
       formattedHash: toContentHash(onDisk)
-    }
-  }
-
-  // Stale-but-edited files spared by the prune keep their lock entry so
-  // future runs can still classify them.
-  for (const path of protectedPaths) {
-    const previousEntry = lock?.files[path]
-    if (previousEntry && !nextLockFiles[path]) {
-      nextLockFiles[path] = previousEntry
     }
   }
 
@@ -482,36 +392,18 @@ export const writeGeneratedFiles = ({
     }
   }
 
-  if (warnOnProtected && protectedPaths.length > 0) {
-    console.error(
-      `Warning: ${protectedPaths.length} generated file(s) have manual edits and were left ` +
-        `untouched:\n${protectedPaths.map(path => `  ${path}`).join('\n')}\n` +
-        `Generated files are overwritten on each run — move lasting changes into enrichments ` +
-        `or hand-written modules, or revert the files to resume generation for them.`
-    )
-  }
-
   // On-disk drift vs the raw render, for the sidecar/manifest realignment
   // in generate-local. Only FORMATTER-attributable drift qualifies:
-  // - collected only when `settings.formatter` is configured (no formatter
-  //   → nothing legitimate can have drifted, and skipping the scan avoids
-  //   re-reading the whole corpus per generate);
-  // - hand-edited files (`protectedPaths` — both the stale-spared and the
-  //   incoming-write-skipped kinds) are excluded: realigning attribution
-  //   onto user-owned text and silencing the reader's drift trigger for it
-  //   would serve confidently wrong spans.
+  // collected only when `settings.formatter` is configured (no formatter
+  // → nothing legitimate can have drifted, and skipping the scan avoids
+  // re-reading the whole corpus per generate).
   // Read AFTER the formatter step so a just-formatted file is captured;
   // covers unwritten (unchanged-render) files too — their on-disk copy
   // stays formatted from a previous run.
   const onDiskDrift: Record<string, string> = {}
   if (formatterCommand) {
-    const protectedSet = new Set(protectedPaths)
     for (const [artifactPath, artifactContent] of Object.entries(artifacts ?? {})) {
-      if (
-        twinArtifactPaths.has(artifactPath) ||
-        ejectedArtifactPaths.has(artifactPath) ||
-        protectedSet.has(artifactPath)
-      ) {
+      if (twinArtifactPaths.has(artifactPath) || ejectedArtifactPaths.has(artifactPath)) {
         continue
       }
       try {
@@ -528,7 +420,7 @@ export const writeGeneratedFiles = ({
   return {
     manifest,
     artifacts,
-    protectedPaths,
+    protectedPaths: [],
     onDiskDrift,
     ...(ejections ? { ejections } : {})
   }

--- a/deno/deno.lock
+++ b/deno/deno.lock
@@ -28,6 +28,7 @@
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/io@~0.225.2": "0.225.3",
+    "jsr:@std/log@0.224": "0.224.14",
     "jsr:@std/log@~0.224.6": "0.224.14",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.6": "1.0.6",

--- a/deno/deno.lock
+++ b/deno/deno.lock
@@ -45,9 +45,11 @@
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@babel/helper-validator-identifier@7.27.1": "7.27.1",
-    "npm:@inkjs/ui@2": "2.0.0_ink@6.8.0__react@19.2.7_react@19.2.7",
+    "npm:@inkjs/ui@2": "2.0.0_ink@6.8.0__@types+react@19.2.17__react@19.2.7_@types+react@19.2.17",
     "npm:@modelcontextprotocol/sdk@^1.29.0": "1.29.0_zod@4.4.3",
+    "npm:@types/babel__helper-validator-identifier@7.15.2": "7.15.2",
     "npm:@types/lodash-es@4.17.12": "4.17.12",
+    "npm:@types/react@19": "19.2.17",
     "npm:@valibot/to-json-schema@1.3.0": "1.3.0_valibot@1.1.0",
     "npm:ajv-draft-04@1": "1.0.0_ajv@8.20.0",
     "npm:ajv-formats@^3.0.1": "3.0.1_ajv@8.20.0",
@@ -58,10 +60,10 @@
     "npm:hono@4.7.2": "4.7.2",
     "npm:ignore@7.0.5": "7.0.5",
     "npm:ignore@^7.0.5": "7.0.5",
-    "npm:ink-link@5": "5.0.0_ink@6.8.0__react@19.2.7_react@19.2.7",
-    "npm:ink-select-input@^6.2.0": "6.2.0_ink@6.8.0__react@19.2.7_react@19.2.7",
-    "npm:ink-testing-library@4": "4.0.0",
-    "npm:ink@^6.2.3": "6.8.0_react@19.2.7",
+    "npm:ink-link@5": "5.0.0_ink@6.8.0__@types+react@19.2.17__react@19.2.7_@types+react@19.2.17",
+    "npm:ink-select-input@^6.2.0": "6.2.0_ink@6.8.0__@types+react@19.2.17__react@19.2.7_react@19.2.7_@types+react@19.2.17",
+    "npm:ink-testing-library@4": "4.0.0_@types+react@19.2.17",
+    "npm:ink@^6.2.3": "6.8.0_@types+react@19.2.17_react@19.2.7",
     "npm:lodash-es@4.17.21": "4.17.21",
     "npm:openapi-types@^12.1.3": "12.1.3",
     "npm:oxc-parser@0.41.0": "0.41.0",
@@ -236,7 +238,7 @@
         "hono@4.12.27"
       ]
     },
-    "@inkjs/ui@2.0.0_ink@6.8.0__react@19.2.7_react@19.2.7": {
+    "@inkjs/ui@2.0.0_ink@6.8.0__@types+react@19.2.17__react@19.2.7_@types+react@19.2.17": {
       "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
       "dependencies": [
         "chalk",
@@ -311,6 +313,9 @@
     "@oxc-project/types@0.41.0": {
       "integrity": "sha512-4O+T4CE+/XYf00LjhSR0GZLO7znu9R73+LwlppJMKnvzA4/gUxxwPcDpMCA1JONvXGoHm9q9Wnshw0XUZ/ICYQ=="
     },
+    "@types/babel__helper-validator-identifier@7.15.2": {
+      "integrity": "sha512-l3dkwCt890NFhMwPKXbxsWXC0Por0/+KaFIiQP1j38/vWSH2P3Tn6m+IuJHkx2SBI3VLFqincFe9JtBk2NFHOw=="
+    },
     "@types/lodash-es@4.17.12": {
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "dependencies": [
@@ -319,6 +324,12 @@
     },
     "@types/lodash@4.17.24": {
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
+    },
+    "@types/react@19.2.17": {
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dependencies": [
+        "csstype"
+      ]
     },
     "@valibot/to-json-schema@1.3.0_valibot@1.1.0": {
       "integrity": "sha512-82Vv6x7sOYhv5YmTRgSppSqj1nn2pMCk5BqCMGWYp0V/fq+qirrbGncqZAtZ09/lrO40ne/7z8ejwE728aVreg==",
@@ -472,6 +483,9 @@
         "shebang-command",
         "which"
       ]
+    },
+    "csstype@3.2.3": {
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
@@ -687,14 +701,14 @@
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ink-link@5.0.0_ink@6.8.0__react@19.2.7_react@19.2.7": {
+    "ink-link@5.0.0_ink@6.8.0__@types+react@19.2.17__react@19.2.7_@types+react@19.2.17": {
       "integrity": "sha512-TFDXc/0mwUW7LMjsr0/LeLxPVV5BnHDuDQff9RCgP4rb3R+V/4dIwGBZbCevcJZtQnVcW+Iz1LUrUbpq+UDwYA==",
       "dependencies": [
         "ink",
         "terminal-link"
       ]
     },
-    "ink-select-input@6.2.0_ink@6.8.0__react@19.2.7_react@19.2.7": {
+    "ink-select-input@6.2.0_ink@6.8.0__@types+react@19.2.17__react@19.2.7_react@19.2.7_@types+react@19.2.17": {
       "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
       "dependencies": [
         "figures",
@@ -703,13 +717,20 @@
         "to-rotated"
       ]
     },
-    "ink-testing-library@4.0.0": {
-      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q=="
+    "ink-testing-library@4.0.0_@types+react@19.2.17": {
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dependencies": [
+        "@types/react"
+      ],
+      "optionalPeers": [
+        "@types/react"
+      ]
     },
-    "ink@6.8.0_react@19.2.7": {
+    "ink@6.8.0_@types+react@19.2.17_react@19.2.7": {
       "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
       "dependencies": [
         "@alcalzone/ansi-tokenize",
+        "@types/react",
         "ansi-escapes",
         "ansi-styles",
         "auto-bind",
@@ -735,6 +756,9 @@
         "wrap-ansi",
         "ws",
         "yoga-layout"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
     "ip-address@10.2.0": {


### PR DESCRIPTION
## Problem

`skmtc generate` was mass-reporting **"Warning: N generated file(s) have manual edits and were left untouched"** for files nobody edited. Traced cause: edit detection classified files by comparing disk hashes against `.settings/generated.lock.json` — a **machine-local, typically git-untracked baseline describing git-shared files**. Any event that moved the generated files without the lock desynced them:

- `git pull`/`checkout` bringing in output regenerated on another machine or branch
- a generate run killed between the per-file writes and the end-of-run lock write

Once flagged, a file was never rewritten **and its stale lock entry was carried forward**, so the false classification recurred on every subsequent run — regenerating could never clear it. With no `settings.formatter` configured there was no secondary check at all: even a file byte-identical to the incoming render was declared hand-edited. The warning also asserted a cause ("manual edits") the code could not observe, and the run still exited 0.

## Change

`writeGeneratedFiles` no longer consults the lock to classify changes. Every artifact converges to this run's render:

- disk byte-identical to the incoming render → skip (mtime stability for Vite/HMR/watchers)
- unchanged render whose disk bytes still match the recorded post-formatter state → skip (pure cache-validity check)
- anything else — hand edits included — → overwrite
- stale manifest paths → pruned unconditionally

**Ejection (`settings.ejected`) remains the one sanctioned way to own a file** — ejected paths are still never written or deleted. The lock is still written each run (it now only powers the two skips), so `status`/`clean` keep working. `protectedPaths` stays in the `--json` shape (always empty) and `warnOnProtected` is a documented no-op, so callers are unaffected.

Behavior note (pinned by test): a formatter-config change alone no longer triggers a mass rewrite — files reconverge when the render changes or after the repo is reformatted.

## Tests

- Rewrote the protection-era tests to pin engine-owned semantics (overwrite hand edits, prune stale edits, formatter reconvergence, lock seeding)
- Updated the `status` orphaned-file test to the new prune behavior
- CLI suite: 638 passed / 0 failed; `deno check` clean

Bumps `@skmtc/cli` 0.9.36 → 0.9.37 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)