### PR TITLE
feat(lang-typescript): sanitizeIdentifier for emitted binding names

### DIFF
--- a/deno/lang-typescript/deno.json
+++ b/deno/lang-typescript/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-typescript",
-  "version": "0.12.16",
+  "version": "0.12.17",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts"

--- a/deno/lang-typescript/mod.ts
+++ b/deno/lang-typescript/mod.ts
@@ -29,7 +29,8 @@
  * carry no `lang`. The TypeScript syntax helpers (`List`, `NextList`,
  * `FunctionParameter`, `PathParams`, `toPathParams`, `toPathTemplate`,
  * `identifiers`, `keyValues`, `withDescription`) and the naming layer
- * (`sanitizePropertyName`) live HERE (moved from core under F5/F6 —
+ * (`sanitizePropertyName` for property keys, `sanitizeIdentifier` for
+ * binding names) live HERE (moved from core under F5/F6 —
  * see ../../notes/lang/17-naming-layer-and-helpers-move.md).
  */
 
@@ -81,6 +82,7 @@ export * from './src/identifiers.ts'
 export * from './src/keyValues.ts'
 export * from './src/withDescription.ts'
 export * from './src/sanitizePropertyName.ts'
+export * from './src/sanitizeIdentifier.ts'
 export {
   createVariable,
   createType,

--- a/deno/lang-typescript/src/sanitizeIdentifier.test.ts
+++ b/deno/lang-typescript/src/sanitizeIdentifier.test.ts
@@ -1,0 +1,75 @@
+import { assertEquals } from 'jsr:@std/assert@^1.0.0'
+import { sanitizeIdentifier } from './sanitizeIdentifier.ts'
+
+Deno.test('sanitizeIdentifier - safe names are untouched', () => {
+  assertEquals(sanitizeIdentifier('user'), 'user')
+  assertEquals(sanitizeIdentifier('User'), 'User')
+  assertEquals(sanitizeIdentifier('_private'), '_private')
+  assertEquals(sanitizeIdentifier('$special'), '$special')
+  assertEquals(sanitizeIdentifier('user2'), 'user2')
+})
+
+Deno.test('sanitizeIdentifier - capitalised keywords are not reserved', () => {
+  // The case that makes a capitalising generator safe and a decapitalising one
+  // not: no JavaScript keyword is capitalised.
+  assertEquals(sanitizeIdentifier('Export'), 'Export')
+  assertEquals(sanitizeIdentifier('Class'), 'Class')
+  assertEquals(sanitizeIdentifier('Delete'), 'Delete')
+})
+
+Deno.test('sanitizeIdentifier - keywords gain a Value suffix', () => {
+  assertEquals(sanitizeIdentifier('export'), 'exportValue')
+  assertEquals(sanitizeIdentifier('class'), 'classValue')
+  assertEquals(sanitizeIdentifier('delete'), 'deleteValue')
+  assertEquals(sanitizeIdentifier('function'), 'functionValue')
+  assertEquals(sanitizeIdentifier('new'), 'newValue')
+  assertEquals(sanitizeIdentifier('typeof'), 'typeofValue')
+  assertEquals(sanitizeIdentifier('null'), 'nullValue')
+  assertEquals(sanitizeIdentifier('true'), 'trueValue')
+})
+
+Deno.test('sanitizeIdentifier - module-reserved words are caught too', () => {
+  // Reserved only under strict mode / modules — which every generated file is.
+  assertEquals(sanitizeIdentifier('await'), 'awaitValue')
+  assertEquals(sanitizeIdentifier('yield'), 'yieldValue')
+  assertEquals(sanitizeIdentifier('let'), 'letValue')
+  assertEquals(sanitizeIdentifier('static'), 'staticValue')
+  assertEquals(sanitizeIdentifier('implements'), 'implementsValue')
+})
+
+Deno.test('sanitizeIdentifier - non-reserved lookalikes are untouched', () => {
+  // `type`, `of` and `as` are contextual, never reserved as bindings.
+  assertEquals(sanitizeIdentifier('type'), 'type')
+  assertEquals(sanitizeIdentifier('of'), 'of')
+  assertEquals(sanitizeIdentifier('as'), 'as')
+  assertEquals(sanitizeIdentifier('status'), 'status')
+})
+
+Deno.test('sanitizeIdentifier - a leading digit gains an underscore', () => {
+  assertEquals(sanitizeIdentifier('2fa'), '_2fa')
+  assertEquals(sanitizeIdentifier('123'), '_123')
+})
+
+Deno.test('sanitizeIdentifier - invalid characters are dropped', () => {
+  assertEquals(sanitizeIdentifier('user-name'), 'username')
+  assertEquals(sanitizeIdentifier('user name'), 'username')
+  assertEquals(sanitizeIdentifier('user.email'), 'useremail')
+  assertEquals(sanitizeIdentifier('@scope/pkg'), 'scopepkg')
+})
+
+Deno.test('sanitizeIdentifier - an empty result still yields an identifier', () => {
+  assertEquals(sanitizeIdentifier(''), '_')
+  assertEquals(sanitizeIdentifier('---'), '_')
+})
+
+Deno.test('sanitizeIdentifier - stripping can expose a keyword', () => {
+  // `class-` is not a valid identifier name, so it is stripped to `class`,
+  // which then has to be renamed — the two repairs have to run in this order.
+  assertEquals(sanitizeIdentifier('class-'), 'classValue')
+})
+
+Deno.test('sanitizeIdentifier - is idempotent', () => {
+  for (const name of ['export', '2fa', 'user-name', '', 'await', 'User']) {
+    assertEquals(sanitizeIdentifier(sanitizeIdentifier(name)), sanitizeIdentifier(name))
+  }
+})

--- a/deno/lang-typescript/src/sanitizeIdentifier.test.ts
+++ b/deno/lang-typescript/src/sanitizeIdentifier.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from 'jsr:@std/assert@^1.0.0'
+import { assertEquals } from '@std/assert'
 import { sanitizeIdentifier } from './sanitizeIdentifier.ts'
 
 Deno.test('sanitizeIdentifier - safe names are untouched', () => {
@@ -37,6 +37,14 @@ Deno.test('sanitizeIdentifier - module-reserved words are caught too', () => {
   assertEquals(sanitizeIdentifier('implements'), 'implementsValue')
 })
 
+Deno.test('sanitizeIdentifier - eval and arguments are bind-only reserved', () => {
+  // `const eval = 1` is `Unexpected eval or arguments in strict mode`, but
+  // babel files these separately from `isStrictReservedWord` — they are only
+  // caught by the bind-reserved superset.
+  assertEquals(sanitizeIdentifier('eval'), 'evalValue')
+  assertEquals(sanitizeIdentifier('arguments'), 'argumentsValue')
+})
+
 Deno.test('sanitizeIdentifier - non-reserved lookalikes are untouched', () => {
   // `type`, `of` and `as` are contextual, never reserved as bindings.
   assertEquals(sanitizeIdentifier('type'), 'type')
@@ -48,6 +56,14 @@ Deno.test('sanitizeIdentifier - non-reserved lookalikes are untouched', () => {
 Deno.test('sanitizeIdentifier - a leading digit gains an underscore', () => {
   assertEquals(sanitizeIdentifier('2fa'), '_2fa')
   assertEquals(sanitizeIdentifier('123'), '_123')
+})
+
+Deno.test('sanitizeIdentifier - a start character that is only ID_Continue is repaired', () => {
+  // `٣` (Arabic-Indic three) and combining marks are ID_Continue but not
+  // ID_Start, so they survive the strip while leaving the name invalid —
+  // `const ٣fa = 1` is a SyntaxError. An ASCII-digit test would miss them.
+  assertEquals(sanitizeIdentifier('٣fa'), '_٣fa')
+  assertEquals(sanitizeIdentifier('́abc'), '_́abc')
 })
 
 Deno.test('sanitizeIdentifier - invalid characters are dropped', () => {

--- a/deno/lang-typescript/src/sanitizeIdentifier.ts
+++ b/deno/lang-typescript/src/sanitizeIdentifier.ts
@@ -1,0 +1,52 @@
+// @deno-types="npm:@types/babel__helper-validator-identifier@7.15.2"
+import {
+  isIdentifierName,
+  isKeyword,
+  isStrictReservedWord
+} from 'npm:@babel/helper-validator-identifier@7.27.1'
+
+/**
+ * Makes a name safe to emit as a **binding** — `export const <name>`,
+ * `export type <name>`, `class <name>`.
+ *
+ * This is a different question from {@link handleKey} / {@link
+ * sanitizePropertyName}, which ask whether a name is safe as an object
+ * *property*. `export` is a perfectly good property key, so
+ * `isIdentifierName('export')` is `true` — but `export const export = …` is a
+ * syntax error. Reserved words therefore have to be checked separately, and
+ * against the module rules, where `await`, `yield`, `let` and `static` are
+ * reserved too.
+ *
+ * Two repairs, in order:
+ *
+ * 1. Anything that is not a valid identifier name loses the offending
+ *    characters, and a leading digit (or an empty result) gains a `_`.
+ * 2. A reserved word gains a `Value` suffix — the convention already used by
+ *    {@link protectedKeywords} for property names (`export` → `exportValue`).
+ *
+ * A name that is already safe is returned unchanged, so this is safe to apply
+ * unconditionally in a projection's `toIdentifierName`.
+ *
+ * @example
+ * ```typescript
+ * sanitizeIdentifier('user')     // 'user'
+ * sanitizeIdentifier('Export')   // 'Export'  — capitalised, so not reserved
+ * sanitizeIdentifier('export')   // 'exportValue'
+ * sanitizeIdentifier('await')    // 'awaitValue'
+ * sanitizeIdentifier('2fa')      // '_2fa'
+ * ```
+ */
+export const sanitizeIdentifier = (name: string): string => {
+  const valid = isIdentifierName(name) ? name : toValidIdentifierName(name)
+
+  // `isKeyword` covers the always-reserved words; `isStrictReservedWord` with
+  // `inModule` adds the ones reserved only under strict mode / modules, which
+  // is what generated files always are.
+  return isKeyword(valid) || isStrictReservedWord(valid, true) ? `${valid}Value` : valid
+}
+
+const toValidIdentifierName = (name: string): string => {
+  const stripped = name.replace(/[^\p{ID_Continue}$]/gu, '')
+
+  return stripped === '' || /^\d/.test(stripped) ? `_${stripped}` : stripped
+}

--- a/deno/lang-typescript/src/sanitizeIdentifier.ts
+++ b/deno/lang-typescript/src/sanitizeIdentifier.ts
@@ -2,51 +2,72 @@
 import {
   isIdentifierName,
   isKeyword,
-  isStrictReservedWord
+  isStrictBindReservedWord
 } from 'npm:@babel/helper-validator-identifier@7.27.1'
 
 /**
- * Makes a name safe to emit as a **binding** — `export const <name>`,
- * `export type <name>`, `class <name>`.
+ * Makes a name safe to emit as a **JavaScript binding** — `export const
+ * <name>`, `class <name>`, `function <name>`.
  *
  * This is a different question from {@link handleKey} / {@link
  * sanitizePropertyName}, which ask whether a name is safe as an object
  * *property*. `export` is a perfectly good property key, so
  * `isIdentifierName('export')` is `true` — but `export const export = …` is a
  * syntax error. Reserved words therefore have to be checked separately, and
- * against the module rules, where `await`, `yield`, `let` and `static` are
- * reserved too.
+ * against the module rules, where `await`, `yield`, `let`, `static`, `eval`
+ * and `arguments` are reserved too.
  *
  * Two repairs, in order:
  *
  * 1. Anything that is not a valid identifier name loses the offending
- *    characters, and a leading digit (or an empty result) gains a `_`.
+ *    characters, and gains a `_` prefix if what remains still cannot start an
+ *    identifier (a leading digit, a combining mark, or nothing at all).
  * 2. A reserved word gains a `Value` suffix — the convention already used by
  *    {@link protectedKeywords} for property names (`export` → `exportValue`).
  *
  * A name that is already safe is returned unchanged, so this is safe to apply
  * unconditionally in a projection's `toIdentifierName`.
  *
+ * Two limits worth knowing:
+ *
+ * - **TypeScript type-alias names are not covered.** TS additionally rejects
+ *   its predefined type names there — `type string = number` is TS2457 — and
+ *   those are not JavaScript reserved words, so they pass through. Generators
+ *   emitting type aliases capitalise (`String` is a legal alias name), so this
+ *   has no practical exposure today.
+ * - **Sanitizing is lossy, so distinct names can collide.** Schemas named
+ *   `export` and `exportValue`, or `user-name` and `username`, both arrive at
+ *   one binding. The engine's definition-uniqueness check turns that into a
+ *   hard error rather than a silent clobber.
+ *
  * @example
  * ```typescript
- * sanitizeIdentifier('user')     // 'user'
- * sanitizeIdentifier('Export')   // 'Export'  — capitalised, so not reserved
- * sanitizeIdentifier('export')   // 'exportValue'
- * sanitizeIdentifier('await')    // 'awaitValue'
- * sanitizeIdentifier('2fa')      // '_2fa'
+ * sanitizeIdentifier('user')      // 'user'
+ * sanitizeIdentifier('Export')    // 'Export'  — capitalised, so not reserved
+ * sanitizeIdentifier('export')    // 'exportValue'
+ * sanitizeIdentifier('await')     // 'awaitValue'
+ * sanitizeIdentifier('eval')      // 'evalValue'
+ * sanitizeIdentifier('2fa')       // '_2fa'
  * ```
  */
 export const sanitizeIdentifier = (name: string): string => {
   const valid = isIdentifierName(name) ? name : toValidIdentifierName(name)
 
-  // `isKeyword` covers the always-reserved words; `isStrictReservedWord` with
-  // `inModule` adds the ones reserved only under strict mode / modules, which
-  // is what generated files always are.
-  return isKeyword(valid) || isStrictReservedWord(valid, true) ? `${valid}Value` : valid
+  // `isKeyword` covers the always-reserved words. `isStrictBindReservedWord`
+  // with `inModule` adds those reserved only under strict mode / modules —
+  // which generated files always are — and, unlike `isStrictReservedWord`,
+  // includes `eval` and `arguments`, which are illegal as bindings but legal
+  // everywhere else.
+  return isKeyword(valid) || isStrictBindReservedWord(valid, true) ? `${valid}Value` : valid
 }
 
 const toValidIdentifierName = (name: string): string => {
   const stripped = name.replace(/[^\p{ID_Continue}$]/gu, '')
 
-  return stripped === '' || /^\d/.test(stripped) ? `_${stripped}` : stripped
+  // Stripping keeps every ID_Continue character, but an identifier's *first*
+  // character has to be ID_Start — so a name beginning with a digit or a
+  // combining mark survives the strip and is still invalid. Re-asking
+  // `isIdentifierName` catches that (and the empty string) rather than
+  // enumerating the cases.
+  return isIdentifierName(stripped) ? stripped : `_${stripped}`
 }


### PR DESCRIPTION
A schema named `Export` makes a model generator emit

```ts
export const export = type({ … })
```

— a syntax error — and every consumer of it emits `[export, "[]"]`. Found by generating the `increase` corpus spec with `gen-arktype` and type-checking the result; `gen-zod` and `gen-valibot` have the identical exposure (same `decapitalize(camelCase(refName))`), as do `gen-typescript-s` and `gen-typescript-sdk`, whose names come from a user enrichment.

## Why the existing naming layer can't answer this

`handleKey` / `sanitizePropertyName` ask whether a name is safe as an object **property**. `export` is a perfectly good property key, so `isIdentifierName('export')` is `true`. A **binding** name needs the reserved-word check instead — and against module rules, where `await`, `yield`, `let` and `static` are reserved too.

`@babel/helper-validator-identifier` is already a dependency here and exports exactly that: `isKeyword` and `isStrictReservedWord`.

## The helper

Two repairs, in order:

1. anything that is not a valid identifier name loses the offending characters, and a leading digit (or an empty result) gains a `_`;
2. a reserved word gains a `Value` suffix — the convention `protectedKeywords` already uses for property names (`export` → `exportValue`).

Order matters: `class-` strips to `class`, which then has to be renamed.

```ts
sanitizeIdentifier('user')   // 'user'
sanitizeIdentifier('Export') // 'Export'  — capitalised, so not reserved
sanitizeIdentifier('export') // 'exportValue'
sanitizeIdentifier('await')  // 'awaitValue'
sanitizeIdentifier('2fa')    // '_2fa'
```

Safe names are returned unchanged, so generators can apply it unconditionally in `toIdentifierName`. It is idempotent.

## Verification

- 10 unit tests; full `lang-typescript` suite green (366 passing).
- End-to-end before release: wired into `gen-arktype`'s `toIdentifierName` and generated the `increase` spec through the CLI — `export const export` becomes `export const exportValue`, the file is renamed, and `exportList` imports `exportValue`. All 234 emitted files then parse, where two previously did not.

## Follow-up (separate, in skmtc-generators)

Apply it in each `toIdentifierName`. Exposure by generator:

| Risk | Generators |
|---|---|
| Reserved word (bare, lowercase-first from `refName`) | gen-zod, gen-valibot, gen-arktype |
| Reserved word (name from a user enrichment) | gen-typescript-s, gen-typescript-sdk |
| Invalid start/char (e.g. a path `/2fa` → `2faSelect`) | gen-typescript, gen-msw, gen-shadcn-{form,select,table}, gen-daisyui-form |

Version bumped to 0.12.17; **not published** — release goes through `deno task release`.