### PR TITLE
cli: one source for Deno's dependency-age flag, and a check that names it

### DIFF
--- a/deno/.scripts/release.test.ts
+++ b/deno/.scripts/release.test.ts
@@ -1,9 +1,12 @@
 import { assertEquals, assertThrows } from '@std/assert'
+import { assertStringIncludes } from '@std/assert/string-includes'
 import {
   assertNoPrivateDeps,
   incrementPatch,
   planRelease,
   toDependencyOrder,
+  toJsrInstallArgs,
+  toJsrReinstallCommand,
   toWorkspaceDep,
   type WorkspacePackage
 } from './release.ts'
@@ -163,4 +166,25 @@ Deno.test('planRelease - a private package still cascade-bumps when a dependency
 
   assertEquals(plan.get('@skmtc/lang-java')?.version, '0.0.2')
   assertEquals(plan.get('@skmtc/lang-java')?.imports['@skmtc/core'], 'jsr:@skmtc/core@0.6.3')
+})
+
+Deno.test('toJsrInstallArgs - the just-published pin carries the dependency-age flag', () => {
+  // An exact pin published seconds ago is the HARD-error face of Deno's
+  // dependency-age gate, so the release script's own reinstall would
+  // fail to resolve the version it just published.
+  const args = toJsrInstallArgs('0.9.42')
+
+  assertEquals(args.includes('--minimum-dependency-age=0'), true)
+  assertEquals(args.at(-1), 'jsr:@skmtc/cli@0.9.42')
+  assertEquals(args[0], 'install')
+})
+
+Deno.test('toJsrReinstallCommand - the printed recovery line carries it too', () => {
+  // This line is aimed at consumers outside this workspace, where
+  // `deno/deno.json`'s `minimumDependencyAge: "0"` does not apply.
+  const command = toJsrReinstallCommand('https://jsr.io/', '0.9.42')
+
+  assertStringIncludes(command, '--minimum-dependency-age=0')
+  assertStringIncludes(command, 'JSR_URL=https://jsr.io/')
+  assertStringIncludes(command, 'jsr:@skmtc/cli@0.9.42')
 })

--- a/deno/.scripts/release.ts
+++ b/deno/.scripts/release.ts
@@ -22,6 +22,7 @@
  */
 
 import { dirname, fromFileUrl, join } from '@std/path'
