### PR TITLE
lang-kotlin 0.10.0: annotation use-site targets

### DIFF
--- a/deno/lang-kotlin/deno.json
+++ b/deno/lang-kotlin/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-kotlin",
-  "version": "0.9.14",
+  "version": "0.10.0",
   "private": false,
   "license": "Apache-2.0",
   "exports": {

--- a/deno/lang-kotlin/mod.ts
+++ b/deno/lang-kotlin/mod.ts
@@ -55,7 +55,8 @@ export {
   KtAnnotations,
   toKtAnnotations,
   type KtAnnotated,
-  type KtAnnotationArgs
+  type KtAnnotationArgs,
+  type KtAnnotationTarget
 } from './src/KtAnnotation.ts'
 export { isKtDocumented, type KtDocumented } from './src/KtDocumented.ts'
 export {

--- a/deno/lang-kotlin/src/KtAnnotation.test.ts
+++ b/deno/lang-kotlin/src/KtAnnotation.test.ts
@@ -64,3 +64,36 @@ Deno.test('an annotation without a packageName renders only (default-scope annot
   assertEquals(`${annotation}`, '@Deprecated("use v2")')
   assertEquals(context.inspectedFiles.size, 0)
 })
+
+Deno.test('a use-site target renders as @target:Name; the import stays the bare symbol', () => {
+  const context = toGenerateContext()
+  const destinationPath = '@/com/example/api/User.generated.kt'
+
+  const annotation = new KtAnnotation({
+    context,
+    name: 'JsonAnySetter',
+    target: 'field',
+    packageName: 'com.fasterxml.jackson.annotation',
+    destinationPath
+  })
+
+  assertEquals(`${annotation}`, '@field:JsonAnySetter')
+
+  const file = context.getFile(destinationPath)
+  assertInstanceOf(file, KtFile)
+  assertStringIncludes(file.toString(), 'import com.fasterxml.jackson.annotation.JsonAnySetter')
+})
+
+Deno.test('a use-site target composes with args', () => {
+  const context = toGenerateContext()
+
+  const annotation = new KtAnnotation({
+    context,
+    name: 'Suppress',
+    target: 'file',
+    args: ['"unused"'],
+    destinationPath: '@/com/example/api/User.generated.kt'
+  })
+
+  assertEquals(`${annotation}`, '@file:Suppress("unused")')
+})

--- a/deno/lang-kotlin/src/KtAnnotation.ts
+++ b/deno/lang-kotlin/src/KtAnnotation.ts
@@ -2,6 +2,23 @@ import type { GenerateContextType, Stringable } from '@skmtc/core'
 import { register } from './register.ts'
 
 /**
+ * Kotlin's annotation use-site targets — the `field:` in
+ * `@field:JsonAnySetter`. Grammar-level, so the set is closed and owned
+ * here; WHICH target a generator picks is its policy.
+ */
+export type KtAnnotationTarget =
+  | 'field'
+  | 'get'
+  | 'set'
+  | 'param'
+  | 'property'
+  | 'receiver'
+  | 'setparam'
+  | 'delegate'
+  | 'file'
+  | 'all'
+
+/**
  * Constructor arguments for {@link KtAnnotation}.
  */
 export type KtAnnotationArgs = {
@@ -9,6 +26,13 @@ export type KtAnnotationArgs = {
   name: string
   /** Pre-quoted argument list rendered inside `(…)`; omitted → bare `@Name`. */
   args?: Stringable[]
+  /**
+   * Use-site target rendered as `@<target>:<Name>` — needed when the
+   * declaration site is ambiguous (a constructor `val` is parameter,
+   * property, field, and getter at once). The imported symbol is still
+   * `name` alone; the target is render-only grammar.
+   */
+  target?: KtAnnotationTarget
   /**
    * Dotted package the annotation class lives in — self-registers
    * `import <packageName>.<name>` into `destinationPath`. Omitted for
@@ -49,10 +73,12 @@ export type KtAnnotationArgs = {
 export class KtAnnotation {
   name: string
   args: Stringable[]
+  target: KtAnnotationTarget | undefined
 
-  constructor({ context, name, args = [], packageName, destinationPath }: KtAnnotationArgs) {
+  constructor({ context, name, args = [], target, packageName, destinationPath }: KtAnnotationArgs) {
     this.name = name
     this.args = args
+    this.target = target
 
     if (packageName !== undefined) {
       register(context, {
@@ -63,7 +89,9 @@ export class KtAnnotation {
   }
 
   toString(): string {
-    return this.args.length ? `@${this.name}(${this.args.join(', ')})` : `@${this.name}`
+    const head = this.target ? `@${this.target}:${this.name}` : `@${this.name}`
+
+    return this.args.length ? `${head}(${this.args.join(', ')})` : head
   }
 }
 


### PR DESCRIPTION
## The gap

A constructor `val` is four declarations at once — parameter, property, field, getter — and Kotlin disambiguates with use-site targets (`@field:`, `@get:`, …). `KtAnnotation` couldn't express them, so Jackson's catch-all pair was unwritable and the mixed object form (properties + `additionalProperties`) had to drop its record channel.

## The change

`KtAnnotation` gains `target?: KtAnnotationTarget` — Kotlin's ten use-site targets as a closed union — rendered as `@<target>:<Name>`:

```ts
new KtAnnotation({ context, destinationPath, name: 'JsonAnySetter', target: 'field',
  packageName: 'com.fasterxml.jackson.annotation' })
// renders @field:JsonAnySetter
// imports  com.fasterxml.jackson.annotation.JsonAnySetter  (bare symbol — target is render-only)
```

Keeping the target out of `name` is the point: the self-registered import, dedup, and same-package suppression all keep operating on the real symbol.

Strictly additive — no existing call site changes meaning; 88/88 tests pass including two new target cases (`@field:` with import assertion, `@file:Suppress("unused")` with args).

## Validation

Driven end-to-end in the kotlin-debug rig (inline-object synthesis work): the generated

```kotlin
data class Settings(
    val theme: String,
    @field:JsonAnySetter
    @get:JsonAnyGetter
    val additionalProperties: MutableMap<String, String> = mutableMapOf()
)
```

compiles clean under Kotlin 2.2.20 with jackson-annotations on the classpath.

0.9.14 → 0.10.0 via `deno task bump --minor`; CI publishes on merge.