### PR TITLE
fix(parse): guard allOf ref expansion against cycles (partial — 4 of 8)

### DIFF
--- a/deno/core/parse/v3-0/_merge-all-of/merge-intersection.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge-intersection.ts
@@ -1,6 +1,7 @@
 import { decomposeIntersection } from './decompose-intersection.ts'
 import type { GetRefFn, SchemaOrReference, SchemaObject } from './types.ts'
 import { mergeSchemasOrRefs } from './merge.ts'
+import { isExpanding, whileExpanding } from './ref-expansion.ts'
 
 type MergeIntersectionArgs = {
   schema: SchemaObject
@@ -15,14 +16,21 @@ export const mergeIntersection = ({ schema, getRef }: MergeIntersectionArgs): Sc
     return decomposed[0]
   }
 
-  const dereffed = decomposed.map(decomposed => {
-    return '$ref' in decomposed ? getRef(decomposed) : decomposed
-  })
+  // Dereferencing happens INSIDE the reduce rather than in a prior `map` so
+  // each member stays paired with the `$ref` it came from: a ref counts as open
+  // for the whole of its own expansion, which is where the cycle would recur.
+  const result = decomposed.reduce<SchemaOrReference>((acc, member) => {
+    if (!('$ref' in member)) {
+      return mergeSchemasOrRefs(acc, member, getRef)
+    }
 
-  const result = dereffed.reduce<SchemaOrReference>((acc, decomposed) => {
-    const merged = mergeSchemasOrRefs(acc, decomposed, getRef)
+    // Already an ancestor of itself — expanding again cannot terminate, and it
+    // adds nothing the outer expansion has not already contributed.
+    if (isExpanding(member)) {
+      return acc
+    }
 
-    return merged
+    return whileExpanding(member, () => mergeSchemasOrRefs(acc, getRef(member), getRef))
   }, {} as SchemaObject)
 
   return result

--- a/deno/core/parse/v3-0/_merge-all-of/merge-union.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge-union.ts
@@ -3,6 +3,7 @@ import type { GetRefFn, SchemaOrReference, SchemaObject } from './types.ts'
 import { mergeSchemasOrRefs } from './merge.ts'
 import { crossProduct } from './cross-product.ts'
 import { isRef } from '@/helpers/refFns.ts'
+import { isExpanding, whileExpanding } from './ref-expansion.ts'
 type MergeUnionArgs = {
   schema: SchemaObject
   getRef: GetRefFn
@@ -25,14 +26,20 @@ export const mergeUnion = ({ schema, getRef, groupType }: MergeUnionArgs): Schem
   //   return result
   // }
 
-  const dereffed = decomposed.map(decomposed => {
-    return '$ref' in decomposed ? getRef(decomposed) : decomposed
-  })
+  // As in `mergeIntersection`: dereference inside the reduce so a member stays
+  // paired with its `$ref` for the duration of its own expansion.
+  const result = decomposed.reduce<SchemaObject>((acc, member) => {
+    if (!('$ref' in member)) {
+      return mergeCrossProduct({ first: acc, second: member, getRef, groupType })
+    }
 
-  const result = dereffed.reduce<SchemaObject>((acc, decomposed) => {
-    const merged = mergeCrossProduct({ first: acc, second: decomposed, getRef, groupType })
+    if (isExpanding(member)) {
+      return acc
+    }
 
-    return merged
+    return whileExpanding(member, () =>
+      mergeCrossProduct({ first: acc, second: getRef(member), getRef, groupType })
+    )
   }, {} as SchemaObject)
 
   const output = {

--- a/deno/core/parse/v3-0/_merge-all-of/merge.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge.ts
@@ -18,6 +18,7 @@ import { mergeIntersection } from './merge-intersection.ts'
 import { mergeCrossProduct } from './merge-union.ts'
 import { isEmpty } from '@/helpers/isEmpty.ts'
 import { isNullOnly, mergeNullOnly } from './nullable-merge.ts'
+import { isExpanding, whileExpanding } from './ref-expansion.ts'
 
 export const mergeSchemasOrRefs = (
   first: SchemaOrReference,
@@ -177,6 +178,21 @@ const typedMerge = (first: SchemaObject, second: SchemaObject, getRef: GetRefFn)
   throw new Error(`Cannot merge schemas with type "${first.type}" with type "${second.type}"`)
 }
 
+/**
+ * Dereference `ref` AND flatten any `allOf` in its body, both inside the
+ * caller's expansion window.
+ *
+ * `genericMerge` spreads its inputs, so an `allOf` left on a dereferenced body
+ * is copied into the merge result and escapes to be expanded later — by which
+ * time the ref is no longer marked open and the cycle guard cannot see it.
+ * Flattening here keeps every expansion inside the window that guards it.
+ */
+const expandRef = (ref: ReferenceObject, getRef: GetRefFn): SchemaOrReference => {
+  const body = getRef(ref)
+
+  return containsAllOf(body) ? mergeIntersection({ schema: body, getRef }) : body
+}
+
 const mergeWithRef = (
   first: SchemaOrReference,
   second: SchemaOrReference,
@@ -188,21 +204,47 @@ const mergeWithRef = (
         ...first,
         ...second
       }
-    } else {
-      return mergeSchemas(getRef(first), getRef(second), getRef)
     }
+
+    // A ref already open on this path contributes nothing further, so the merge
+    // degenerates to whichever side can still be expanded.
+    if (isExpanding(first)) {
+      return isExpanding(second) ? first : second
+    }
+
+    if (isExpanding(second)) {
+      return first
+    }
+
+    return whileExpanding(first, () =>
+      whileExpanding(second, () =>
+        mergeSchemasOrRefs(expandRef(first, getRef), expandRef(second, getRef), getRef)
+      )
+    )
   }
 
   if (isRef(first) && !isRef(second)) {
-    const merged = isEmpty(second) ? first : mergeSchemas(getRef(first), second, getRef)
+    if (isEmpty(second)) {
+      return first
+    }
 
-    return merged
+    if (isExpanding(first)) {
+      return second
+    }
+
+    return whileExpanding(first, () => mergeSchemasOrRefs(expandRef(first, getRef), second, getRef))
   }
 
   if (!isRef(first) && isRef(second)) {
-    const merged = isEmpty(first) ? second : mergeSchemas(first, getRef(second), getRef)
+    if (isEmpty(first)) {
+      return second
+    }
 
-    return merged
+    if (isExpanding(second)) {
+      return first
+    }
+
+    return whileExpanding(second, () => mergeSchemasOrRefs(first, expandRef(second, getRef), getRef))
   }
 
   throw new Error('Invalid input')

--- a/deno/core/parse/v3-0/_merge-all-of/ref-cycles.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/ref-cycles.test.ts
@@ -1,0 +1,177 @@
+import type { OpenAPIV3 } from 'openapi-types'
+import { assertEquals } from '@std/assert/equals'
+import { mergeIntersection } from './merge-intersection.ts'
+
+/**
+ * Cyclic `$ref`s reachable through `allOf` used to make the merge run forever.
+ *
+ * The shape below is the standard OpenAPI discriminated-union idiom, and it is
+ * what `buddy/buddy-api` publishes: a base schema `oneOf`-lists its variants,
+ * and every variant `allOf`-extends the base. Merging one variant inlines the
+ * base, whose `oneOf` cross-products back over every variant, each of which
+ * inlines the base again — so the work branches by the number of variants at
+ * every level and never bottoms out.
+ *
+ * Live effect before the guard: every docs operation page whose closure
+ * contained one of these died with `exceededMemory` (skmtc-hub#179).
+ *
+ * The rule is that a `$ref` already being expanded contributes nothing further
+ * — its constraints are, by construction, already in the accumulator from the
+ * level that started expanding it. Dropping it is the correct algebraic
+ * simplification, not a lossy bail-out.
+ */
+
+const variantNames = ['Ssh', 'Ftp', 'Git']
+
+const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+  Target: {
+    type: 'object',
+    properties: { id: { type: 'string' }, kind: { type: 'string' } },
+    required: ['id'],
+    discriminator: { propertyName: 'kind' },
+    oneOf: variantNames.map(name => ({ $ref: `#/components/schemas/Target${name}` }))
+  },
+  ...Object.fromEntries(
+    variantNames.map(name => [
+      `Target${name}`,
+      {
+        type: 'object',
+        allOf: [
+          { $ref: '#/components/schemas/Target' },
+          { type: 'object', properties: { [name.toLowerCase()]: { type: 'string' } } }
+        ]
+      } satisfies OpenAPIV3.SchemaObject
+    ])
+  )
+}
+
+const getRef = (ref: OpenAPIV3.ReferenceObject): OpenAPIV3.SchemaObject => {
+  const name = ref.$ref.split('/').at(-1) ?? ''
+  const schema = schemas[name]
+
+  if (!schema) {
+    throw new Error(`No schema for ${ref.$ref}`)
+  }
+
+  return schema
+}
+
+Deno.test('mergeIntersection terminates on a variant that allOf-extends its own union base', () => {
+  // Termination is the point: unguarded this never returned.
+  const merged = mergeIntersection({ schema: schemas.TargetGit, getRef }) as OpenAPIV3.SchemaObject
+
+  // It resolves to the union of the variants, and each member carries the
+  // extending variant's own contribution.
+  assertEquals(Array.isArray(merged.oneOf), true)
+
+  const members = (merged.oneOf ?? []) as OpenAPIV3.SchemaObject[]
+
+  assertEquals(members.length > 0, true)
+  assertEquals(
+    members.every(member => Object.keys(member.properties ?? {}).includes('git')),
+    true
+  )
+})
+
+Deno.test('KNOWN GAP: the union base loses its own properties (issue #111, change 1)', () => {
+  // Not the cycle guard's doing — the same loss happens on an equivalent
+  // ACYCLIC schema. `mergeCrossProduct` replaces the union schema with its
+  // members and returns only `{ [groupType]: … }`, so `Target`'s own `id` /
+  // `kind` / `required` / `discriminator` never reach the result.
+  //
+  // This test pins the CURRENT (wrong) behaviour deliberately, so that fixing
+  // sibling-key preservation FAILS here and forces this file to be updated
+  // rather than silently drifting.
+  const merged = mergeIntersection({ schema: schemas.TargetGit, getRef }) as OpenAPIV3.SchemaObject
+  const members = (merged.oneOf ?? []) as OpenAPIV3.SchemaObject[]
+
+  const anyMemberHasBaseProperty = members.some(member =>
+    ['id', 'kind'].some(name => Object.keys(member.properties ?? {}).includes(name))
+  )
+
+  assertEquals(anyMemberHasBaseProperty, false)
+  assertEquals('discriminator' in merged, false)
+})
+
+Deno.test('mergeIntersection terminates on a two-schema ref cycle', () => {
+  // The smaller shape: A allOf-extends B, B allOf-extends A. No union, so no
+  // branching — this one would recurse forever rather than explode.
+  const pair: Record<string, OpenAPIV3.SchemaObject> = {
+    A: {
+      type: 'object',
+      allOf: [
+        { $ref: '#/components/schemas/B' },
+        { type: 'object', properties: { a: { type: 'string' } } }
+      ]
+    },
+    B: {
+      type: 'object',
+      allOf: [
+        { $ref: '#/components/schemas/A' },
+        { type: 'object', properties: { b: { type: 'string' } } }
+      ]
+    }
+  }
+
+  const getPairRef = (ref: OpenAPIV3.ReferenceObject): OpenAPIV3.SchemaObject => {
+    const schema = pair[ref.$ref.split('/').at(-1) ?? '']
+
+    if (!schema) {
+      throw new Error(`No schema for ${ref.$ref}`)
+    }
+
+    return schema
+  }
+
+  const merged = mergeIntersection({ schema: pair.A, getRef: getPairRef })
+  const properties = Object.keys((merged as OpenAPIV3.SchemaObject).properties ?? {})
+
+  assertEquals(properties.includes('a'), true)
+  assertEquals(properties.includes('b'), true)
+})
+
+Deno.test('a ref reused in sibling branches is still expanded twice', () => {
+  // A diamond is not a cycle. Guarding with one global seen-set instead of the
+  // expansion PATH would silently drop the second occurrence.
+  const diamond: Record<string, OpenAPIV3.SchemaObject> = {
+    Leaf: { type: 'object', properties: { marker: { type: 'string' } } },
+    Left: {
+      type: 'object',
+      allOf: [
+        { $ref: '#/components/schemas/Leaf' },
+        { type: 'object', properties: { left: { type: 'string' } } }
+      ]
+    },
+    Right: {
+      type: 'object',
+      allOf: [
+        { $ref: '#/components/schemas/Leaf' },
+        { type: 'object', properties: { right: { type: 'string' } } }
+      ]
+    },
+    Root: {
+      type: 'object',
+      allOf: [
+        { $ref: '#/components/schemas/Left' },
+        { $ref: '#/components/schemas/Right' }
+      ]
+    }
+  }
+
+  const getDiamondRef = (ref: OpenAPIV3.ReferenceObject): OpenAPIV3.SchemaObject => {
+    const schema = diamond[ref.$ref.split('/').at(-1) ?? '']
+
+    if (!schema) {
+      throw new Error(`No schema for ${ref.$ref}`)
+    }
+
+    return schema
+  }
+
+  const merged = mergeIntersection({ schema: diamond.Root, getRef: getDiamondRef })
+  const properties = Object.keys((merged as OpenAPIV3.SchemaObject).properties ?? {})
+
+  assertEquals(properties.includes('marker'), true)
+  assertEquals(properties.includes('left'), true)
+  assertEquals(properties.includes('right'), true)
+})

--- a/deno/core/parse/v3-0/_merge-all-of/ref-expansion.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/ref-expansion.ts
@@ -1,0 +1,38 @@
+import type { ReferenceObject } from './types.ts'
+
+/**
+ * The `$ref`s currently being expanded, innermost last.
+ *
+ * The `allOf` merge flattens composition by inlining referenced schemas. That
+ * only terminates while the reference graph is acyclic, and OpenAPI's standard
+ * discriminated-union idiom is not: a base schema `oneOf`-lists its variants
+ * and every variant `allOf`-extends the base, so expanding one variant reaches
+ * the base, whose `oneOf` reaches every variant, which reach the base again.
+ * Unguarded, that branches once per union member at every level and exhausts
+ * memory in seconds (issue #111).
+ *
+ * This is the EXPANSION PATH, not a set of everything ever seen. A schema
+ * referenced from two sibling `allOf` branches — a diamond — is not a cycle,
+ * and both branches must still expand it. Only a `$ref` that is already an
+ * ancestor of itself is cut.
+ *
+ * A module-level stack is sufficient because merging is synchronous and
+ * single-threaded: nothing else can interleave between a push and its pop, and
+ * `whileExpanding` pops in a `finally` so a thrown conflict (which the merge
+ * uses for control flow — see `mergeCrossProduct`) cannot leave the stack dirty.
+ */
+const expanding: string[] = []
+
+/** True when `ref` is already being expanded further up the current path. */
+export const isExpanding = (ref: ReferenceObject): boolean => expanding.includes(ref.$ref)
+
+/** Run `expand` with `ref` marked as open, popping it again on any exit path. */
+export const whileExpanding = <T>(ref: ReferenceObject, expand: () => T): T => {
+  expanding.push(ref.$ref)
+
+  try {
+    return expand()
+  } finally {
+    expanding.pop()
+  }
+}


### PR DESCRIPTION
Partial fix for #111. **Draft — does not close the issue.** It fixes 4 of the 8 known non-terminating specs; 4 still fail. Opening it because the mechanism is now understood and measured, and the remaining failures need a different approach than the one the issue proposes.

## What this does

Bounds `$ref` expansion in the `allOf` flattener by the **current expansion path**, so a ref that is already an ancestor of itself is not expanded again.

New `ref-expansion.ts` holds the open refs as a stack. Merging is synchronous and single-threaded, so a module-level stack is enough, and `whileExpanding` pops in a `finally` — the merge uses thrown conflicts for control flow (`mergeCrossProduct` catches and drops the pair), so an un-popped stack would silently corrupt later merges.

It is the **path**, not a global seen-set. A schema referenced from two sibling `allOf` branches is a diamond, not a cycle, and both branches must still expand it. Covered by a test.

Guarded at the three expansion sites: `merge-intersection.ts` (`allOf` members), `merge-union.ts` (`oneOf`/`anyOf` members), `merge.ts` (`mergeWithRef`, both sides).

## The part the issue got wrong

The guard alone did not work, and the reason is worth recording.

`genericMerge` does `{ ...first, ...second }`. An `allOf` left on a dereferenced body is therefore **copied into the merge result** and escapes the expansion window. It gets flattened later — by which time the ref is no longer marked open and the guard cannot see it. A dynamic-extent guard cannot bound an expansion that is deferred through data.

`expandRef` closes that: it dereferences **and** flattens any `allOf` in the body inside the window that guards it, so no unexpanded `allOf` leaks out. On the synthetic reproducer this took expansion from unbounded to **4** `getRef` calls.

## Measured

Against the 2,123-spec local corpus (`skmtc-catalog-seed` + `typescript-sdk-corpus`):

| spec | before | after |
|---|---|---|
| `docs-cortex-io` | hangs | **76 operations, 58 ms** |
| `docs-verifone-com` | hangs | **53 operations, 77 ms** |
| `docs-kameleoon-com` | hangs | **176 operations, 44 ms** |
| `qbusiness` | hangs | **80 operations, 9,544 ms** ⚠️ |
| `docs-cerc-com` | hangs | still hangs |
| `docs-fourthwall-com` | hangs | still hangs |
| `amplifyuibuilder` | hangs | still hangs |
| `docs-wiremock-io` | OOM | still OOMs (4 GB heap, ~14 s) |

`qbusiness` parses but at 9.5 s — likely still exponential, just bounded enough to finish. A Worker with a CPU ceiling would probably still lose it.

Regression gate — the existing merge suite is unchanged:

```
before: ok | 146 passed (43 steps) | 0 failed (750ms)
after:  ok | 150 passed (43 steps) | 0 failed (748ms)
```

150 = 146 pre-existing + 4 new. No existing test changed.

## What it deliberately does not do

The sibling-key loss from #111 is untouched: `mergeCrossProduct` still replaces a union schema with its members and returns only `{ [groupType]: … }`, so a base's own `properties` / `required` / `discriminator` are dropped. That happens on **acyclic** schemas too and is the more serious of the two defects, because it fails silently on APIs that work today.

A test pins the current (wrong) behaviour on purpose — `KNOWN GAP: the union base loses its own properties` — so fixing it **fails** here and forces this file to be updated rather than drifting.

## Not ready to merge

- 4 of 8 known-bad specs still fail, so #111 stays open regardless.
- The remaining failures have **not** been diagnosed. They may be the same escaping-`allOf` mechanism through a path `expandRef` misses, or something else. Assuming the former without measuring would repeat the mistake that produced the first broken attempt.
- **The corpus was checked for termination, not for output equivalence.** The 2,108 specs that parsed before have not been diffed before/after. `expandRef` routes dereferenced bodies through `mergeSchemasOrRefs` instead of `mergeSchemas`, which is a real behaviour change on acyclic schemas — the existing 146 tests passing is reassuring but not sufficient. **This diff is the gate that should decide whether this lands.**
- No generator output has been regenerated or diffed.

## Verifying

```bash
cd deno/core && deno test --allow-all parse/v3-0/_merge-all-of/
```

Refs #111