+import { toDependencyAgeArgs } from '../cli/lib/dependency-age.ts'
 
 /**
  * Scoped runtime permissions for the installed `skmtc` CLI — replaces a
@@ -361,21 +362,41 @@ const reinstallCliLocalCompile = async (cliDir: string): Promise<void> => {
   }
 }
 
+/**
+ * `deno install` args for the just-published CLI. The version landed
+ * seconds ago, so it sits as deep inside Deno's dependency-age window as
+ * a version gets — and an EXACT pin inside that window is a hard
+ * resolution error, not a silent downgrade. Both the run and the printed
+ * recovery command build from here so neither can lose the flag.
+ */
+export const toJsrInstallArgs = (version: string): string[] => [
+  'install',
+  ...toDependencyAgeArgs(),
+  ...SKMTC_PERMS,
+  '-g',
+  '--unstable-worker-options',
+  '-n',
+  'skmtc',
+  '-f',
+  `jsr:@skmtc/cli@${version}`
+]
+
+/**
+ * The same install as a copy-pasteable line. This one is handed to
+ * consumers running OUTSIDE this workspace, where `deno/deno.json`'s
+ * `minimumDependencyAge: "0"` does not apply — so the string has to
+ * carry the flag itself or it reproduces the error it exists to recover
+ * from.
+ */
+export const toJsrReinstallCommand = (jsrUrl: string, version: string): string =>
+  `JSR_URL=${jsrUrl} deno ${toJsrInstallArgs(version).join(' ')}`
+
 const reinstallCliFromJsr = async (jsrUrl: string, version: string): Promise<void> => {
   console.log(`Polling ${jsrUrl}@skmtc/cli for v${version}...`)
   await waitForJsrPropagation(jsrUrl, '@skmtc/cli', version)
   console.log(`Installing @skmtc/cli@${version} from JSR...`)
   const result = await new Deno.Command('deno', {
-    args: [
-      'install',
-      ...SKMTC_PERMS,
-      '-g',
-      '--unstable-worker-options',
-      '-n',
-      'skmtc',
-      '-f',
-      `jsr:@skmtc/cli@${version}`
-    ],
+    args: toJsrInstallArgs(version),
     env: { ...Deno.env.toObject(), JSR_URL: jsrUrl },
     stdout: 'inherit',
     stderr: 'inherit'
@@ -401,9 +422,7 @@ const printReinstallHint = (
   console.error(`    -o ~/.deno/bin/skmtc \\`)
   console.error(`    ${join(cliDir, 'mod.ts')}`)
   console.error('  # From JSR (downstream consumers):')
-  console.error(
-    `  JSR_URL=${jsrUrl} deno install ${SKMTC_PERMS_STR} -g --unstable-worker-options -n skmtc -f jsr:@skmtc/cli@${version}`
-  )
+  console.error(`  ${toJsrReinstallCommand(jsrUrl, version)}`)
   if (mode !== 'none') {
     console.error(`(mode "${mode}" was attempted but failed — defer to the manual commands above.)`)
   }

--- a/deno/CLAUDE.md
+++ b/deno/CLAUDE.md
@@ -230,6 +230,17 @@ failure. `skmtc doctor`'s
 registry and names the gate when the newest release is inside the
 window.
 
+One printed `deno` command is deliberately outside the invariant:
+`cli/workspaces/serve.node.tsx` prints `deno run jsr:@skmtc/cli serve …`
+from the **Node.js** build, where `Deno.version` does not exist — every
+helper in `dependency-age.ts` defaults to it, so routing this one
+through the module would throw a `ReferenceError` in the environment
+that prints it. The exposure is the mild face of the gate (an unpinned
+`deno run` resolves the previous release and runs it) rather than the
+hard error, and the message is a "you are on the wrong runtime" pointer,
+not a recovery step. Leave it hard-coded; do not "fix" it by importing
+the module.
+
 Other escape hatches: deno ≤ 2.8, or `"minimumDependencyAge": "0"` in
 the relevant `deno.json` (this workspace sets it; generated project
 configs deliberately do NOT — that is the user's file). Verified

--- a/deno/CLAUDE.md
+++ b/deno/CLAUDE.md
@@ -217,11 +217,15 @@ The silent one is the dangerous one: the install succeeds, `skmtc
 --version` reports the older version truthfully, and a fresh release
 looks like it never published.
 
-`deno/cli/lib/dependency-age.ts` is the single source: every `deno`
-subprocess the CLI spawns passes `toDependencyAgeArgs()`, and every
-remediation the CLI or the docs PRINT is built from
-`toCliInstallCommand()` — a printed command without the flag sends the
-reader back to the version they are leaving. `skmtc doctor`'s
+`deno/cli/lib/dependency-age.ts` is the single source, and the invariant
+is "goes through this module", not "through one function in it": every
+`deno` subprocess the CLI spawns splices `toDependencyAgeArgs()`, and
+every `deno install` the CLI or the docs PRINT is built here —
+`toCliInstallCommand()` for the global CLI, `toProjectInstallCommand()`
+for a project directory, `toJsrReinstallCommand()` (in
+`.scripts/release.ts`) for the just-published pin. A printed command
+without the flag hands the reader a recovery step that reproduces the
+failure. `skmtc doctor`'s
 `cli-version-current` check compares the running CLI against the
 registry and names the gate when the newest release is inside the
 window.

--- a/deno/CLAUDE.md
+++ b/deno/CLAUDE.md
@@ -200,17 +200,36 @@ The CLI uses Cliffy framework with these patterns:
 - `deno task check` runs the full CI suite locally (doc-sync + workspace type-check & tests). A version-controlled `pre-push` hook (`<repo>/.githooks/pre-push`) runs it before every push so failures surface locally, not in GitHub Actions. Enable it per-clone with `git config core.hooksPath .githooks`; bypass a single push with `git push --no-verify`.
 - Use absolute import paths prefixed with `@/`, not of relative path imports
 
-## Deno 2.9 dependency age gate (misleading bundle failure)
+## Deno 2.9 dependency age gate (three faces, one cause)
 
-Deno ≥ 2.9 blocks recently published dependency versions by default
-(`--minimum-dependency-age`, unstable). The failure is misleading:
-`deno bundle` — and therefore `skmtc install` / `skmtc bundle`, which
-shell out to it — fails with `Do not know how to load path:
-deno:jsr:@skmtc/…` and no mention of age. Because `@skmtc/*` publishes
-on every merge to main, a just-released version ALWAYS trips the gate
-on jsr.io. Workarounds: pass `--minimum-dependency-age=0` to
-`deno bundle`, or use deno ≤ 2.8, or the local mirror (the gate does
-not fire against it). Verified 2026-07-12 — full write-up in
+Deno ≥ 2.9 refuses to resolve a dependency version published in the last
+24 hours by default (`--minimum-dependency-age`, unstable). Because
+`@skmtc/*` publishes on every merge to main, a just-released version
+ALWAYS trips it on jsr.io. It shows up three different ways:
+
+| resolution | symptom |
+| --- | --- |
+| exact pin (project `deno.json`, `deno bundle`) | hard error naming the policy on ≥ 2.9.3; on 2.9.0–2.9.2 the misleading `Do not know how to load path: deno:jsr:@skmtc/…` |
+| unpinned (`deno install jsr:@skmtc/cli`) | **silent** — resolves the previous version and reports success |
+| existing lockfile | keeps the older resolution; clearing the lock without the flag lands on it again |
+
+The silent one is the dangerous one: the install succeeds, `skmtc
+--version` reports the older version truthfully, and a fresh release
+looks like it never published.
+
+`deno/cli/lib/dependency-age.ts` is the single source: every `deno`
+subprocess the CLI spawns passes `toDependencyAgeArgs()`, and every
+remediation the CLI or the docs PRINT is built from
+`toCliInstallCommand()` — a printed command without the flag sends the
+reader back to the version they are leaving. `skmtc doctor`'s
+`cli-version-current` check compares the running CLI against the
+registry and names the gate when the newest release is inside the
+window.
+
+Other escape hatches: deno ≤ 2.8, or `"minimumDependencyAge": "0"` in
+the relevant `deno.json` (this workspace sets it; generated project
+configs deliberately do NOT — that is the user's file). Verified
+2026-07-12, extended 2026-08-07 — write-up in
 `deno/docs/friction-log/2026-07-12-docs-journey-program.md` entry 6.
 
 Use US English spelling in code, prose and documentation

--- a/deno/cli/commands/doctor.ts
+++ b/deno/cli/commands/doctor.ts
@@ -35,7 +35,7 @@ export const renderDoctor = async ({
 }: RenderDoctorArgs): Promise<void> => {
   const result = await runDoctor({
     cliVersion: denoJson.version,
-    ...(offlineFlag ? { getLatestCliMeta: () => Promise.resolve(undefined) } : {})
+    offline: offlineFlag === true
   })
   printDoctorResult(result, { format: resolveOutputFormat({ jsonFlag }) })
   Deno.exit(result.summary === 'error' ? 1 : 0)

--- a/deno/cli/commands/doctor.ts
+++ b/deno/cli/commands/doctor.ts
@@ -23,10 +23,20 @@ import denoJson from '../deno.json' with { type: 'json' }
 
 type RenderDoctorArgs = {
   jsonFlag?: boolean
+  /** Skip the one check that reaches the network (`cli-version-current`),
+   *  for a run that already knows it is offline and does not want to
+   *  spend the lookup's timeout to be told so. */
+  offlineFlag?: boolean
 }
 
-export const renderDoctor = async ({ jsonFlag }: RenderDoctorArgs): Promise<void> => {
-  const result = await runDoctor({ cliVersion: denoJson.version })
+export const renderDoctor = async ({
+  jsonFlag,
+  offlineFlag
+}: RenderDoctorArgs): Promise<void> => {
+  const result = await runDoctor({
+    cliVersion: denoJson.version,
+    ...(offlineFlag ? { getLatestCliMeta: () => Promise.resolve(undefined) } : {})
+  })
   printDoctorResult(result, { format: resolveOutputFormat({ jsonFlag }) })
   Deno.exit(result.summary === 'error' ? 1 : 0)
 }

--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.40",
+  "version": "0.9.42",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {

--- a/deno/cli/lib/cli-schema.test.ts
+++ b/deno/cli/lib/cli-schema.test.ts
@@ -80,3 +80,15 @@ Deno.test('cli-schema - toArgsString handles empty args', () => {
     ''
   )
 })
+
+Deno.test('cli-schema - doctor declares --offline, which agents discover through this schema', () => {
+  // `agent-context` prints these descriptors verbatim, and the audience
+  // for `--offline` is an automated run — which reads the schema, not
+  // `--help`. A flag wired into the Cliffy command but not declared here
+  // is invisible to the only caller that wants it.
+  const doctor = getCommandDescriptor('doctor')
+  const flags = doctor.flags.map(f => f.flag)
+
+  assertEquals(flags.includes('--json'), true)
+  assertEquals(flags.includes('--offline'), true)
+})

--- a/deno/cli/lib/cli-schema.ts
+++ b/deno/cli/lib/cli-schema.ts
@@ -329,7 +329,14 @@ export const COMMAND_DESCRIPTORS: CommandDescriptor[] = [
     name: 'doctor',
     description: 'Diagnose common SKMTC misconfigurations',
     args: [],
-    flags: [{ flag: '--json', description: 'Emit structured JSON output.' }],
+    flags: [
+      { flag: '--json', description: 'Emit structured JSON output.' },
+      {
+        flag: '--offline',
+        description:
+          'Skip the registry lookup behind `cli-version-current`, which reports `skipped`. Every other check is filesystem-only.'
+      }
+    ],
     agentMode: 'json-only'
   },
   {

--- a/deno/cli/lib/create-bundle.ts
+++ b/deno/cli/lib/create-bundle.ts
@@ -1,6 +1,7 @@
 import { join } from '@std/path/join'
 import type { Project } from '@/lib/project.ts'
 import { toBundlePath } from '@/lib/to-bundle-path.ts'
+import { toDependencyAgeArgs } from '@/lib/dependency-age.ts'
 
 /**
  * Build a project's `bundle.js` from its generated `worker.ts`.
@@ -27,23 +28,13 @@ export const createBundle = async ({ project }: CreateBundleArgs): Promise<strin
 
   await project.createWorker()
 
-  // --minimum-dependency-age=0 disables the dependency-age holdback
-  // (enforced by default from Deno 2.9) for the bundle's own
-  // resolution. @skmtc/* publishes on every merge, so the newest
-  // generator/worker versions are always younger than the default
-  // cutoff — without the flag, `deno bundle` on Deno ≥ 2.9 rejects a
-  // freshly released stack with the misleading
-  // `Do not know how to load path: deno:jsr:…`. Same rationale as the
-  // installer's flag on `deno install` (skmtc-hub/apps/install).
-  // The flag parses from Deno 2.6 (a no-op before the 2.9 gate) and is
-  // an unknown-argument error on ≤ 2.5, so gate on the running Deno's
-  // version — the subprocess resolves `deno` from PATH, the same
-  // binary running this code in the supported setups.
-  const [major, minor] = Deno.version.deno.split('.').map(Number)
-  const ageArgs = major > 2 || (major === 2 && minor >= 6) ? ['--minimum-dependency-age=0'] : []
-
+  // Without the age flag, `deno bundle` on Deno ≥ 2.9 rejects a freshly
+  // released stack — the project's pins name `@skmtc/*` versions that
+  // publish on every merge, so they are younger than the default cutoff.
+  // Same rationale as the installer's flag on `deno install`
+  // (skmtc-hub/apps/install); see `@/lib/dependency-age.ts`.
   const command = new Deno.Command('deno', {
-    args: ['bundle', ...ageArgs, '-o', fileName, 'worker.ts'],
+    args: ['bundle', ...toDependencyAgeArgs(), '-o', fileName, 'worker.ts'],
     cwd: projectPath,
     stdout: 'piped',
     stderr: 'piped'

--- a/deno/cli/lib/debug-session.ts
+++ b/deno/cli/lib/debug-session.ts
@@ -1,4 +1,5 @@
 import { join } from '@std/path/join'
+import { toDependencyAgeArgs } from '@/lib/dependency-age.ts'
 
 type RunDebugSessionArgs = {
   /** Absolute path to the project dir (`.skmtc/<project>`). */
@@ -104,7 +105,17 @@ export const runDebugSession = async ({
 
   const inspectionPath = await Deno.makeTempFile({ prefix: 'skmtc-inspection-', suffix: '.json' })
 
-  const args = ['run', '--config', join(projectPath, 'deno.json'), '-A']
+  // The harness resolves the project's pins, which name `@skmtc/*`
+  // versions that can be younger than Deno's dependency-age cutoff — the
+  // same holdback `deno bundle` has to clear. Without the flag a debug run
+  // against a freshly released stack fails to resolve before it can pause.
+  const args = [
+    'run',
+    ...toDependencyAgeArgs(),
+    '--config',
+    join(projectPath, 'deno.json'),
+    '-A'
+  ]
   if (!auto) {
     // Standard "pause until a debugger connects, then run" — the same flow as
     // `node --inspect-brk`. Deno prints the ws:// URL on stderr; on attach the

--- a/deno/cli/lib/dependency-age.test.ts
+++ b/deno/cli/lib/dependency-age.test.ts
@@ -11,14 +11,25 @@ import {
   toProjectInstallCommand
 } from '@/lib/dependency-age.ts'
 
-Deno.test('supportsDependencyAgeFlag - the flag parses from Deno 2.6', () => {
-  // On ≤ 2.5 the flag is an unknown argument, which would fail the whole
-  // subprocess — worse than the holdback it exists to clear.
-  assertEquals(supportsDependencyAgeFlag('2.5.9'), false)
+Deno.test('supportsDependencyAgeFlag - the flag parses from Deno 2.5.5', () => {
+  // On ≤ 2.5.4 the flag is an unknown argument, which would fail the whole
+  // subprocess — worse than the holdback it exists to clear. 2.5.5 is where
+  // `min_dep_age_arg()` lands in `compile_args_without_check_args` (#30752),
+  // so the boundary is a PATCH, not a minor.
+  assertEquals(supportsDependencyAgeFlag('2.5.4'), false)
+  assertEquals(supportsDependencyAgeFlag('2.5.5'), true)
+  assertEquals(supportsDependencyAgeFlag('2.5.9'), true)
   assertEquals(supportsDependencyAgeFlag('2.6.0'), true)
   assertEquals(supportsDependencyAgeFlag('2.9.4'), true)
   assertEquals(supportsDependencyAgeFlag('3.0.0'), true)
+  assertEquals(supportsDependencyAgeFlag('2.4.9'), false)
   assertEquals(supportsDependencyAgeFlag('1.46.3'), false)
+})
+
+Deno.test('supportsDependencyAgeFlag - a prerelease compares as its release', () => {
+  // `2.5.5-rc.1` must not fall back to patch 0 and read as unsupported.
+  assertEquals(supportsDependencyAgeFlag('2.5.5-rc.1'), true)
+  assertEquals(supportsDependencyAgeFlag('2.5.4-rc.1'), false)
 })
 
 Deno.test('supportsDependencyAgeFlag - an unreadable version omits the flag', () => {
@@ -69,14 +80,24 @@ Deno.test('isWithinDependencyAgeWindow - a future publish time counts as inside'
   assertEquals(isWithinDependencyAgeWindow(hoursAgo(-5)), true)
 })
 
-Deno.test('enforcesDependencyAgeGate - the holdback starts at Deno 2.9, not 2.6', () => {
+Deno.test('isWithinDependencyAgeWindow - an absurd future time is not a fresh release', () => {
+  // A `createdAt` days or years ahead is a broken clock or a mirror
+  // inventing timestamps. Calling that "published a moment ago, inside
+  // the window" names the wrong cause to someone already debugging.
+  assertEquals(isWithinDependencyAgeWindow(hoursAgo(-25)), false)
+  assertEquals(isWithinDependencyAgeWindow(hoursAgo(-24 * 365)), false)
+})
+
+Deno.test('enforcesDependencyAgeGate - the holdback starts at Deno 2.9, not 2.5.5', () => {
   // Two versions matter and conflating them gives wrong advice: the flag
-  // PARSES from 2.6, but nothing is HELD BACK until 2.9.
+  // PARSES from 2.5.5, but nothing is HELD BACK until 2.9.
   assertEquals(enforcesDependencyAgeGate('2.8.5'), false)
   assertEquals(enforcesDependencyAgeGate('2.9.0'), true)
   assertEquals(enforcesDependencyAgeGate('3.0.0'), true)
   assertEquals(enforcesDependencyAgeGate('canary'), false)
-  // 2.6-2.8 accept the flag but have nothing to hold back.
+  // 2.5.5-2.8 accept the flag but have nothing to hold back.
+  assertEquals(supportsDependencyAgeFlag('2.5.5'), true)
+  assertEquals(enforcesDependencyAgeGate('2.5.5'), false)
   assertEquals(supportsDependencyAgeFlag('2.7.0'), true)
   assertEquals(enforcesDependencyAgeGate('2.7.0'), false)
 })

--- a/deno/cli/lib/dependency-age.test.ts
+++ b/deno/cli/lib/dependency-age.test.ts
@@ -2,11 +2,13 @@ import { assertEquals } from '@std/assert/equals'
 import { assertStringIncludes } from '@std/assert/string-includes'
 import {
   DEPENDENCY_AGE_FLAG,
+  enforcesDependencyAgeGate,
   isWithinDependencyAgeWindow,
   supportsDependencyAgeFlag,
   toCliInstallCommand,
   toDependencyAgeArgs,
-  toHoursSincePublish
+  toHoursSincePublish,
+  toProjectInstallCommand
 } from '@/lib/dependency-age.ts'
 
 Deno.test('supportsDependencyAgeFlag - the flag parses from Deno 2.6', () => {
@@ -65,4 +67,25 @@ Deno.test('isWithinDependencyAgeWindow - a future publish time counts as inside'
   // the one case the window is checked for.
   assertEquals(isWithinDependencyAgeWindow(hoursAgo(-0.02)), true)
   assertEquals(isWithinDependencyAgeWindow(hoursAgo(-5)), true)
+})
+
+Deno.test('enforcesDependencyAgeGate - the holdback starts at Deno 2.9, not 2.6', () => {
+  // Two versions matter and conflating them gives wrong advice: the flag
+  // PARSES from 2.6, but nothing is HELD BACK until 2.9.
+  assertEquals(enforcesDependencyAgeGate('2.8.5'), false)
+  assertEquals(enforcesDependencyAgeGate('2.9.0'), true)
+  assertEquals(enforcesDependencyAgeGate('3.0.0'), true)
+  assertEquals(enforcesDependencyAgeGate('canary'), false)
+  // 2.6-2.8 accept the flag but have nothing to hold back.
+  assertEquals(supportsDependencyAgeFlag('2.7.0'), true)
+  assertEquals(enforcesDependencyAgeGate('2.7.0'), false)
+})
+
+Deno.test('toProjectInstallCommand - the publish remediation carries the flag', () => {
+  // `skmtc publish` tells you to run this inside `.skmtc/<project>/`,
+  // whose deno.json holds EXACT @skmtc/* pins written at the CLI's own
+  // version — the hard-error face of the gate on a fresh release.
+  assertStringIncludes(toProjectInstallCommand('2.9.4'), DEPENDENCY_AGE_FLAG)
+  assertEquals(toProjectInstallCommand('2.9.4').startsWith('deno install'), true)
+  assertEquals(toProjectInstallCommand('2.5.0'), 'deno install')
 })

--- a/deno/cli/lib/dependency-age.test.ts
+++ b/deno/cli/lib/dependency-age.test.ts
@@ -57,3 +57,12 @@ Deno.test('isWithinDependencyAgeWindow - 24 hours is the boundary', () => {
   // No publish time reported: assume nothing rather than claim a hold.
   assertEquals(isWithinDependencyAgeWindow(undefined), false)
 })
+
+Deno.test('isWithinDependencyAgeWindow - a future publish time counts as inside', () => {
+  // Clock skew between the machine and the registry puts `publishedAt`
+  // marginally ahead. The release just landed, so it is as held back as
+  // a version gets — reading it as "outside" drops the explanation in
+  // the one case the window is checked for.
+  assertEquals(isWithinDependencyAgeWindow(hoursAgo(-0.02)), true)
+  assertEquals(isWithinDependencyAgeWindow(hoursAgo(-5)), true)
+})

--- a/deno/cli/lib/dependency-age.test.ts
+++ b/deno/cli/lib/dependency-age.test.ts
@@ -1,0 +1,59 @@
+import { assertEquals } from '@std/assert/equals'
+import { assertStringIncludes } from '@std/assert/string-includes'
+import {
+  DEPENDENCY_AGE_FLAG,
+  isWithinDependencyAgeWindow,
+  supportsDependencyAgeFlag,
+  toCliInstallCommand,
+  toDependencyAgeArgs,
+  toHoursSincePublish
+} from '@/lib/dependency-age.ts'
+
+Deno.test('supportsDependencyAgeFlag - the flag parses from Deno 2.6', () => {
+  // On ≤ 2.5 the flag is an unknown argument, which would fail the whole
+  // subprocess — worse than the holdback it exists to clear.
+  assertEquals(supportsDependencyAgeFlag('2.5.9'), false)
+  assertEquals(supportsDependencyAgeFlag('2.6.0'), true)
+  assertEquals(supportsDependencyAgeFlag('2.9.4'), true)
+  assertEquals(supportsDependencyAgeFlag('3.0.0'), true)
+  assertEquals(supportsDependencyAgeFlag('1.46.3'), false)
+})
+
+Deno.test('supportsDependencyAgeFlag - an unreadable version omits the flag', () => {
+  assertEquals(supportsDependencyAgeFlag('canary'), false)
+})
+
+Deno.test('toDependencyAgeArgs - splices the flag in for a supported Deno', () => {
+  assertEquals(toDependencyAgeArgs('2.9.4'), [DEPENDENCY_AGE_FLAG])
+  assertEquals(toDependencyAgeArgs('2.5.0'), [])
+})
+
+Deno.test('toCliInstallCommand - the printed remediation carries the flag', () => {
+  // The trap this closes: a remediation without the flag re-resolves to
+  // the version the reader is trying to leave, and reports success.
+  const command = toCliInstallCommand('2.9.4')
+  assertStringIncludes(command, DEPENDENCY_AGE_FLAG)
+  assertStringIncludes(command, '--unstable-worker-options')
+  assertStringIncludes(command, 'jsr:@skmtc/cli')
+})
+
+Deno.test('toCliInstallCommand - omits the flag where Deno would reject it', () => {
+  assertEquals(toCliInstallCommand('2.5.0').includes(DEPENDENCY_AGE_FLAG), false)
+})
+
+const hoursAgo = (hours: number): string =>
+  new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
+
+Deno.test('toHoursSincePublish - measures the age, or reports it unknown', () => {
+  assertEquals(Math.round(toHoursSincePublish(hoursAgo(5)) ?? 0), 5)
+  assertEquals(toHoursSincePublish(undefined), undefined)
+  assertEquals(toHoursSincePublish('not a date'), undefined)
+})
+
+Deno.test('isWithinDependencyAgeWindow - 24 hours is the boundary', () => {
+  assertEquals(isWithinDependencyAgeWindow(hoursAgo(1)), true)
+  assertEquals(isWithinDependencyAgeWindow(hoursAgo(23.5)), true)
+  assertEquals(isWithinDependencyAgeWindow(hoursAgo(25)), false)
+  // No publish time reported: assume nothing rather than claim a hold.
+  assertEquals(isWithinDependencyAgeWindow(undefined), false)
+})

--- a/deno/cli/lib/dependency-age.ts
+++ b/deno/cli/lib/dependency-age.ts
@@ -1,0 +1,85 @@
+/**
+ * Deno's minimum-dependency-age gate, in one place.
+ *
+ * From Deno 2.9 the runtime refuses to resolve a dependency version
+ * published within the last 24 hours (a supply-chain measure). Every
+ * `@skmtc/*` package publishes on merge to main, so a just-released
+ * version ALWAYS sits inside that window — and the gate has three
+ * different faces:
+ *
+ *  - an EXACT pin (what `ensureServerDeps` / `ensureWorkerDeps` write, and
+ *    what a project's `deno.json` carries) is a hard error naming the
+ *    policy on Deno ≥ 2.9.3, and on 2.9.0–2.9.2 the misleading
+ *    `Do not know how to load path: deno:jsr:…`;
+ *  - an UNPINNED specifier (`deno install jsr:@skmtc/cli`) resolves
+ *    SILENTLY to the previous version — the install reports success and
+ *    the older CLI runs;
+ *  - a lockfile already holding the older resolution keeps it, so
+ *    clearing the lock without also passing the flag lands right back on
+ *    the older version.
+ *
+ * Anything that shells out to `deno` on the CLI's behalf passes
+ * {@link toDependencyAgeArgs}, and anything that PRINTS a `deno` command
+ * for someone to run builds it through {@link toCliInstallCommand} — a
+ * remediation without the flag sends the reader back to the version they
+ * are trying to leave.
+ */
+
+/** The flag as `deno` spells it. `0` disables the holdback outright. */
+export const DEPENDENCY_AGE_FLAG = '--minimum-dependency-age=0'
+
+/** Deno's default holdback window, for messages that explain the wait. */
+export const DEPENDENCY_AGE_WINDOW_HOURS = 24
+
+/**
+ * Does this Deno understand the flag? It parses from 2.6 (a no-op until
+ * the 2.9 gate) and is an unknown-argument error on ≤ 2.5. Callers pass
+ * the running version because a subprocess resolves `deno` from PATH —
+ * the same binary running this code in the supported setups.
+ */
+export const supportsDependencyAgeFlag = (
+  denoVersion: string = Deno.version.deno
+): boolean => {
+  const [major, minor] = denoVersion.split('.').map(Number)
+  if (Number.isNaN(major) || Number.isNaN(minor)) return false
+  return major > 2 || (major === 2 && minor >= 6)
+}
+
+/** Args to splice into a `deno` subprocess invocation, empty when the
+ *  running Deno predates the flag. */
+export const toDependencyAgeArgs = (denoVersion?: string): string[] =>
+  supportsDependencyAgeFlag(denoVersion) ? [DEPENDENCY_AGE_FLAG] : []
+
+/**
+ * The reinstall command the CLI hands out — `skmtc doctor`'s hints and
+ * the how-to docs print this one string, so the flag cannot drift out of
+ * a remediation again.
+ */
+export const toCliInstallCommand = (denoVersion?: string): string =>
+  [
+    'deno install -gAf',
+    ...toDependencyAgeArgs(denoVersion),
+    '--unstable-worker-options --name skmtc jsr:@skmtc/cli'
+  ].join(' ')
+
+/** Hours since `publishedAt`, or `undefined` when the registry did not
+ *  report a publish time. */
+export const toHoursSincePublish = (
+  publishedAt: string | undefined,
+  now: Date = new Date()
+): number | undefined => {
+  if (publishedAt === undefined) return undefined
+  const published = new Date(publishedAt)
+  if (Number.isNaN(published.getTime())) return undefined
+  return (now.getTime() - published.getTime()) / (1000 * 60 * 60)
+}
+
+/** Is this version still inside Deno's holdback window — i.e. will a
+ *  resolution without the flag refuse to reach it? */
+export const isWithinDependencyAgeWindow = (
+  publishedAt: string | undefined,
+  now?: Date
+): boolean => {
+  const hours = toHoursSincePublish(publishedAt, now)
+  return hours !== undefined && hours >= 0 && hours < DEPENDENCY_AGE_WINDOW_HOURS
+}

--- a/deno/cli/lib/dependency-age.ts
+++ b/deno/cli/lib/dependency-age.ts
@@ -20,7 +20,8 @@
  *
  * Anything that shells out to `deno` on the CLI's behalf passes
  * {@link toDependencyAgeArgs}, and anything that PRINTS a `deno` command
- * for someone to run builds it through {@link toCliInstallCommand} — a
+ * for someone to run builds it here — {@link toCliInstallCommand} for the
+ * global CLI, {@link toProjectInstallCommand} for a project directory. A
  * remediation without the flag sends the reader back to the version they
  * are trying to leave.
  */
@@ -31,33 +32,57 @@ export const DEPENDENCY_AGE_FLAG = '--minimum-dependency-age=0'
 /** Deno's default holdback window, for messages that explain the wait. */
 export const DEPENDENCY_AGE_WINDOW_HOURS = 24
 
+/** `major.minor.patch` as numbers, or `undefined` when the string is not
+ *  a version. A prerelease suffix (`2.9.0-rc.1`) still yields its numeric
+ *  patch, so a release candidate compares as its own release. */
+const toVersionParts = (
+  denoVersion: string
+): { major: number; minor: number; patch: number } | undefined => {
+  const [major, minor, patch] = denoVersion.split('.')
+  const parsedMajor = Number(major)
+  const parsedMinor = Number(minor)
+  if (Number.isNaN(parsedMajor) || Number.isNaN(parsedMinor)) return undefined
+  return { major: parsedMajor, minor: parsedMinor, patch: parseInt(patch, 10) || 0 }
+}
+
 /**
- * Does this Deno understand the flag? It parses from 2.6 (a no-op until
- * the 2.9 gate) and is an unknown-argument error on ≤ 2.5. Callers pass
- * the running version because a subprocess resolves `deno` from PATH —
- * the same binary running this code in the supported setups.
+ * Does this Deno understand the flag? It parses from 2.5.5 — `deno
+ * 2.5.5 / 2025.10.28`, *"feat(unstable): ability to only install
+ * dependencies older than a certain date (#30752)"*, which registers
+ * `min_dep_age_arg()` in `compile_args_without_check_args`, composed by
+ * `run` / `bundle` / `install` alike. (The 2.8.3 and 2.9.4 release notes
+ * add it to `deno info` and `deno add`/`remove`; those are per-subcommand
+ * backfills, not the introduction.) It is a no-op until the 2.9 gate, and
+ * an unknown-argument error only on ≤ 2.5.4.
+ *
+ * Callers pass the running version because a subprocess resolves `deno`
+ * from PATH — the same binary running this code in the supported setups.
  */
 export const supportsDependencyAgeFlag = (
   denoVersion: string = Deno.version.deno
 ): boolean => {
-  const [major, minor] = denoVersion.split('.').map(Number)
-  if (Number.isNaN(major) || Number.isNaN(minor)) return false
-  return major > 2 || (major === 2 && minor >= 6)
+  const parts = toVersionParts(denoVersion)
+  if (parts === undefined) return false
+  const { major, minor, patch } = parts
+  if (major !== 2) return major > 2
+  if (minor !== 5) return minor > 5
+  return patch >= 5
 }
 
 /**
  * Does this Deno actually ENFORCE the holdback? Two different versions
  * matter and conflating them produces wrong advice: the flag parses from
- * 2.6, but nothing is held back until 2.9. Below that there is no gate
- * to explain, so a "your release is too new to install" hint would name
- * a cause that does not exist.
+ * 2.5.5, but nothing is held back until 2.9 — `deno 2.9.0 / 2026.06.25`,
+ * *"feat: enable default minimum dependency age (#35458)"*. Below that
+ * there is no gate to explain, so a "your release is too new to install"
+ * hint would name a cause that does not exist.
  */
 export const enforcesDependencyAgeGate = (
   denoVersion: string = Deno.version.deno
 ): boolean => {
-  const [major, minor] = denoVersion.split('.').map(Number)
-  if (Number.isNaN(major) || Number.isNaN(minor)) return false
-  return major > 2 || (major === 2 && minor >= 9)
+  const parts = toVersionParts(denoVersion)
+  if (parts === undefined) return false
+  return parts.major > 2 || (parts.major === 2 && parts.minor >= 9)
 }
 
 /** Args to splice into a `deno` subprocess invocation, empty when the
@@ -104,16 +129,22 @@ export const toHoursSincePublish = (
  * Is this version still inside Deno's holdback window — i.e. will a
  * resolution without the flag refuse to reach it?
  *
- * A NEGATIVE age counts as inside. A publish time slightly ahead of the
- * local clock (a lagging machine, a registry timestamp a moment ahead)
- * means the release just landed, which is the deepest part of the window
- * — reading it as "outside" would drop the explanation in the one case
- * the check exists for.
+ * A SLIGHTLY negative age counts as inside. A publish time a little
+ * ahead of the local clock (a lagging machine, a registry timestamp a
+ * moment ahead) means the release just landed, which is the deepest part
+ * of the window — reading it as "outside" would drop the explanation in
+ * the one case the check exists for.
+ *
+ * The tolerance is bounded, though: a `createdAt` far in the future is a
+ * broken clock or a mirror inventing timestamps, not a fresh release, and
+ * calling it "held back" would name the wrong cause to someone already
+ * debugging. Beyond one window's slack it reads as outside.
  */
 export const isWithinDependencyAgeWindow = (
   publishedAt: string | undefined,
   now?: Date
 ): boolean => {
   const hours = toHoursSincePublish(publishedAt, now)
-  return hours !== undefined && hours < DEPENDENCY_AGE_WINDOW_HOURS
+  if (hours === undefined) return false
+  return hours > -DEPENDENCY_AGE_WINDOW_HOURS && hours < DEPENDENCY_AGE_WINDOW_HOURS
 }

--- a/deno/cli/lib/dependency-age.ts
+++ b/deno/cli/lib/dependency-age.ts
@@ -74,12 +74,20 @@ export const toHoursSincePublish = (
   return (now.getTime() - published.getTime()) / (1000 * 60 * 60)
 }
 
-/** Is this version still inside Deno's holdback window — i.e. will a
- *  resolution without the flag refuse to reach it? */
+/**
+ * Is this version still inside Deno's holdback window — i.e. will a
+ * resolution without the flag refuse to reach it?
+ *
+ * A NEGATIVE age counts as inside. A publish time slightly ahead of the
+ * local clock (a lagging machine, a registry timestamp a moment ahead)
+ * means the release just landed, which is the deepest part of the window
+ * — reading it as "outside" would drop the explanation in the one case
+ * the check exists for.
+ */
 export const isWithinDependencyAgeWindow = (
   publishedAt: string | undefined,
   now?: Date
 ): boolean => {
   const hours = toHoursSincePublish(publishedAt, now)
-  return hours !== undefined && hours >= 0 && hours < DEPENDENCY_AGE_WINDOW_HOURS
+  return hours !== undefined && hours < DEPENDENCY_AGE_WINDOW_HOURS
 }

--- a/deno/cli/lib/dependency-age.ts
+++ b/deno/cli/lib/dependency-age.ts
@@ -45,6 +45,21 @@ export const supportsDependencyAgeFlag = (
   return major > 2 || (major === 2 && minor >= 6)
 }
 
+/**
+ * Does this Deno actually ENFORCE the holdback? Two different versions
+ * matter and conflating them produces wrong advice: the flag parses from
+ * 2.6, but nothing is held back until 2.9. Below that there is no gate
+ * to explain, so a "your release is too new to install" hint would name
+ * a cause that does not exist.
+ */
+export const enforcesDependencyAgeGate = (
+  denoVersion: string = Deno.version.deno
+): boolean => {
+  const [major, minor] = denoVersion.split('.').map(Number)
+  if (Number.isNaN(major) || Number.isNaN(minor)) return false
+  return major > 2 || (major === 2 && minor >= 9)
+}
+
 /** Args to splice into a `deno` subprocess invocation, empty when the
  *  running Deno predates the flag. */
 export const toDependencyAgeArgs = (denoVersion?: string): string[] =>
@@ -61,6 +76,17 @@ export const toCliInstallCommand = (denoVersion?: string): string =>
     ...toDependencyAgeArgs(denoVersion),
     '--unstable-worker-options --name skmtc jsr:@skmtc/cli'
   ].join(' ')
+
+/**
+ * `deno install` for a PROJECT directory — the one `skmtc publish` tells
+ * you to run when the upload has no `deno.lock`. That directory's
+ * `deno.json` carries the exact `@skmtc/*` pins `ensureWorkerDeps` /
+ * `ensureServerDeps` wrote at the CLI's own version, so on a CLI
+ * released minutes ago it is the hard-error face of the gate: without
+ * the flag, the recovery instruction reproduces the failure.
+ */
+export const toProjectInstallCommand = (denoVersion?: string): string =>
+  ['deno install', ...toDependencyAgeArgs(denoVersion)].join(' ')
 
 /** Hours since `publishedAt`, or `undefined` when the registry did not
  *  report a publish time. */

--- a/deno/cli/lib/doctor-headless.test.ts
+++ b/deno/cli/lib/doctor-headless.test.ts
@@ -608,18 +608,25 @@ const hoursAgo = (hours: number): string =>
  * happens to have — passing only because these tests assert on one
  * check, and one malformed manifest in someone's scratch project away
  * from a confusing failure in a check they are not testing.
+ *
+ * `denoVersion` defaults to a gate-ENFORCING version rather than falling
+ * through to the ambient one. Leaving it ambient made the outcome depend
+ * on the developer's Deno: `heldBack` flips to false on 2.6-2.8 (the flag
+ * parses, nothing is held back) and the flag drops out of the printed
+ * command on ≤ 2.5.4 — both inside doctor's own >= 2.4.0 supported range,
+ * so the suite passed here and failed for someone one minor behind.
  */
 const toVersionCheck = async (
   cliVersion: string,
   getLatestCliMeta: Parameters<typeof runDoctorWithRegistry>[0]['getLatestCliMeta'],
-  denoVersion?: string
+  denoVersion: string = '2.9.4'
 ): Promise<Check> => {
   const found: Check[] = []
   await withTempSkmtcRoot(async () => {
     const result = await runDoctorWithRegistry({
       cliVersion,
       getLatestCliMeta,
-      ...(denoVersion === undefined ? {} : { denoVersion })
+      denoVersion
     })
     const check = result.checks.find(c => c.id === 'cli-version-current')
     if (check === undefined) throw new Error('cli-version-current check missing')
@@ -714,6 +721,18 @@ Deno.test('runDoctor - cli-version-current tolerates a missing publish time', as
   assertEquals(check.data?.heldBack, false)
 })
 
+Deno.test('runDoctor - cli-version-current names no gate on a Deno that has none', async () => {
+  // 2.5.5-2.8 parse the flag but hold nothing back. Naming the window
+  // here would explain a cause that does not exist on this runtime, and
+  // the command still carries the flag because it is a harmless no-op.
+  const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41', hoursAgo(2)), '2.7.0')
+
+  assertEquals(check.status, 'warning')
+  assertEquals(check.data?.heldBack, false)
+  assertEquals(check.hint?.includes('window'), false)
+  assertStringIncludes(check.hint ?? '', '--minimum-dependency-age=0')
+})
+
 /**
  * Every check id, read out of the source the docs point at. Both
  * spellings appear: a plain literal (`id: 'deno-version'`) for a
@@ -757,7 +776,7 @@ Deno.test('runDoctor - --offline says it was skipped by request, not that the ne
 })
 
 Deno.test('runDoctor - on a Deno without the gate, the hint neither claims nor prints the flag', async () => {
-  // Deno < 2.9 enforces no holdback, and <= 2.5 rejects the flag as an
+  // Deno < 2.9 enforces no holdback, and <= 2.5.4 rejects the flag as an
   // unknown argument. Claiming the flag is the fix while handing over a
   // command that omits it is the contradiction to avoid — and doctor's
   // own floor (2.4.0) puts such a reader inside the supported range.

--- a/deno/cli/lib/doctor-headless.test.ts
+++ b/deno/cli/lib/doctor-headless.test.ts
@@ -13,7 +13,7 @@ import { assertEquals } from '@std/assert/equals'
 import { assertStringIncludes } from '@std/assert/string-includes'
 import { join } from '@std/path/join'
 import { ensureDir } from '@std/fs/ensure-dir'
-import { runDoctor as runDoctorWithRegistry } from '@/lib/doctor-headless.ts'
+import { runDoctor as runDoctorWithRegistry, type Check } from '@/lib/doctor-headless.ts'
 import { printDoctorResult } from '@/commands/doctor.ts'
 import { captureStdout } from '@/tests/strict-mode-helpers.test.ts'
 
@@ -601,14 +601,31 @@ const toCliMeta = (latest: string, publishedAt?: string) => () =>
 const hoursAgo = (hours: number): string =>
   new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
 
+/**
+ * The `cli-version-current` check from a doctor run, taken inside a temp
+ * root like every other test here. `toRootPath()` walks up `cwd`, so a
+ * run outside `withTempSkmtcRoot` reads whatever `.skmtc` the developer
+ * happens to have — passing only because these tests assert on one
+ * check, and one malformed manifest in someone's scratch project away
+ * from a confusing failure in a check they are not testing.
+ */
 const toVersionCheck = async (
   cliVersion: string,
-  getLatestCliMeta: Parameters<typeof runDoctorWithRegistry>[0]['getLatestCliMeta']
-) => {
-  const result = await runDoctorWithRegistry({ cliVersion, getLatestCliMeta })
-  const check = result.checks.find(c => c.id === 'cli-version-current')
-  if (check === undefined) throw new Error('cli-version-current check missing')
-  return check
+  getLatestCliMeta: Parameters<typeof runDoctorWithRegistry>[0]['getLatestCliMeta'],
+  denoVersion?: string
+): Promise<Check> => {
+  const found: Check[] = []
+  await withTempSkmtcRoot(async () => {
+    const result = await runDoctorWithRegistry({
+      cliVersion,
+      getLatestCliMeta,
+      ...(denoVersion === undefined ? {} : { denoVersion })
+    })
+    const check = result.checks.find(c => c.id === 'cli-version-current')
+    if (check === undefined) throw new Error('cli-version-current check missing')
+    found.push(check)
+  })
+  return found[0]
 }
 
 Deno.test('runDoctor - cli-version-current is ok on the latest release', async () => {
@@ -715,6 +732,48 @@ const toCheckIds = async (): Promise<string[]> => {
   }
   return [...ids].sort()
 }
+
+Deno.test('runDoctor - --offline says it was skipped by request, not that the network failed', async () => {
+  // `--offline` never attempts the lookup, so reporting a connectivity
+  // problem would have an agent tell the user about a failure that did
+  // not happen — in the command whose value is naming an accurate cause.
+  const checks: Check[] = []
+  await withTempSkmtcRoot(async () => {
+    const result = await runDoctorWithRegistry({
+      cliVersion: '0.9.40',
+      offline: true,
+      getLatestCliMeta: () => {
+        throw new Error('the registry must not be consulted')
+      }
+    })
+    const check = result.checks.find(c => c.id === 'cli-version-current')
+    if (check === undefined) throw new Error('cli-version-current check missing')
+    checks.push(check)
+  })
+
+  assertEquals(checks[0].status, 'skipped')
+  assertStringIncludes(checks[0].message, 'Skipped by --offline')
+  assertEquals(checks[0].message.includes('Could not reach'), false)
+})
+
+Deno.test('runDoctor - on a Deno without the gate, the hint neither claims nor prints the flag', async () => {
+  // Deno < 2.9 enforces no holdback, and <= 2.5 rejects the flag as an
+  // unknown argument. Claiming the flag is the fix while handing over a
+  // command that omits it is the contradiction to avoid — and doctor's
+  // own floor (2.4.0) puts such a reader inside the supported range.
+  const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41', hoursAgo(2)), '2.5.0')
+
+  assertEquals(check.status, 'warning')
+  assertEquals(check.data?.heldBack, false)
+  assertEquals(check.hint?.includes('--minimum-dependency-age=0'), false)
+})
+
+Deno.test('runDoctor - on a gate-enforcing Deno the hint both claims and prints the flag', async () => {
+  const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41', hoursAgo(2)), '2.9.4')
+
+  assertEquals(check.data?.heldBack, true)
+  assertStringIncludes(check.hint ?? '', '--minimum-dependency-age=0')
+})
 
 Deno.test('doctor - every check id is documented in all three catalogues', async () => {
   // The docs are what an agent reads to reason about a check without

--- a/deno/cli/lib/doctor-headless.test.ts
+++ b/deno/cli/lib/doctor-headless.test.ts
@@ -658,9 +658,82 @@ Deno.test('runDoctor - cli-version-current skips when the registry is unreachabl
   assertStringIncludes(check.message, 'Could not reach')
 })
 
+Deno.test('runDoctor - cli-version-current survives a registry answering the wrong shape', async () => {
+  // A mirror or proxy behind JSR_URL answering 200 with a JSON error
+  // object. Doctor is the "everything else is broken" command, so an
+  // unreadable answer must be one `skipped` line, not a throw that takes
+  // the other twelve checks with it.
+  const check = await toVersionCheck(
+    '0.9.40',
+    () => Promise.resolve(JSON.parse('{"error":"nope"}'))
+  )
+
+  assertEquals(check.status, 'skipped')
+})
+
+Deno.test('runDoctor - cli-version-current survives a rejected registry lookup', async () => {
+  const check = await toVersionCheck('0.9.40', () =>
+    Promise.reject(new Error('socket hang up'))
+  )
+
+  assertEquals(check.status, 'skipped')
+})
+
+Deno.test('runDoctor - cli-version-current treats a future publish time as inside the window', async () => {
+  // A machine whose clock lags the registry by a minute. The release
+  // landed moments ago — the deepest part of the window, and the exact
+  // case this check exists to explain.
+  const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41', hoursAgo(-0.02)))
+
+  assertEquals(check.status, 'warning')
+  assertEquals(check.data?.heldBack, true)
+  assertStringIncludes(check.hint ?? '', 'published a moment ago')
+})
+
 Deno.test('runDoctor - cli-version-current tolerates a missing publish time', async () => {
   const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41'))
 
   assertEquals(check.status, 'warning')
   assertEquals(check.data?.heldBack, false)
+})
+
+/**
+ * Every check id, read out of the source the docs point at. Both
+ * spellings appear: a plain literal (`id: 'deno-version'`) for a
+ * workspace check, and a template (`id: \`project-bundle/${name}\``)
+ * for a per-project one, which the docs write as
+ * `project-bundle/<project>`.
+ */
+const toCheckIds = async (): Promise<string[]> => {
+  const sources = ['doctor-headless.ts', 'doctor-anchors.ts']
+  const ids = new Set<string>()
+  for (const source of sources) {
+    const text = await Deno.readTextFile(new URL(source, import.meta.url))
+    for (const match of text.matchAll(/\bid = `([a-z-]+)\/\$\{/g)) ids.add(match[1])
+    for (const match of text.matchAll(/\bid: `([a-z-]+)\/\$\{/g)) ids.add(match[1])
+    for (const match of text.matchAll(/\bid: '([a-z-]+)'/g)) ids.add(match[1])
+  }
+  return [...ids].sort()
+}
+
+Deno.test('doctor - every check id is documented in all three catalogues', async () => {
+  // The docs are what an agent reads to reason about a check without
+  // running it, and three files carry the same table. Adding a check
+  // without a row makes it invisible to exactly those readers — which is
+  // how `cli-version-current` shipped undocumented in review.
+  const catalogues = [
+    '../../docs/reference/cli/doctor.md',
+    '../../docs/skills/skmtc-cli/SKILL.md',
+    '../../docs/skills/skmtc-cli-v2/reference.md'
+  ]
+  const ids = await toCheckIds()
+  // Guard the guard: a broken extraction would vacuously pass.
+  assertEquals(ids.length > 10, true)
+  assertEquals(ids.includes('cli-version-current'), true)
+
+  for (const catalogue of catalogues) {
+    const text = await Deno.readTextFile(new URL(catalogue, import.meta.url))
+    const undocumented = ids.filter(id => !text.includes(`\`${id}`))
+    assertEquals(undocumented, [], `undocumented in ${catalogue}`)
+  }
 })

--- a/deno/cli/lib/doctor-headless.test.ts
+++ b/deno/cli/lib/doctor-headless.test.ts
@@ -13,9 +13,23 @@ import { assertEquals } from '@std/assert/equals'
 import { assertStringIncludes } from '@std/assert/string-includes'
 import { join } from '@std/path/join'
 import { ensureDir } from '@std/fs/ensure-dir'
-import { runDoctor } from '@/lib/doctor-headless.ts'
+import { runDoctor as runDoctorWithRegistry } from '@/lib/doctor-headless.ts'
 import { printDoctorResult } from '@/commands/doctor.ts'
 import { captureStdout } from '@/tests/strict-mode-helpers.test.ts'
+
+/**
+ * `runDoctor` with the registry lookup answered as "unreachable" — the
+ * checks below are filesystem facts, and a real fetch would make every
+ * one of them depend on the network. The registry comparison has its own
+ * tests, which state the registry's answer explicitly.
+ */
+const runDoctor = (
+  args: Parameters<typeof runDoctorWithRegistry>[0]
+): ReturnType<typeof runDoctorWithRegistry> =>
+  runDoctorWithRegistry({
+    getLatestCliMeta: () => Promise.resolve(undefined),
+    ...args
+  })
 
 /**
  * Sets up a temp directory, cd's into it, runs `fn` with the temp dir
@@ -571,4 +585,82 @@ Deno.test('runDoctor - hub-auth check reports stored credential shape offline', 
       }
     }
   })
+})
+
+/** A registry answer: `latest`, and when it was published. */
+const toCliMeta = (latest: string, publishedAt?: string) => () =>
+  Promise.resolve({
+    scope: 'skmtc',
+    name: 'cli',
+    latest,
+    versions: {
+      [latest]: publishedAt === undefined ? {} : { createdAt: publishedAt }
+    }
+  })
+
+const hoursAgo = (hours: number): string =>
+  new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
+
+const toVersionCheck = async (
+  cliVersion: string,
+  getLatestCliMeta: Parameters<typeof runDoctorWithRegistry>[0]['getLatestCliMeta']
+) => {
+  const result = await runDoctorWithRegistry({ cliVersion, getLatestCliMeta })
+  const check = result.checks.find(c => c.id === 'cli-version-current')
+  if (check === undefined) throw new Error('cli-version-current check missing')
+  return check
+}
+
+Deno.test('runDoctor - cli-version-current is ok on the latest release', async () => {
+  const check = await toVersionCheck('0.9.41', toCliMeta('0.9.41', hoursAgo(48)))
+
+  assertEquals(check.status, 'ok')
+  assertStringIncludes(check.message, 'latest published')
+})
+
+Deno.test('runDoctor - cli-version-current names the age gate for a fresh release', async () => {
+  // The silent case: an unpinned `deno install` inside the window
+  // resolves the older version and reports success, so doctor has to say
+  // why a plain reinstall will not move it.
+  const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41', hoursAgo(2)))
+
+  assertEquals(check.status, 'warning')
+  assertStringIncludes(check.message, '0.9.40 is behind')
+  assertStringIncludes(check.hint ?? '', 'minimum-dependency-age')
+  assertStringIncludes(check.hint ?? '', '--minimum-dependency-age=0')
+  assertStringIncludes(check.hint ?? '', '2 hours ago')
+  assertEquals(check.data?.heldBack, true)
+})
+
+Deno.test('runDoctor - cli-version-current omits the age note once the window has passed', async () => {
+  const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41', hoursAgo(72)))
+
+  assertEquals(check.status, 'warning')
+  assertEquals(check.data?.heldBack, false)
+  assertEquals(check.hint?.includes('window'), false)
+  // The flag stays in the command regardless — it is a no-op once the
+  // release is old enough, and wrong to drop from a copied command.
+  assertStringIncludes(check.hint ?? '', '--minimum-dependency-age=0')
+})
+
+Deno.test('runDoctor - cli-version-current accepts a build ahead of the registry', async () => {
+  const check = await toVersionCheck('0.10.0', toCliMeta('0.9.41', hoursAgo(48)))
+
+  assertEquals(check.status, 'ok')
+  assertStringIncludes(check.message, 'ahead of the published')
+})
+
+Deno.test('runDoctor - cli-version-current skips when the registry is unreachable', async () => {
+  const check = await toVersionCheck('0.9.40', () => Promise.resolve(undefined))
+
+  assertEquals(check.status, 'skipped')
+  // Offline is not a failure: doctor still reports every other check.
+  assertStringIncludes(check.message, 'Could not reach')
+})
+
+Deno.test('runDoctor - cli-version-current tolerates a missing publish time', async () => {
+  const check = await toVersionCheck('0.9.40', toCliMeta('0.9.41'))
+
+  assertEquals(check.status, 'warning')
+  assertEquals(check.data?.heldBack, false)
 })

--- a/deno/cli/lib/doctor-headless.ts
+++ b/deno/cli/lib/doctor-headless.ts
@@ -36,6 +36,7 @@ import {
   DEPENDENCY_AGE_WINDOW_HOURS,
   enforcesDependencyAgeGate,
   isWithinDependencyAgeWindow,
+  supportsDependencyAgeFlag,
   toCliInstallCommand,
   toHoursSincePublish
 } from '@/lib/dependency-age.ts'
@@ -112,7 +113,7 @@ export const runDoctor = async ({
   checks.push(
     await checkCliVersionCurrent({ cliVersion, denoVersion, getLatestCliMeta, offline })
   )
-  checks.push(checkInstallLockfile())
+  checks.push(checkInstallLockfile(denoVersion))
   checks.push(checkDenoVersion(denoVersion))
   checks.push(checkHubAuth())
 
@@ -191,7 +192,12 @@ const checkCliVersionCurrent = async ({
   // command you run when everything else is broken, so a registry answer
   // it cannot read has to become a `skipped` line, never a throw that
   // takes the other twelve checks down with it.
-  const meta = await getLatestCliMeta().catch(() => undefined)
+  //
+  // Called through `Promise.resolve().then` rather than `f().catch`: an
+  // injected or refactored `getLatestCliMeta` that throws SYNCHRONOUSLY
+  // never produces a promise for `.catch` to attach to, so the throw
+  // escapes past exactly the guard this comment is describing.
+  const meta = await Promise.resolve().then(getLatestCliMeta).catch(() => undefined)
   if (typeof meta?.latest !== 'string' || typeof meta.versions !== 'object') {
     return {
       id: 'cli-version-current',
@@ -278,7 +284,7 @@ const formatHours = (publishedAt: string | undefined): string => {
  * behavior from here, but we can detect the situation and tell the
  * operator how to clear it.
  */
-const checkInstallLockfile = (): Check => {
+const checkInstallLockfile = (denoVersion?: string): Check => {
   const lockPath = join(homedir(), '.deno', 'bin', '.skmtc', 'deno.lock')
   if (!existsSync(lockPath)) {
     return {
@@ -297,14 +303,21 @@ const checkInstallLockfile = (): Check => {
       id: 'install-lockfile',
       status: 'ok',
       message: `Install lockfile present. Pinned: @skmtc/cli=${cliVersion ?? 'unknown'}, @skmtc/core=${coreVersion ?? 'unknown'}.`,
+      // The flag half of this hint only holds where the command actually
+      // carries the flag. On a Deno too old to parse it `toCliInstallCommand`
+      // omits it, and asserting "not optional" over a command without it
+      // is the contradiction the sibling check's two-predicate split exists
+      // to avoid.
       hint:
         `If enrichment leaves arrive as \`{}\` inside generators, your installed ` +
         `CLI might be pinned to an old @skmtc/core. Remediation: ` +
-        `\`rm -f ${lockPath} && ${toCliInstallCommand()}\`. ` +
-        `The age flag is part of the remediation, not optional: clearing the ` +
-        `lock alone re-resolves to the same older version whenever the ` +
-        `newest release is under ${DEPENDENCY_AGE_WINDOW_HOURS}h old. ` +
-        `See friction #16 in skmtc-cli skill §7.`,
+        `\`rm -f ${lockPath} && ${toCliInstallCommand(denoVersion)}\`.` +
+        (supportsDependencyAgeFlag(denoVersion)
+          ? ` The age flag is part of the remediation, not optional: clearing the ` +
+            `lock alone re-resolves to the same older version whenever the ` +
+            `newest release is under ${DEPENDENCY_AGE_WINDOW_HOURS}h old.`
+          : '') +
+        ` See friction #16 in skmtc-cli skill §7.`,
       data: { lockPath, cliVersion, coreVersion }
     }
   } catch (error) {

--- a/deno/cli/lib/doctor-headless.ts
+++ b/deno/cli/lib/doctor-headless.ts
@@ -156,8 +156,12 @@ const checkCliVersionCurrent = async (
   cliVersion: string,
   getLatestCliMeta: () => Promise<JsrPkgMetaVersions | undefined>
 ): Promise<Check> => {
-  const meta = await getLatestCliMeta()
-  if (meta === undefined) {
+  // Belt and braces with `tryGetLatestMeta`'s shape check: doctor is the
+  // command you run when everything else is broken, so a registry answer
+  // it cannot read has to become a `skipped` line, never a throw that
+  // takes the other twelve checks down with it.
+  const meta = await getLatestCliMeta().catch(() => undefined)
+  if (typeof meta?.latest !== 'string' || typeof meta.versions !== 'object') {
     return {
       id: 'cli-version-current',
       status: 'skipped',
@@ -183,7 +187,7 @@ const checkCliVersionCurrent = async (
     }
   }
 
-  const publishedAt = meta.versions[meta.latest]?.createdAt
+  const publishedAt = meta.versions?.[meta.latest]?.createdAt
   const heldBack = isWithinDependencyAgeWindow(publishedAt)
   const lockPath = join(homedir(), '.deno', 'bin', '.skmtc', 'deno.lock')
   const reinstall = existsSync(lockPath)
@@ -221,8 +225,14 @@ const isAheadOfRegistry = (cliVersion: string, latest: string): boolean => {
 const formatHours = (publishedAt: string | undefined): string => {
   const hours = toHoursSincePublish(publishedAt)
   if (hours === undefined) return 'an unknown time'
-  if (hours < 1) return `${Math.max(1, Math.round(hours * 60))} minutes`
-  return `${Math.round(hours)} hours`
+  if (hours < 1) {
+    // Negative when the publish time is a touch ahead of the local clock;
+    // "a moment" reads correctly either way.
+    const minutes = Math.round(hours * 60)
+    return minutes <= 1 ? 'a moment' : `${minutes} minutes`
+  }
+  const rounded = Math.round(hours)
+  return rounded === 1 ? '1 hour' : `${rounded} hours`
 }
 
 /**

--- a/deno/cli/lib/doctor-headless.ts
+++ b/deno/cli/lib/doctor-headless.ts
@@ -26,6 +26,18 @@ import {
   checkAnchorsStaleness
 } from '@/lib/doctor-anchors.ts'
 import { maskToken, readStoredAuth, toAuthFilePath } from '@/lib/hub-token.ts'
+import { Jsr } from '@/lib/jsr.ts'
+import type { JsrPkgMetaVersions } from '@/lib/jsr.ts'
+import { getJsrBaseUrl } from '@/lib/jsr-registry.ts'
+import { greaterThan } from '@std/semver/greater-than'
+import { parse as parseSemver } from '@std/semver/parse'
+import {
+  DEPENDENCY_AGE_FLAG,
+  DEPENDENCY_AGE_WINDOW_HOURS,
+  isWithinDependencyAgeWindow,
+  toCliInstallCommand,
+  toHoursSincePublish
+} from '@/lib/dependency-age.ts'
 
 export type CheckStatus = 'ok' | 'warning' | 'error' | 'skipped'
 
@@ -69,17 +81,27 @@ type RunDoctorArgs = {
    * injectable so tests can exercise the version-floor check.
    */
   denoVersion?: string
+  /**
+   * The registry lookup behind the `cli-version-current` check — the
+   * only network call doctor makes. Injectable so tests state the
+   * registry's answer instead of reaching for it.
+   */
+  getLatestCliMeta?: () => Promise<JsrPkgMetaVersions | undefined>
 }
 
 export const runDoctor = async ({
   cliVersion,
-  denoVersion = Deno.version.deno
+  denoVersion = Deno.version.deno,
+  // `scopeName` carries its `@` — `toJsrUrl` joins the parts verbatim.
+  getLatestCliMeta = () =>
+    Jsr.tryGetLatestMeta({ scopeName: '@skmtc', packageName: 'cli' })
 }: RunDoctorArgs): Promise<DoctorResult> => {
   const skmtcRootPath = toRootPath()
   const globalStateDir = join(homedir(), '.skmtc')
   const projects = listProjects(skmtcRootPath)
   const checks: Check[] = []
 
+  checks.push(await checkCliVersionCurrent(cliVersion, getLatestCliMeta))
   checks.push(checkInstallLockfile())
   checks.push(checkDenoVersion(denoVersion))
   checks.push(checkHubAuth())
@@ -119,6 +141,91 @@ const aggregate = (checks: Check[]): CheckStatus => {
 }
 
 /**
+ * Is the running CLI the newest published one? Doctor otherwise reports
+ * the version it is running as a fact with nothing to compare it to, so
+ * "you are a release behind" stays invisible — and the way you most often
+ * end up there is silent: an unpinned `deno install` inside Deno's
+ * dependency-age window resolves the PREVIOUS version and reports
+ * success. When that is the situation, say so and name the flag.
+ *
+ * Diagnostic only: unreachable registry, missing publish time or a local
+ * build ahead of the registry all degrade to `skipped`/`ok` rather than
+ * failing the command.
+ */
+const checkCliVersionCurrent = async (
+  cliVersion: string,
+  getLatestCliMeta: () => Promise<JsrPkgMetaVersions | undefined>
+): Promise<Check> => {
+  const meta = await getLatestCliMeta()
+  if (meta === undefined) {
+    return {
+      id: 'cli-version-current',
+      status: 'skipped',
+      message: `Could not reach ${getJsrBaseUrl()} to compare @skmtc/cli versions.`
+    }
+  }
+  if (meta.latest === cliVersion) {
+    return {
+      id: 'cli-version-current',
+      status: 'ok',
+      message: `CLI ${cliVersion} is the latest published @skmtc/cli.`,
+      data: { cliVersion, latest: meta.latest }
+    }
+  }
+  if (isAheadOfRegistry(cliVersion, meta.latest)) {
+    return {
+      id: 'cli-version-current',
+      status: 'ok',
+      message:
+        `CLI ${cliVersion} is ahead of the published ${meta.latest} — ` +
+        `a local build, or a release still propagating.`,
+      data: { cliVersion, latest: meta.latest }
+    }
+  }
+
+  const publishedAt = meta.versions[meta.latest]?.createdAt
+  const heldBack = isWithinDependencyAgeWindow(publishedAt)
+  const lockPath = join(homedir(), '.deno', 'bin', '.skmtc', 'deno.lock')
+  const reinstall = existsSync(lockPath)
+    ? `rm -f ${lockPath} && ${toCliInstallCommand()}`
+    : toCliInstallCommand()
+
+  return {
+    id: 'cli-version-current',
+    status: 'warning',
+    message: `CLI ${cliVersion} is behind the latest published @skmtc/cli ${meta.latest}.`,
+    hint: heldBack
+      ? `${meta.latest} was published ${formatHours(publishedAt)} ago, inside ` +
+        `Deno's ${DEPENDENCY_AGE_WINDOW_HOURS}h minimum-dependency-age window: ` +
+        `an install without \`${DEPENDENCY_AGE_FLAG}\` silently resolves an ` +
+        `older release instead and reports success. Run: \`${reinstall}\`.`
+      : `Run: \`${reinstall}\`.`,
+    data: { cliVersion, latest: meta.latest, publishedAt, heldBack }
+  }
+}
+
+/** Is the running version newer than the registry's latest — a local
+ *  build, or a release still propagating? An unparseable version is
+ *  treated as not ahead, so the check errs toward reporting a
+ *  difference rather than hiding one. */
+const isAheadOfRegistry = (cliVersion: string, latest: string): boolean => {
+  try {
+    return greaterThan(parseSemver(cliVersion), parseSemver(latest))
+  } catch {
+    return false
+  }
+}
+
+/** "3 hours" / "45 minutes" — enough to see whether the wait is nearly
+ *  over without printing a timestamp the reader has to subtract. */
+const formatHours = (publishedAt: string | undefined): string => {
+  const hours = toHoursSincePublish(publishedAt)
+  if (hours === undefined) return 'an unknown time'
+  if (hours < 1) return `${Math.max(1, Math.round(hours * 60))} minutes`
+  return `${Math.round(hours)} hours`
+}
+
+/**
  * Friction #16: the lockfile of the globally-installed `skmtc` CLI,
  * at `~/.deno/bin/.skmtc/deno.lock`, silently pins an old CLI/core
  * version even when `deno install -f` is rerun. We can't fix Deno's
@@ -147,7 +254,10 @@ const checkInstallLockfile = (): Check => {
       hint:
         `If enrichment leaves arrive as \`{}\` inside generators, your installed ` +
         `CLI might be pinned to an old @skmtc/core. Remediation: ` +
-        `\`rm -f ${lockPath} && deno install -gAf --unstable-worker-options --name skmtc jsr:@skmtc/cli\`. ` +
+        `\`rm -f ${lockPath} && ${toCliInstallCommand()}\`. ` +
+        `The age flag is part of the remediation, not optional: clearing the ` +
+        `lock alone re-resolves to the same older version whenever the ` +
+        `newest release is under ${DEPENDENCY_AGE_WINDOW_HOURS}h old. ` +
         `See friction #16 in skmtc-cli skill §7.`,
       data: { lockPath, cliVersion, coreVersion }
     }

--- a/deno/cli/lib/doctor-headless.ts
+++ b/deno/cli/lib/doctor-headless.ts
@@ -34,6 +34,7 @@ import { parse as parseSemver } from '@std/semver/parse'
 import {
   DEPENDENCY_AGE_FLAG,
   DEPENDENCY_AGE_WINDOW_HOURS,
+  enforcesDependencyAgeGate,
   isWithinDependencyAgeWindow,
   toCliInstallCommand,
   toHoursSincePublish
@@ -87,6 +88,12 @@ type RunDoctorArgs = {
    * registry's answer instead of reaching for it.
    */
   getLatestCliMeta?: () => Promise<JsrPkgMetaVersions | undefined>
+  /**
+   * Don't look the registry up at all (`--offline`). Distinct from the
+   * lookup failing: doctor's value is naming an accurate cause, so a run
+   * that never asked must not report a connectivity problem.
+   */
+  offline?: boolean
 }
 
 export const runDoctor = async ({
@@ -94,14 +101,17 @@ export const runDoctor = async ({
   denoVersion = Deno.version.deno,
   // `scopeName` carries its `@` — `toJsrUrl` joins the parts verbatim.
   getLatestCliMeta = () =>
-    Jsr.tryGetLatestMeta({ scopeName: '@skmtc', packageName: 'cli' })
+    Jsr.tryGetLatestMeta({ scopeName: '@skmtc', packageName: 'cli' }),
+  offline = false
 }: RunDoctorArgs): Promise<DoctorResult> => {
   const skmtcRootPath = toRootPath()
   const globalStateDir = join(homedir(), '.skmtc')
   const projects = listProjects(skmtcRootPath)
   const checks: Check[] = []
 
-  checks.push(await checkCliVersionCurrent(cliVersion, getLatestCliMeta))
+  checks.push(
+    await checkCliVersionCurrent({ cliVersion, denoVersion, getLatestCliMeta, offline })
+  )
   checks.push(checkInstallLockfile())
   checks.push(checkDenoVersion(denoVersion))
   checks.push(checkHubAuth())
@@ -140,22 +150,43 @@ const aggregate = (checks: Check[]): CheckStatus => {
   return 'ok'
 }
 
+type CheckCliVersionArgs = {
+  cliVersion: string
+  denoVersion: string
+  getLatestCliMeta: () => Promise<JsrPkgMetaVersions | undefined>
+  offline: boolean
+}
+
 /**
  * Is the running CLI the newest published one? Doctor otherwise reports
  * the version it is running as a fact with nothing to compare it to, so
  * "you are a release behind" stays invisible — and the way you most often
- * end up there is silent: an unpinned `deno install` inside Deno's
- * dependency-age window resolves the PREVIOUS version and reports
- * success. When that is the situation, say so and name the flag.
+ * end up there is silent: on a Deno that enforces the dependency-age
+ * gate, an unpinned `deno install` inside the window resolves the
+ * PREVIOUS version and reports success. When that is the situation, say
+ * so and name the flag.
  *
- * Diagnostic only: unreachable registry, missing publish time or a local
- * build ahead of the registry all degrade to `skipped`/`ok` rather than
- * failing the command.
+ * Diagnostic only: `--offline`, an unreachable registry, a missing
+ * publish time or a local build ahead of the registry all degrade to
+ * `skipped`/`ok` rather than failing the command. The `--offline` and
+ * unreachable cases carry DIFFERENT messages — a run that never asked
+ * must not report a connectivity problem.
  */
-const checkCliVersionCurrent = async (
-  cliVersion: string,
-  getLatestCliMeta: () => Promise<JsrPkgMetaVersions | undefined>
-): Promise<Check> => {
+const checkCliVersionCurrent = async ({
+  cliVersion,
+  denoVersion,
+  getLatestCliMeta,
+  offline
+}: CheckCliVersionArgs): Promise<Check> => {
+  if (offline) {
+    return {
+      id: 'cli-version-current',
+      status: 'skipped',
+      message:
+        `Skipped by --offline; the running CLI ${cliVersion} was not compared ` +
+        `against ${getJsrBaseUrl()}.`
+    }
+  }
   // Belt and braces with `tryGetLatestMeta`'s shape check: doctor is the
   // command you run when everything else is broken, so a registry answer
   // it cannot read has to become a `skipped` line, never a throw that
@@ -188,11 +219,16 @@ const checkCliVersionCurrent = async (
   }
 
   const publishedAt = meta.versions?.[meta.latest]?.createdAt
-  const heldBack = isWithinDependencyAgeWindow(publishedAt)
+  // Both halves have to hold: the release is young enough to be held
+  // back, AND the running Deno is one that enforces the holdback. On
+  // Deno < 2.9 nothing is gated, so the explanation would name a cause
+  // that does not exist — and the command below correctly omits a flag
+  // the prose would be telling the reader to use.
+  const heldBack =
+    enforcesDependencyAgeGate(denoVersion) && isWithinDependencyAgeWindow(publishedAt)
   const lockPath = join(homedir(), '.deno', 'bin', '.skmtc', 'deno.lock')
-  const reinstall = existsSync(lockPath)
-    ? `rm -f ${lockPath} && ${toCliInstallCommand()}`
-    : toCliInstallCommand()
+  const install = toCliInstallCommand(denoVersion)
+  const reinstall = existsSync(lockPath) ? `rm -f ${lockPath} && ${install}` : install
 
   return {
     id: 'cli-version-current',

--- a/deno/cli/lib/jsr.ts
+++ b/deno/cli/lib/jsr.ts
@@ -26,9 +26,14 @@ export type JsrPkgManifestFile = {
   readonly checksum: string
 }
 
-export type JsrPkgMetaVersion = { yanked?: boolean }
+export type JsrPkgMetaVersion = {
+  yanked?: boolean
+  /** Publish time, as JSR reports it. Optional — a registry mirror need
+   *  not carry it, and callers must degrade without it. */
+  createdAt?: string
+}
 
-type JsrPkgMetaVersions = {
+export type JsrPkgMetaVersions = {
   scope: string
   name: string
   latest: string
@@ -68,6 +73,29 @@ export class Jsr {
     const meta: JsrPkgMetaVersions = await res.json()
 
     return meta
+  }
+
+  /**
+   * {@link getLatestMeta} for a caller that must not fail or print when
+   * the registry is unreachable — a diagnostic, not a step in a workflow.
+   * Returns `undefined` on any network, status or parse failure, and
+   * bounds the wait so an offline machine does not stall the command.
+   */
+  static async tryGetLatestMeta({
+    scopeName,
+    packageName,
+    timeoutMs = 2_000
+  }: GetLatestMetaArgs & { timeoutMs?: number }): Promise<
+    JsrPkgMetaVersions | undefined
+  > {
+    try {
+      const url = toJsrUrl(`${scopeName}/${packageName}/meta.json`)
+      const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
+      if (!res.ok) return undefined
+      return await res.json()
+    } catch {
+      return undefined
+    }
   }
 
   static async getLatestVersion({

--- a/deno/cli/lib/jsr.ts
+++ b/deno/cli/lib/jsr.ts
@@ -115,7 +115,13 @@ export class Jsr {
     try {
       const url = toJsrUrl(`${scopeName}/${packageName}/meta.json`)
       const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
-      if (!res.ok) return undefined
+      if (!res.ok) {
+        // Drain the body so the connection is released — a mirror that
+        // 404s the package, or an incident at jsr.io, would otherwise
+        // leak one per `skmtc doctor` run.
+        await res.body?.cancel()
+        return undefined
+      }
       const parsed = v.safeParse(jsrPkgMetaVersionsSchema, await res.json())
       return parsed.success ? parsed.output : undefined
     } catch {

--- a/deno/cli/lib/jsr.ts
+++ b/deno/cli/lib/jsr.ts
@@ -3,6 +3,7 @@ import { maxSatisfying } from '@std/semver/max-satisfying'
 import { parse } from '@std/semver/parse'
 import { parseRange } from '@std/semver/parse-range'
 import { toJsrUrl } from '@/lib/jsr-registry.ts'
+import * as v from 'valibot'
 
 export type Pkg = {
   name: string
@@ -42,6 +43,23 @@ export type JsrPkgMetaVersions = {
   }
 }
 
+/** Runtime shape for {@link Jsr.tryGetLatestMeta} — `latest` is a string
+ *  and `versions` a map, or the answer is not a package meta document.
+ *  (A package whose versions are all yanked reports `latest: null`; that
+ *  fails here, which is the right answer for a version comparison.) */
+const jsrPkgMetaVersionsSchema = v.object({
+  scope: v.string(),
+  name: v.string(),
+  latest: v.string(),
+  versions: v.record(
+    v.string(),
+    v.object({
+      yanked: v.optional(v.boolean()),
+      createdAt: v.optional(v.string())
+    })
+  )
+})
+
 type GetLatestMetaArgs = {
   scopeName: string
   packageName: string
@@ -78,8 +96,14 @@ export class Jsr {
   /**
    * {@link getLatestMeta} for a caller that must not fail or print when
    * the registry is unreachable — a diagnostic, not a step in a workflow.
-   * Returns `undefined` on any network, status or parse failure, and
-   * bounds the wait so an offline machine does not stall the command.
+   * Returns `undefined` on any network, status, parse OR SHAPE failure,
+   * and bounds the wait so an offline machine does not stall the command.
+   *
+   * The shape check is the point of the separate method: `JSR_URL` can
+   * name a mirror or proxy, and one answering 200 with a JSON error
+   * object would otherwise hand the caller a `JsrPkgMetaVersions` whose
+   * `versions` is undefined — a crash at the use site, in a diagnostic
+   * that exists for when everything else is already broken.
    */
   static async tryGetLatestMeta({
     scopeName,
@@ -92,7 +116,8 @@ export class Jsr {
       const url = toJsrUrl(`${scopeName}/${packageName}/meta.json`)
       const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
       if (!res.ok) return undefined
-      return await res.json()
+      const parsed = v.safeParse(jsrPkgMetaVersionsSchema, await res.json())
+      return parsed.success ? parsed.output : undefined
     } catch {
       return undefined
     }

--- a/deno/cli/lib/publish-headless.ts
+++ b/deno/cli/lib/publish-headless.ts
@@ -32,6 +32,7 @@ import { join } from '@std/path/join'
 import type { SkmtcRoot } from '@/lib/skmtc-root.ts'
 import { collectSourceFiles, type SourceFile } from '@/lib/source-upload.ts'
 import { parseScopedName } from '@/lib/scoped-name.ts'
+import { toProjectInstallCommand } from '@/lib/dependency-age.ts'
 
 type PublishHeadlessArgs = {
   skmtcRoot: SkmtcRoot
@@ -293,8 +294,8 @@ export const publishHeadless = async ({
     // the lockfile, so publishing without one always 422s server-side.
     if (!files.some(file => file.path === 'deno.lock')) {
       throw new Error(
-        'deno.lock not found in the upload — the hub requires it. Run `deno install` in the ' +
-          'project (and make sure .skmtcignore does not exclude deno.lock), then re-publish.'
+        `deno.lock not found in the upload — the hub requires it. Run \`${toProjectInstallCommand()}\` ` +
+          'in the project (and make sure .skmtcignore does not exclude deno.lock), then re-publish.'
       )
     }
   } catch (err) {

--- a/deno/cli/mod.ts
+++ b/deno/cli/mod.ts
@@ -7,9 +7,13 @@ import denoJson from './deno.json' with { type: 'json' }
 //   dsn: 'https://9904234a7aabfeff2145622ccb0824e3@o4508018789646336.ingest.de.sentry.io/4509532871262288'
 // })
 
-// Commands that never touch JSR can be allow-listed here so they keep
-// working offline. Adding new commands defaults to "requires registry"
-// — make it an explicit decision when something can skip the check.
+// Commands that don't need JSR to do their job are allow-listed here so
+// they keep working offline. Adding new commands defaults to "requires
+// registry" — make it an explicit decision when something can skip the
+// check. `doctor` is a partial exception: its `cli-version-current`
+// check asks the registry which CLI version is current, but the lookup
+// is bounded and degrades to `skipped`, so doctor still reports every
+// other check offline (`--offline` skips the lookup outright).
 const COMMANDS_THAT_SKIP_REGISTRY_CHECK = new Set<string>([
   'generate',
   'dev',
@@ -473,9 +477,13 @@ const run = async () => {
   const doctorCommand = new Command()
     .description(getCommandDescriptor('doctor').description)
     .option('--json', 'Emit structured JSON output.')
-    .action(async ({ json }) => {
+    .option(
+      '--offline',
+      'Skip the registry lookup behind `cli-version-current`, which reports `skipped` instead.'
+    )
+    .action(async ({ json, offline }) => {
       const { renderDoctor } = await import('@/commands/doctor.ts')
-      await renderDoctor({ jsonFlag: json })
+      await renderDoctor({ jsonFlag: json, offlineFlag: offline })
     })
 
   const agentContextCommand = new Command()

--- a/deno/docs/reference/cli/doctor.md
+++ b/deno/docs/reference/cli/doctor.md
@@ -12,7 +12,7 @@ before `generate`, or when diagnosing a confusing failure.
 ## Synopsis
 
 ```
-skmtc doctor [--json]
+skmtc doctor [--json] [--offline]
 ```
 
 The command takes no positional arguments — it always operates on
@@ -29,6 +29,15 @@ a human-readable check-by-check report.
 by agents — the structured form is designed for programmatic
 remediation.
 
+### `--offline`
+
+Skip the registry lookup behind `cli-version-current`, which then
+reports `skipped`. Every other check is filesystem-only, so this makes
+the whole command network-free. Without it the lookup is bounded at 2
+seconds and degrades to `skipped` anyway — use `--offline` when a run
+already knows it has no network and does not want to spend the timeout
+being told so.
+
 ## Behavior
 
 ### Checks performed
@@ -36,14 +45,16 @@ remediation.
 Each check has an ID, a target (workspace or project), and a
 pass/fail result. Failures include a remediation hint.
 
-There are exactly **six** check IDs (the full surface is enumerated
-in `cli/lib/doctor-headless.ts` — every `id:` literal). Workspace-scoped
-checks plus per-project checks:
+The full surface is enumerated in `cli/lib/doctor-headless.ts` and
+`cli/lib/doctor-anchors.ts` — every `id:` literal. A test asserts that
+each one appears in this table, so a check added without a row here
+fails the suite. Workspace-scoped checks plus per-project checks:
 
 #### Workspace-level checks
 
 | Check ID | What it verifies |
 |---|---|
+| `cli-version-current` | The running CLI against the newest published `@skmtc/cli`. The only check that reaches the network (2s bound; `skipped` when unreachable, and `skmtc doctor --offline` skips the lookup outright). When the newest release is still inside Deno's 24h minimum-dependency-age window, the hint says so — a reinstall without `--minimum-dependency-age=0` silently resolves an older release. |
 | `install-lockfile` | The installed CLI's `deno.lock` (under `~/.deno/bin/.skmtc/`) exists and pins `@skmtc/cli` and `@skmtc/core` to compatible versions |
 | `deno-version` | The running Deno satisfies the `>= 2.4.0` floor for the esbuild-based `deno bundle` |
 | `hub-auth` | `~/.skmtc/auth.json` (written by `skmtc login`) parses to the expected `{ host, token }` shape. Offline only — no network call; `skipped` when not logged in, `warning` with a logout/login hint when malformed. Reports at most the token's last 4 characters. |
@@ -60,6 +71,10 @@ For each project under `.skmtc/<project>/`:
 | `project-bundle/<project>` | If the project has at least one *local* generator import, `bundle.js` exists. Pure JSR projects return `ok` with `hasLocalGenerator: false` (no bundle needed). |
 | `project-manifest/<project>` | `manifest.json` (if present) parses and matches the schema the current `@skmtc/core` expects |
 | `project-enrichments/<project>` | The last generate's `manifest.enrichmentWarnings` has no `warning`-level entries — dead enrichment config (typo'd generator ids, paths, methods, model names; schema-dropped keys) surfaces here between runs. `info` entries (enrichments on deliberately skipped items) keep the check `ok`. Skips when the manifest is missing, broken (deferred to `project-manifest`), or written by a core older than 0.28.0. |
+| `project-worker-pin/<project>` | The project pins `@skmtc/worker` — the generated `worker.ts` needs it to bundle. `skipped` before the first `skmtc bundle` writes `worker.ts`; `warning` with a `skmtc bundle` hint when the pin is missing. |
+| `anchors-config/<project>` | `client.json#settings.anchors` parses and reports whether gen-maps are enabled (opt-in via `settings.anchors.enabled`) and where they are written. |
+| `anchors-coverage/<project>` | Share of the manifest's files that have an attribution sidecar; `warning` below the coverage threshold. `skipped` when anchors are disabled or the project has not generated yet. |
+| `anchors-staleness/<project>` | Sidecars on disk are current for the last run. `skipped` when anchors are disabled or no manifest exists. |
 
 The exact set of checks evolves over time. Run `skmtc doctor` itself
 to see the current battery.

--- a/deno/docs/skills/skmtc-cli-v2/reference.md
+++ b/deno/docs/skills/skmtc-cli-v2/reference.md
@@ -394,6 +394,7 @@ reasoning about a specific check without running it.
 
 | Check id | What it inspects |
 |---|---|
+| `cli-version-current` | The running CLI vs the newest published `@skmtc/cli` — the only check that reaches the network (2s bound, `skipped` when unreachable, `--offline` skips it). Names Deno's 24h minimum-dependency-age window when the newest release is still inside it, since a reinstall without `--minimum-dependency-age=0` silently resolves an older one |
 | `install-lockfile` | `~/.deno/bin/.skmtc/deno.lock` — the installed CLI's version pin of `@skmtc/cli` and `@skmtc/core` |
 | `deno-version` | Running Deno is ≥ 2.4.0 — the floor for the esbuild-based `deno bundle` |
 | `hub-auth` | `~/.skmtc/auth.json` parses to `{ host, token }` — offline only; `skipped` when not logged in, `warning` + logout/login hint when malformed; never reports more than the token's last 4 chars |
@@ -401,5 +402,9 @@ reasoning about a specific check without running it.
 | `project-base-path/<project>` | `client.json#settings.basePath` present and relative |
 | `project-core-pin/<project>` | Project's `@skmtc/core` pin matches the CLI's major.minor |
 | `project-bundle/<project>` | `bundle.js` exists — every project (remote-only included) generates from it; warning with a `skmtc bundle` hint when missing |
+| `project-enrichments/<project>` | Last generate's `manifest.enrichmentWarnings` has no `warning`-level entries — dead enrichment config (typo'd generator id, path, method or model name) surfaces here between runs; `info` entries keep it `ok` |
 | `project-worker-pin/<project>` | If `worker.ts` exists, `@skmtc/worker` is pinned (the generated worker imports it); ok-noop before the first bundle |
 | `project-manifest/<project>` | `manifest.json` matches the current `@skmtc/core` schema |
+| `anchors-config/<project>` | `client.json#settings.anchors` shape; gen-maps are opt-in via `settings.anchors.enabled` |
+| `anchors-coverage/<project>` | Share of manifest files carrying an attribution sidecar; `warning` below threshold |
+| `anchors-staleness/<project>` | Sidecars on disk are current for the last run |

--- a/deno/docs/skills/skmtc-cli/SKILL.md
+++ b/deno/docs/skills/skmtc-cli/SKILL.md
@@ -196,6 +196,7 @@ Known check ids:
 
 | Check id | What it inspects |
 |---|---|
+| `cli-version-current` | The running CLI vs the newest published `@skmtc/cli` — the only check that reaches the network (2s bound, `skipped` when unreachable, `--offline` skips it). Names Deno's 24h minimum-dependency-age window when the newest release is still inside it, since a reinstall without `--minimum-dependency-age=0` silently resolves an older one |
 | `install-lockfile` | `~/.deno/bin/.skmtc/deno.lock` — the installed CLI's version pin of `@skmtc/cli` and `@skmtc/core` |
 | `deno-version` | Running Deno is ≥ 2.4.0 — the floor for the esbuild-based `deno bundle` |
 | `hub-auth` | `~/.skmtc/auth.json` parses to `{ host, token }` — offline only; `skipped` when not logged in, `warning` + logout/login hint when malformed; never reports more than the token's last 4 chars |
@@ -203,8 +204,12 @@ Known check ids:
 | `project-base-path/<project>` | `client.json#settings.basePath` present and relative |
 | `project-core-pin/<project>` | Project's `@skmtc/core` pin matches the CLI's major.minor |
 | `project-bundle/<project>` | `bundle.js` exists — every project (remote-only included) generates from it; warning with a `skmtc bundle` hint when missing |
+| `project-enrichments/<project>` | Last generate's `manifest.enrichmentWarnings` has no `warning`-level entries — dead enrichment config (typo'd generator id, path, method or model name) surfaces here between runs; `info` entries keep it `ok` |
 | `project-worker-pin/<project>` | If `worker.ts` exists, `@skmtc/worker` is pinned (the generated worker imports it); ok-noop before the first bundle |
 | `project-manifest/<project>` | `manifest.json` matches the current `@skmtc/core` schema |
+| `anchors-config/<project>` | `client.json#settings.anchors` shape; gen-maps are opt-in via `settings.anchors.enabled` |
+| `anchors-coverage/<project>` | Share of manifest files carrying an attribution sidecar; `warning` below threshold |
+| `anchors-staleness/<project>` | Sidecars on disk are current for the last run |
 ## 6. The client.json shape
 
 `.skmtc/<project>/.settings/client.json` — top level is

--- a/deno/docs/using/how-to/debug-failing-generation.md
+++ b/deno/docs/using/how-to/debug-failing-generation.md
@@ -102,8 +102,17 @@ Fix: reinstall the CLI with the flag. The `curl` installer
 with a bare `deno install`, overwrite the binary:
 
 ```bash
-deno install -gAf --unstable-worker-options --name skmtc jsr:@skmtc/cli
+deno install -gAf --minimum-dependency-age=0 --unstable-worker-options \
+  --name skmtc jsr:@skmtc/cli
 ```
+
+`--minimum-dependency-age=0` is not optional. Deno holds back any version
+published in the last 24 hours, and `@skmtc/*` publishes on every merge —
+so without it an unpinned install resolves the *previous* CLI, reports
+success, and leaves you on the version you were trying to replace. If a
+stale `~/.deno/bin/.skmtc/deno.lock` is also pinning that version, delete
+it first (`rm -f ~/.deno/bin/.skmtc/deno.lock`). `skmtc doctor` reports
+both conditions.
 
 #### No output for an operation
 

--- a/deno/docs/using/how-to/debug-failing-generation.md
+++ b/deno/docs/using/how-to/debug-failing-generation.md
@@ -114,10 +114,12 @@ replace. If a stale `~/.deno/bin/.skmtc/deno.lock` is also pinning that
 version, delete it first (`rm -f ~/.deno/bin/.skmtc/deno.lock`).
 `skmtc doctor` reports both conditions.
 
-On Deno ≤ 2.5, drop the flag — the gate doesn't exist there and the
+On Deno ≤ 2.5.4, drop the flag — the gate doesn't exist there and the
 argument is unknown, so the install fails with
-`error: unexpected argument '--minimum-dependency-age' found`. (The CLI
-does this for you wherever it builds the command itself.)
+`error: unexpected argument '--minimum-dependency-age' found`. The flag
+parses from 2.5.5 onward, where it is an accepted no-op until the gate
+itself arrives in 2.9. (The CLI does this for you wherever it builds the
+command itself.)
 
 #### No output for an operation
 

--- a/deno/docs/using/how-to/debug-failing-generation.md
+++ b/deno/docs/using/how-to/debug-failing-generation.md
@@ -106,13 +106,18 @@ deno install -gAf --minimum-dependency-age=0 --unstable-worker-options \
   --name skmtc jsr:@skmtc/cli
 ```
 
-`--minimum-dependency-age=0` is not optional. Deno holds back any version
-published in the last 24 hours, and `@skmtc/*` publishes on every merge —
-so without it an unpinned install resolves the *previous* CLI, reports
-success, and leaves you on the version you were trying to replace. If a
-stale `~/.deno/bin/.skmtc/deno.lock` is also pinning that version, delete
-it first (`rm -f ~/.deno/bin/.skmtc/deno.lock`). `skmtc doctor` reports
-both conditions.
+Deno holds back any version published in the last 24 hours, and
+`@skmtc/*` publishes on every merge — so without
+`--minimum-dependency-age=0` an unpinned install resolves the *previous*
+CLI, reports success, and leaves you on the version you were trying to
+replace. If a stale `~/.deno/bin/.skmtc/deno.lock` is also pinning that
+version, delete it first (`rm -f ~/.deno/bin/.skmtc/deno.lock`).
+`skmtc doctor` reports both conditions.
+
+On Deno ≤ 2.5, drop the flag — the gate doesn't exist there and the
+argument is unknown, so the install fails with
+`error: unexpected argument '--minimum-dependency-age' found`. (The CLI
+does this for you wherever it builds the command itself.)
 
 #### No output for an operation
 


### PR DESCRIPTION
## What

Deno ≥ 2.9 refuses to resolve a dependency version published in the last 24 hours. `@skmtc/*` publishes on every merge, so **every** release sits inside that window. The gate has three faces:

| resolution | symptom |
| --- | --- |
| exact pin (project `deno.json`, `deno bundle`) | hard error naming the policy on ≥ 2.9.3; `Do not know how to load path: deno:jsr:…` on 2.9.0–2.9.2 |
| unpinned (`deno install jsr:@skmtc/cli`) | **silent** — resolves the previous version, reports success |
| existing lockfile | keeps the older resolution; clearing the lock without the flag lands on it again |

Only the first was handled (`create-bundle.ts`). The silent one is the trap, and we hit it live: installing the CLI right after #107 merged reported success and left `skmtc` on 0.9.40, with `--version` truthfully reporting the older release.

### One source
`cli/lib/dependency-age.ts` holds the flag, the Deno 2.6 support floor, the 24h window, and the printed reinstall command.
- `deno bundle` had an inlined copy of the version gate; `debug-session.ts` had none. Both call `toDependencyAgeArgs()`.
- Every remediation the CLI prints is built from `toCliInstallCommand()`. Doctor's `install-lockfile` hint told the reader to clear the lock and reinstall **without** the flag — which re-resolves the same older version, i.e. the hint reproduced the bug it existed to fix.

### A check that names it
New `cli-version-current` doctor check compares the running CLI to the registry:

```
warning: CLI 0.9.40 is behind the latest published @skmtc/cli 0.9.41.
   hint: 0.9.41 was published 26 minutes ago, inside Deno's 24h minimum-dependency-age
   window: an install without `--minimum-dependency-age=0` silently resolves an older
   release instead and reports success. Run: `rm -f ~/.deno/bin/.skmtc/deno.lock && …`
```

Degrades to `skipped` when offline (2s timeout, never throws) and `ok` for a local build ahead of the registry. The lookup is injected, so the other 20 doctor tests stay off the network.

### Docs
The how-to's bare `deno install` gains the flag and the reason; `CLAUDE.md` documents all three signatures rather than only the bundle one.

## Deliberately not done

`skmtc init` does **not** write `"minimumDependencyAge": "0"` into the generated project `deno.json`. It would cover `deno` commands the *user* runs in the project (LSP, `deno check`, `deno task`), which the CLI's own flag cannot reach — but it disables a supply-chain protection across a file the user owns, including third-party generators. Flagged for a call rather than defaulted.

## Test plan

- 33 CLI tests covering the new module and check: support floor either side of Deno 2.6, printed command carries the flag, window boundary at 24h, and the check's five outcomes (current / behind-and-held-back / behind-past-window / ahead / offline / no publish time).
- Verified against the live registry, which the stubs cannot prove — it caught a real bug: `scopeName` carries its `@`, so the first version built `jsr.io/skmtc/cli/meta.json` and reported "unreachable" for every input.
- Full workspace gate: 3149 passed, 0 failed. `deno lint` clean.

## Version

0.9.42 — the cascade published 0.9.41 from main without committing the bump back, so both 0.9.40 and 0.9.41 are taken on the registry.