### PR TITLE
fix(core): cut $ref cycles when merging allOf/oneOf

### DIFF
--- a/deno/core/parse/v3-0/_merge-all-of/cycles.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/cycles.test.ts
@@ -1,0 +1,176 @@
+import type { OpenAPIV3 } from 'openapi-types'
+import { assertEquals } from '@std/assert/equals'
+import { assert } from '@std/assert'
+import { mergeIntersection } from './merge-intersection.ts'
+import type { GetRefFn } from './types.ts'
+
+/**
+ * Reference cycles through `allOf` / `oneOf`.
+ *
+ * The shape is buddy-api's, reduced: `Hub` carries a `oneOf` of variants and
+ * every variant is `allOf: [{$ref: Hub}, …]`. Expanding one variant used to
+ * re-expand every variant, each of which re-expanded the first — base-N growth
+ * with no bound. Parsing the real document never returned, and the operation
+ * pages built from it answered 503 while the isolate was killed.
+ *
+ * Two things keep it finite, and both are load-bearing:
+ *
+ *  - the path of `$ref`s being expanded, so a reference back into the path is
+ *    left as a reference instead of inlined; and
+ *  - `mergeWithRef` routing resolved schemas through `mergeSchemasOrRefs`
+ *    rather than `mergeSchemas`, so a referent's `allOf` is CONSUMED while that
+ *    path is still in hand. Without it the `allOf` survived into the merged
+ *    output and re-triggered expansion higher up the stack, where the path had
+ *    been left behind — the cycle marker is scoped to the descent, but the data
+ *    escapes upward.
+ *
+ * These tests fail by hanging or exhausting the stack rather than by asserting,
+ * so they are kept small enough to fail fast.
+ */
+
+const toGetRef = (schemas: Record<string, OpenAPIV3.SchemaObject>): GetRefFn =>
+  (({ $ref }: OpenAPIV3.ReferenceObject) => {
+    const name = $ref.split('/').pop() ?? ''
+    const schema = schemas[name]
+
+    if (!schema) {
+      throw new Error(`Unknown ref: ${$ref}`)
+    }
+
+    return schema
+  }) as GetRefFn
+
+const ref = (name: string): OpenAPIV3.ReferenceObject => ({
+  $ref: `#/components/schemas/${name}`
+})
+
+/** `Hub` + `count` variants, each `allOf: [{$ref: Hub}, {own property}]`. */
+const hubAndVariants = (count: number): Record<string, OpenAPIV3.SchemaObject> => {
+  const names = Array.from({ length: count }, (_, index) => `Variant${index}`)
+
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Hub: {
+      type: 'object',
+      required: ['kind'],
+      properties: { kind: { type: 'string' } },
+      oneOf: names.map(ref)
+    }
+  }
+
+  names.forEach((name, index) => {
+    schemas[name] = {
+      type: 'object',
+      allOf: [ref('Hub'), { type: 'object', properties: { [`field${index}`]: { type: 'string' } } }]
+    }
+  })
+
+  return schemas
+}
+
+Deno.test('merge - a variant referencing its own hub terminates', () => {
+  const schemas = hubAndVariants(4)
+  const merged = mergeIntersection({ schema: schemas.Variant0, getRef: toGetRef(schemas) })
+
+  assert(!('$ref' in merged), 'expected a merged schema, not a bare reference')
+  assert(Array.isArray(merged.oneOf), 'expected the hub union to survive the merge')
+  assertEquals(merged.oneOf?.length, 4)
+})
+
+Deno.test('merge - cost stays linear as variants are added', () => {
+  // The defect was exponential in the variant count: 18 variants never
+  // finished. If growth returns, this does not fail politely — it hangs.
+  for (const count of [2, 4, 8, 18]) {
+    const schemas = hubAndVariants(count)
+    const merged = mergeIntersection({ schema: schemas.Variant0, getRef: toGetRef(schemas) })
+
+    assert(!('$ref' in merged))
+    assertEquals(merged.oneOf?.length, count)
+  }
+})
+
+Deno.test('merge - a directly self-referential allOf terminates', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Node: {
+      type: 'object',
+      allOf: [ref('Node'), { type: 'object', properties: { label: { type: 'string' } } }]
+    }
+  }
+
+  const merged = mergeIntersection({ schema: schemas.Node, getRef: toGetRef(schemas) })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.properties?.label, { type: 'string' })
+})
+
+Deno.test('merge - a mutual cycle between two schemas terminates', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Left: {
+      type: 'object',
+      allOf: [ref('Right'), { type: 'object', properties: { left: { type: 'string' } } }]
+    },
+    Right: {
+      type: 'object',
+      allOf: [ref('Left'), { type: 'object', properties: { right: { type: 'string' } } }]
+    }
+  }
+
+  const merged = mergeIntersection({ schema: schemas.Left, getRef: toGetRef(schemas) })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.properties?.right, { type: 'string' })
+})
+
+/**
+ * The dispatch change in `mergeWithRef` is what makes this pass: a referent
+ * carrying `allOf` is merged rather than having the `allOf` copied through into
+ * the output by `typedMerge`.
+ */
+Deno.test('merge - allOf on a referenced schema is consumed, not passed through', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Composed: {
+      allOf: [
+        { type: 'object', properties: { base: { type: 'string' } } },
+        { type: 'object', properties: { extra: { type: 'string' } } }
+      ]
+    }
+  }
+
+  const merged = mergeIntersection({
+    schema: {
+      allOf: [ref('Composed'), { type: 'object', properties: { own: { type: 'string' } } }]
+    },
+    getRef: toGetRef(schemas)
+  })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.allOf, undefined, 'allOf must not survive into the merged output')
+  assertEquals(merged.properties?.base, { type: 'string' })
+  assertEquals(merged.properties?.extra, { type: 'string' })
+  assertEquals(merged.properties?.own, { type: 'string' })
+})
+
+/**
+ * The guard is path-scoped. A global visited set would also stop the cycles
+ * above and would additionally leave the second sibling use of a shared schema
+ * unexpanded — changing output for acyclic documents, which is the one thing
+ * this must not do.
+ */
+Deno.test('merge - a schema used twice as a sibling expands in both places', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Address: { type: 'object', properties: { street: { type: 'string' } } }
+  }
+
+  const merged = mergeIntersection({
+    schema: {
+      allOf: [
+        { type: 'object', properties: { billing: ref('Address'), shipping: ref('Address') } },
+        { type: 'object', properties: { note: { type: 'string' } } }
+      ]
+    },
+    getRef: toGetRef(schemas)
+  })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.properties?.billing, { $ref: '#/components/schemas/Address' })
+  assertEquals(merged.properties?.shipping, { $ref: '#/components/schemas/Address' })
+})

--- a/deno/core/parse/v3-0/_merge-all-of/merge-intersection.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge-intersection.ts
@@ -1,6 +1,7 @@
 import { decomposeIntersection } from './decompose-intersection.ts'
 import type { GetRefFn, SchemaOrReference, SchemaObject } from './types.ts'
 import { mergeSchemasOrRefs } from './merge.ts'
+import { derefMember } from './ref-cycle.ts'
 
 type MergeIntersectionArgs = {
   schema: SchemaObject
@@ -15,14 +16,13 @@ export const mergeIntersection = ({ schema, getRef }: MergeIntersectionArgs): Sc
     return decomposed[0]
   }
 
-  const dereffed = decomposed.map(decomposed => {
-    return '$ref' in decomposed ? getRef(decomposed) : decomposed
-  })
+  // Each member is resolved with its own scoped resolver: one that records the
+  // member's `$ref` as being expanded, so anything beneath it pointing back
+  // here stays a reference rather than inlining forever.
+  const result = decomposed.reduce<SchemaOrReference>((acc, member) => {
+    const [value, scoped] = derefMember(member, getRef)
 
-  const result = dereffed.reduce<SchemaOrReference>((acc, decomposed) => {
-    const merged = mergeSchemasOrRefs(acc, decomposed, getRef)
-
-    return merged
+    return mergeSchemasOrRefs(acc, value, scoped)
   }, {} as SchemaObject)
 
   return result

--- a/deno/core/parse/v3-0/_merge-all-of/merge-union.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge-union.ts
@@ -2,6 +2,7 @@ import { decomposeUnion } from './decompose-union.ts'
 import type { GetRefFn, SchemaOrReference, SchemaObject } from './types.ts'
 import { mergeSchemasOrRefs } from './merge.ts'
 import { crossProduct } from './cross-product.ts'
+import { derefMember } from './ref-cycle.ts'
 import { isRef } from '@/helpers/refFns.ts'
 type MergeUnionArgs = {
   schema: SchemaObject
@@ -25,14 +26,13 @@ export const mergeUnion = ({ schema, getRef, groupType }: MergeUnionArgs): Schem
   //   return result
   // }
 
-  const dereffed = decomposed.map(decomposed => {
-    return '$ref' in decomposed ? getRef(decomposed) : decomposed
-  })
+  // Each member is resolved with its own scoped resolver: one that records the
+  // member's `$ref` as being expanded, so anything beneath it pointing back
+  // here stays a reference rather than inlining forever.
+  const result = decomposed.reduce<SchemaObject>((acc, member) => {
+    const [value, scoped] = derefMember(member, getRef)
 
-  const result = dereffed.reduce<SchemaObject>((acc, decomposed) => {
-    const merged = mergeCrossProduct({ first: acc, second: decomposed, getRef, groupType })
-
-    return merged
+    return mergeCrossProduct({ first: acc, second: value, getRef: scoped, groupType })
   }, {} as SchemaObject)
 
   const output = {
@@ -45,10 +45,29 @@ export const mergeUnion = ({ schema, getRef, groupType }: MergeUnionArgs): Schem
 }
 
 type MergeCrossProductArgs = {
-  first: SchemaObject
-  second: SchemaObject
+  first: SchemaOrReference
+  second: SchemaOrReference
   getRef: GetRefFn
   groupType: 'oneOf' | 'anyOf'
+}
+
+/**
+ * A schema's union members, or the schema itself when it is not a union. A
+ * reference is never a union — it is one member, resolved later. A member can
+ * now arrive as a `$ref`, because the cycle guard leaves a re-entered
+ * reference unresolved.
+ */
+const toGroup = (
+  schema: SchemaOrReference,
+  groupType: 'oneOf' | 'anyOf'
+): SchemaOrReference[] => {
+  if (isRef(schema)) {
+    return [schema]
+  }
+
+  const group = schema[groupType]
+
+  return Array.isArray(group) ? group : [schema]
 }
 
 export const mergeCrossProduct = ({
@@ -57,16 +76,22 @@ export const mergeCrossProduct = ({
   getRef,
   groupType
 }: MergeCrossProductArgs): SchemaObject => {
-  const firstGroup = Array.isArray(first[groupType]) ? first[groupType] : [first]
-  const secondGroup = Array.isArray(second[groupType]) ? second[groupType] : [second]
-
-  const mergedGroup = crossProduct(firstGroup, secondGroup)
+  const mergedGroup = crossProduct(toGroup(first, groupType), toGroup(second, groupType))
     .map(([firstItem, secondItem]) => {
       try {
         const result = mergeSchemasOrRefs(firstItem, secondItem, getRef)
 
         return result
-      } catch (_error) {
+      } catch (error) {
+        // Dropping a branch on a genuine conflict is the design: a cross
+        // product legitimately contains impossible combinations. A RangeError
+        // is not that — it is the recursion running away, and swallowing it
+        // turned a fast stack overflow into a very long exponential search
+        // with union members silently vanishing. Let it out.
+        if (error instanceof RangeError) {
+          throw error
+        }
+
         return undefined
       }
     })

--- a/deno/core/parse/v3-0/_merge-all-of/merge.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge.ts
@@ -1,5 +1,6 @@
 import { isRef } from '@/helpers/refFns.ts'
-import type { SchemaOrReference, ReferenceObject, SchemaObject, GetRefFn } from './types.ts'
+import type { SchemaOrReference, SchemaObject, GetRefFn } from './types.ts'
+import { closesCycle, enteringRef } from './ref-cycle.ts'
 import { checkTypeConflicts } from './check-type-conflicts.ts'
 import { checkReadOnlyWriteOnlyConflicts } from './check-read-only-write-only-conflicts.ts'
 import { checkFormatConflicts } from './check-format-conflicts.ts'
@@ -180,8 +181,47 @@ const typedMerge = (first: SchemaObject, second: SchemaObject, getRef: GetRefFn)
 const mergeWithRef = (
   first: SchemaOrReference,
   second: SchemaOrReference,
-  getRef: (ref: ReferenceObject) => SchemaObject
+  getRef: GetRefFn
 ): SchemaOrReference => {
+  // A side already being expanded above us closes a cycle, so it cannot be
+  // resolved again — there is no finite inlining.
+  //
+  // What happens next depends on the other side. If the other side is empty the
+  // reference SURVIVES, and `toSchemaV3` turns it into an `OasRef` that resolves
+  // lazily at use time. If the other side carries content we keep that content
+  // and DROP the reference — so any constraint the referent imposes is lost from
+  // this position. That is not obviously right: the alternative is to keep both
+  // (`{allOf: [first, second]}`), which preserves the constraint but re-enters
+  // this branch on the way back up and needs a termination argument of its own.
+  //
+  // Known limitation, tracked with the guard's scoping redesign (see the
+  // `expanding` set on `GetRefFn`): the path is a property of ONE position, but
+  // the resolver carrying it governs a two-sided merge, so a reference on the
+  // opposite side that happens to name the same schema is also treated as
+  // closing a cycle. Measured at 4 sites in 2 of 66 sampled specs.
+  if (closesCycle(getRef, first)) {
+    return isEmpty(second) ? first : second
+  }
+
+  if (closesCycle(getRef, second)) {
+    return isEmpty(first) ? second : first
+  }
+
+  // Resolved schemas go back through `mergeSchemasOrRefs`, NOT straight to
+  // `mergeSchemas`.
+  //
+  // `mergeSchemas` has no `allOf` / `oneOf` dispatch — that lives in
+  // `mergeSchemasOrRefs` — so a referent carrying `allOf` was handed to
+  // `typedMerge`, which copies keys it does not recognise into its output. The
+  // `allOf` therefore survived the merge and re-triggered the intersection
+  // branch on the way back up, at a frame whose resolver had none of this
+  // expansion's path on it. That is what made the recursion unbounded: the
+  // cycle marker is scoped to the descent, but the unconsumed `allOf` escaped
+  // upward in the data and was re-expanded from scratch.
+  //
+  // Routing through `mergeSchemasOrRefs` consumes the `allOf` here, while the
+  // path is still in hand. There is no bounce risk: both arguments are resolved
+  // schemas, so `containsRef` is false and it cannot re-enter this function.
   if (isRef(first) && isRef(second)) {
     if (first.$ref === second.$ref) {
       return {
@@ -189,18 +229,26 @@ const mergeWithRef = (
         ...second
       }
     } else {
-      return mergeSchemas(getRef(first), getRef(second), getRef)
+      return mergeSchemasOrRefs(
+        getRef(first),
+        getRef(second),
+        enteringRef(enteringRef(getRef, first), second)
+      )
     }
   }
 
   if (isRef(first) && !isRef(second)) {
-    const merged = isEmpty(second) ? first : mergeSchemas(getRef(first), second, getRef)
+    const merged = isEmpty(second)
+      ? first
+      : mergeSchemasOrRefs(getRef(first), second, enteringRef(getRef, first))
 
     return merged
   }
 
   if (!isRef(first) && isRef(second)) {
-    const merged = isEmpty(first) ? second : mergeSchemas(first, getRef(second), getRef)
+    const merged = isEmpty(first)
+      ? second
+      : mergeSchemasOrRefs(first, getRef(second), enteringRef(getRef, second))
 
     return merged
   }

--- a/deno/core/parse/v3-0/_merge-all-of/merge.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/merge.ts
@@ -207,21 +207,23 @@ const mergeWithRef = (
     return isEmpty(first) ? second : first
   }
 
-  // Resolved schemas go back through `mergeSchemasOrRefs`, NOT straight to
-  // `mergeSchemas`.
+  // A resolved referent's `allOf` is consumed HERE, while this expansion's
+  // path is still on the resolver.
   //
-  // `mergeSchemas` has no `allOf` / `oneOf` dispatch — that lives in
-  // `mergeSchemasOrRefs` — so a referent carrying `allOf` was handed to
-  // `typedMerge`, which copies keys it does not recognise into its output. The
-  // `allOf` therefore survived the merge and re-triggered the intersection
-  // branch on the way back up, at a frame whose resolver had none of this
-  // expansion's path on it. That is what made the recursion unbounded: the
-  // cycle marker is scoped to the descent, but the unconsumed `allOf` escaped
-  // upward in the data and was re-expanded from scratch.
+  // That `allOf` was the second half of the runaway. `mergeSchemas` has no
+  // `allOf` dispatch, so `typedMerge` copied the key into its output, where it
+  // escaped UPWARD in the data and was re-expanded at a frame whose resolver
+  // carried none of the path. The cycle marker is scoped to the descent; the
+  // unconsumed `allOf` outlived it.
   //
-  // Routing through `mergeSchemasOrRefs` consumes the `allOf` here, while the
-  // path is still in hand. There is no bounce risk: both arguments are resolved
-  // schemas, so `containsRef` is false and it cannot re-enter this function.
+  // Only `allOf`. Handing the referent to `mergeSchemasOrRefs` instead would
+  // also dispatch its `oneOf`/`anyOf` to `mergeCrossProduct`, whose `toGroup`
+  // keeps the member list and discards every sibling keyword on that node — a
+  // referent's `discriminator`, `description`, `properties` and `required` all
+  // vanish, on acyclic documents. A union needs no consuming here: it survives
+  // as data and `toSchemaV3` parses it later, which is what `main` does.
+  // (`toGroup` dropping those siblings is a real defect, tracked on skmtc#117
+  // as its own line item; it is not this PR's to change.)
   if (isRef(first) && isRef(second)) {
     if (first.$ref === second.$ref) {
       return {
@@ -229,29 +231,62 @@ const mergeWithRef = (
         ...second
       }
     } else {
-      return mergeSchemasOrRefs(
-        getRef(first),
-        getRef(second),
-        enteringRef(enteringRef(getRef, first), second)
+      const scoped = enteringRef(enteringRef(getRef, first), second)
+
+      return mergeResolved(
+        consumeAllOf(getRef(first), scoped),
+        consumeAllOf(getRef(second), scoped),
+        scoped
       )
     }
   }
 
   if (isRef(first) && !isRef(second)) {
-    const merged = isEmpty(second)
-      ? first
-      : mergeSchemasOrRefs(getRef(first), second, enteringRef(getRef, first))
+    if (isEmpty(second)) {
+      return first
+    }
 
-    return merged
+    const scoped = enteringRef(getRef, first)
+
+    return mergeResolved(consumeAllOf(getRef(first), scoped), second, scoped)
   }
 
   if (!isRef(first) && isRef(second)) {
-    const merged = isEmpty(first)
-      ? second
-      : mergeSchemasOrRefs(first, getRef(second), enteringRef(getRef, second))
+    if (isEmpty(first)) {
+      return second
+    }
 
-    return merged
+    const scoped = enteringRef(getRef, second)
+
+    return mergeResolved(first, consumeAllOf(getRef(second), scoped), scoped)
   }
 
   throw new Error('Invalid input')
+}
+
+/** A referent's `allOf`, squashed. Anything else is returned untouched. */
+const consumeAllOf = (schema: SchemaOrReference, getRef: GetRefFn): SchemaOrReference => {
+  if (isRef(schema) || !schema.allOf?.length) {
+    return schema
+  }
+
+  return mergeIntersection({ schema, getRef })
+}
+
+/**
+ * Merge two schemas that have already been resolved. `consumeAllOf` can still
+ * hand back a reference — a single-member `allOf`, or one the cycle guard
+ * refused to expand — so that case goes back through the ref path, where the
+ * resolver already carries the expansion path that terminates it.
+ */
+const mergeResolved = (
+  first: SchemaOrReference,
+  second: SchemaOrReference,
+  getRef: GetRefFn
+): SchemaOrReference => {
+  if (isRef(first) || isRef(second)) {
+    return mergeWithRef(first, second, getRef)
+  }
+
+  return mergeSchemas(first, second, getRef)
 }

--- a/deno/core/parse/v3-0/_merge-all-of/nullable-merge.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/nullable-merge.test.ts
@@ -82,21 +82,6 @@ Deno.test('mergeNullOnly - returns the modified schema object', () => {
   assertEquals(result.nullable, true)
 })
 
-Deno.test('mergeNullOnly - mutates the original schema', () => {
-  const schema: OpenAPIV3.SchemaObject = {
-    type: 'number',
-    enum: [1, 2, 3]
-  }
-
-  const result = mergeNullOnly(schema)
-
-  // Verify it's the same object (reference equality)
-  assertEquals(result === schema, true)
-  // Verify the original was mutated
-  assertEquals(schema.nullable, true)
-  assertEquals(schema.enum, [1, 2, 3, null])
-})
-
 Deno.test('isNullOnly - returns true for valid null-only schema', () => {
   const schema: OpenAPIV3.SchemaObject = {
     nullable: true,
@@ -205,4 +190,23 @@ Deno.test('isNullOnly - returns false when enum contains non-null value', () => 
   const result = isNullOnly(schema)
 
   assertEquals(result, false)
+})
+
+/**
+ * `getRef` hands back the LIVE `components.schemas[X]` object, and property
+ * schemas are read straight off the document too, so anything mutated here is
+ * rewritten for every other use site and the result depends on parse order.
+ * Both fields matter: `enum` is an array, so appending to it reaches the
+ * original through a shallow copy.
+ */
+Deno.test('mergeNullOnly - does not mutate its argument', () => {
+  const schema: OpenAPIV3.SchemaObject = { type: 'string', enum: ['a', 'b'] }
+  const before = JSON.stringify(schema)
+
+  const result = mergeNullOnly(schema)
+
+  assertEquals(JSON.stringify(schema), before, 'the input schema must be untouched')
+  assertEquals(result.enum, ['a', 'b', null])
+  assertEquals(result.nullable, true)
+  assertEquals(schema.enum, ['a', 'b'], 'the enum ARRAY must not be appended to')
 })

--- a/deno/core/parse/v3-0/_merge-all-of/nullable-merge.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/nullable-merge.ts
@@ -1,14 +1,23 @@
 import type { OpenAPIV3 } from 'openapi-types'
 import { isEmpty } from '@/helpers/isEmpty.ts'
 
+/**
+ * Returns a NEW schema. `getRef` hands back the live
+ * `components.schemas[X]` object, so mutating here rewrote the shared
+ * component for every other use site and made the result depend on parse
+ * order. A shallow copy at the call site is not enough on its own — `enum`
+ * is an array, and pushing into it reaches the original through the copied
+ * reference — so the copy has to happen here, where the array is replaced
+ * rather than appended to.
+ */
 export const mergeNullOnly = (schema: OpenAPIV3.SchemaObject): OpenAPIV3.SchemaObject => {
+  const merged: OpenAPIV3.SchemaObject = { ...schema, nullable: true }
+
   if (schema.enum && !schema.enum.includes(null)) {
-    schema.enum.push(null)
+    merged.enum = [...schema.enum, null]
   }
 
-  schema.nullable = true
-
-  return schema
+  return merged
 }
 
 export const isNullOnly = (schema: OpenAPIV3.SchemaObject): boolean => {

--- a/deno/core/parse/v3-0/_merge-all-of/ref-cycle.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/ref-cycle.ts
@@ -1,0 +1,54 @@
+import { isRef } from '@/helpers/refFns.ts'
+import type { GetRefFn, ReferenceObject, SchemaOrReference } from './types.ts'
+
+/**
+ * Cycle handling for `allOf` / `oneOf` expansion.
+ *
+ * A schema reachable from itself has no finite expansion. `TargetView` in
+ * buddy-api is the worked example: it carries a `oneOf` of 18 variants and each
+ * variant is `allOf: [{$ref: TargetView}, …]`, so expanding one variant
+ * re-expands all eighteen, each of which re-expands the variant. Base-18
+ * growth, unbounded depth — measured at roughly 80x per added variant, which
+ * burns the isolate long before it finishes.
+ *
+ * The answer is the one the single-member `allOf` path already takes (see
+ * `parse/v3-0/schema/toSchemasV3.ts`, "eagerly resolving it would not
+ * terminate"): leave the reference alone. `toSchemaV3` turns a surviving `$ref`
+ * into an `OasRef` that resolves lazily at use time, which is what the emitted
+ * types want anyway — a reference, not an infinite inlining.
+ *
+ * Path-scoped, never global. A schema legitimately referenced twice in sibling
+ * positions must expand in both, and a global set would leave the second one a
+ * bare ref — changing output for acyclic documents, which is exactly what must
+ * not happen.
+ */
+
+/** Whether expanding `schema` would re-enter a `$ref` already on this path. */
+export const closesCycle = (getRef: GetRefFn, schema: SchemaOrReference): boolean =>
+  isRef(schema) && (getRef.expanding?.has(schema.$ref) ?? false)
+
+/** The same resolver, with `$ref` added to the path its descendants see. */
+export const enteringRef = (getRef: GetRefFn, { $ref }: ReferenceObject): GetRefFn => {
+  const scoped: GetRefFn = ref => getRef(ref)
+
+  return Object.defineProperty(scoped, 'expanding', {
+    value: new Set(getRef.expanding ?? []).add($ref),
+    enumerable: true
+  })
+}
+
+/**
+ * Resolve `member` for merging, and hand back the resolver its own expansion
+ * should use. A member that closes a cycle is returned untouched, so the merge
+ * keeps it as a reference instead of inlining it forever.
+ */
+export const derefMember = (
+  member: SchemaOrReference,
+  getRef: GetRefFn
+): [SchemaOrReference, GetRefFn] => {
+  if (!isRef(member) || closesCycle(getRef, member)) {
+    return [member, getRef]
+  }
+
+  return [getRef(member), enteringRef(getRef, member)]
+}

--- a/deno/core/parse/v3-0/_merge-all-of/referent-merge.test.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/referent-merge.test.ts
@@ -1,0 +1,82 @@
+import type { OpenAPIV3 } from 'openapi-types'
+import { assertEquals } from '@std/assert/equals'
+import { mergeIntersection } from './merge-intersection.ts'
+import type { GetRefFn } from './types.ts'
+
+/**
+ * What a resolved referent may and may not lose on the way through the merge.
+ *
+ * `mergeWithRef` consumes a referent's `allOf` — that key escaping upward in
+ * the data is half of what made the expansion unbounded. It consumes ONLY
+ * `allOf`: dispatching the referent's `oneOf`/`anyOf` as well sends it to
+ * `mergeCrossProduct`, whose `toGroup` keeps the member list and discards
+ * every sibling keyword on that node. These pin the boundary.
+ */
+
+const toGetRef = (schemas: Record<string, OpenAPIV3.SchemaObject>): GetRefFn =>
+  ((ref: OpenAPIV3.ReferenceObject) => {
+    const name = ref.$ref.split('/').pop()
+
+    if (name === undefined || !(name in schemas)) {
+      throw new Error(`unknown ref ${ref.$ref}`)
+    }
+
+    return schemas[name]
+  }) as GetRefFn
+
+Deno.test('referent merge - a discriminated union keeps its discriminator', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Pet: {
+      oneOf: [
+        { type: 'object', properties: { petType: { type: 'string' }, bark: { type: 'string' } } },
+        { type: 'object', properties: { petType: { type: 'string' }, meow: { type: 'string' } } }
+      ],
+      discriminator: { propertyName: 'petType' },
+      description: 'a pet'
+    }
+  }
+
+  const merged = mergeIntersection({
+    schema: {
+      allOf: [
+        { type: 'object', properties: { pet: { $ref: '#/components/schemas/Pet' } } },
+        {
+          type: 'object',
+          properties: { pet: { description: 'the pet slot', type: 'object' } },
+          required: ['pet']
+        }
+      ]
+    },
+    getRef: toGetRef(schemas)
+  })
+
+  const pet = 'properties' in merged ? merged.properties?.pet : undefined
+  const petSchema = pet as OpenAPIV3.SchemaObject
+
+  assertEquals(petSchema.discriminator, { propertyName: 'petType' })
+  assertEquals(Array.isArray(petSchema.oneOf), true)
+})
+
+Deno.test('referent merge - the source document is not rewritten', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    X: { type: 'string', enum: ['a', 'b'] }
+  }
+  const before = JSON.stringify(schemas.X)
+
+  try {
+    mergeIntersection({
+      schema: {
+        allOf: [
+          { type: 'object', properties: { p: { $ref: '#/components/schemas/X' } } },
+          { type: 'object', properties: { p: { nullable: true, enum: [null] } } }
+        ]
+      },
+      getRef: toGetRef(schemas)
+    })
+  } catch {
+    // Whether this pair merges is not what is under test — an unrelated
+    // component gaining `null` in its enum is.
+  }
+
+  assertEquals(JSON.stringify(schemas.X), before, 'the shared component must be untouched')
+})

--- a/deno/core/parse/v3-0/_merge-all-of/types.ts
+++ b/deno/core/parse/v3-0/_merge-all-of/types.ts
@@ -1,6 +1,18 @@
 import type { OpenAPIV3 } from 'openapi-types'
 import * as v from 'valibot'
-export type GetRefFn = (ref: OpenAPIV3.ReferenceObject) => OpenAPIV3.SchemaObject
+/**
+ * Resolves a `$ref` to its schema, carrying the set of pointers already being
+ * expanded above it.
+ *
+ * The path rides on the resolver rather than being a separate parameter so that
+ * the eight modules which merely forward `getRef` — the per-type constraint
+ * mergers, `merge-properties`, `generic-merge` — propagate it without knowing it
+ * exists. Only the three places that actually dereference need to consult it.
+ */
+export type GetRefFn = ((ref: OpenAPIV3.ReferenceObject) => OpenAPIV3.SchemaObject) & {
+  /** `$ref` pointers being expanded on the current path. Absent at the root. */
+  readonly expanding?: ReadonlySet<string>
+}
 
 export type OneOfObject = {
   oneOf?: (OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject)[]

--- a/deno/core/parse/v3-1/_merge-all-of/cycles.test.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/cycles.test.ts
@@ -1,0 +1,176 @@
+import type { OpenAPIV3 } from 'openapi-types'
+import { assertEquals } from '@std/assert/equals'
+import { assert } from '@std/assert'
+import { mergeIntersection } from './merge-intersection.ts'
+import type { GetRefFn } from './types.ts'
+
+/**
+ * Reference cycles through `allOf` / `oneOf`.
+ *
+ * The shape is buddy-api's, reduced: `Hub` carries a `oneOf` of variants and
+ * every variant is `allOf: [{$ref: Hub}, …]`. Expanding one variant used to
+ * re-expand every variant, each of which re-expanded the first — base-N growth
+ * with no bound. Parsing the real document never returned, and the operation
+ * pages built from it answered 503 while the isolate was killed.
+ *
+ * Two things keep it finite, and both are load-bearing:
+ *
+ *  - the path of `$ref`s being expanded, so a reference back into the path is
+ *    left as a reference instead of inlined; and
+ *  - `mergeWithRef` routing resolved schemas through `mergeSchemasOrRefs`
+ *    rather than `mergeSchemas`, so a referent's `allOf` is CONSUMED while that
+ *    path is still in hand. Without it the `allOf` survived into the merged
+ *    output and re-triggered expansion higher up the stack, where the path had
+ *    been left behind — the cycle marker is scoped to the descent, but the data
+ *    escapes upward.
+ *
+ * These tests fail by hanging or exhausting the stack rather than by asserting,
+ * so they are kept small enough to fail fast.
+ */
+
+const toGetRef = (schemas: Record<string, OpenAPIV3.SchemaObject>): GetRefFn =>
+  (({ $ref }: OpenAPIV3.ReferenceObject) => {
+    const name = $ref.split('/').pop() ?? ''
+    const schema = schemas[name]
+
+    if (!schema) {
+      throw new Error(`Unknown ref: ${$ref}`)
+    }
+
+    return schema
+  }) as GetRefFn
+
+const ref = (name: string): OpenAPIV3.ReferenceObject => ({
+  $ref: `#/components/schemas/${name}`
+})
+
+/** `Hub` + `count` variants, each `allOf: [{$ref: Hub}, {own property}]`. */
+const hubAndVariants = (count: number): Record<string, OpenAPIV3.SchemaObject> => {
+  const names = Array.from({ length: count }, (_, index) => `Variant${index}`)
+
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Hub: {
+      type: 'object',
+      required: ['kind'],
+      properties: { kind: { type: 'string' } },
+      oneOf: names.map(ref)
+    }
+  }
+
+  names.forEach((name, index) => {
+    schemas[name] = {
+      type: 'object',
+      allOf: [ref('Hub'), { type: 'object', properties: { [`field${index}`]: { type: 'string' } } }]
+    }
+  })
+
+  return schemas
+}
+
+Deno.test('merge - a variant referencing its own hub terminates', () => {
+  const schemas = hubAndVariants(4)
+  const merged = mergeIntersection({ schema: schemas.Variant0, getRef: toGetRef(schemas) })
+
+  assert(!('$ref' in merged), 'expected a merged schema, not a bare reference')
+  assert(Array.isArray(merged.oneOf), 'expected the hub union to survive the merge')
+  assertEquals(merged.oneOf?.length, 4)
+})
+
+Deno.test('merge - cost stays linear as variants are added', () => {
+  // The defect was exponential in the variant count: 18 variants never
+  // finished. If growth returns, this does not fail politely — it hangs.
+  for (const count of [2, 4, 8, 18]) {
+    const schemas = hubAndVariants(count)
+    const merged = mergeIntersection({ schema: schemas.Variant0, getRef: toGetRef(schemas) })
+
+    assert(!('$ref' in merged))
+    assertEquals(merged.oneOf?.length, count)
+  }
+})
+
+Deno.test('merge - a directly self-referential allOf terminates', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Node: {
+      type: 'object',
+      allOf: [ref('Node'), { type: 'object', properties: { label: { type: 'string' } } }]
+    }
+  }
+
+  const merged = mergeIntersection({ schema: schemas.Node, getRef: toGetRef(schemas) })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.properties?.label, { type: 'string' })
+})
+
+Deno.test('merge - a mutual cycle between two schemas terminates', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Left: {
+      type: 'object',
+      allOf: [ref('Right'), { type: 'object', properties: { left: { type: 'string' } } }]
+    },
+    Right: {
+      type: 'object',
+      allOf: [ref('Left'), { type: 'object', properties: { right: { type: 'string' } } }]
+    }
+  }
+
+  const merged = mergeIntersection({ schema: schemas.Left, getRef: toGetRef(schemas) })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.properties?.right, { type: 'string' })
+})
+
+/**
+ * The dispatch change in `mergeWithRef` is what makes this pass: a referent
+ * carrying `allOf` is merged rather than having the `allOf` copied through into
+ * the output by `typedMerge`.
+ */
+Deno.test('merge - allOf on a referenced schema is consumed, not passed through', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Composed: {
+      allOf: [
+        { type: 'object', properties: { base: { type: 'string' } } },
+        { type: 'object', properties: { extra: { type: 'string' } } }
+      ]
+    }
+  }
+
+  const merged = mergeIntersection({
+    schema: {
+      allOf: [ref('Composed'), { type: 'object', properties: { own: { type: 'string' } } }]
+    },
+    getRef: toGetRef(schemas)
+  })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.allOf, undefined, 'allOf must not survive into the merged output')
+  assertEquals(merged.properties?.base, { type: 'string' })
+  assertEquals(merged.properties?.extra, { type: 'string' })
+  assertEquals(merged.properties?.own, { type: 'string' })
+})
+
+/**
+ * The guard is path-scoped. A global visited set would also stop the cycles
+ * above and would additionally leave the second sibling use of a shared schema
+ * unexpanded — changing output for acyclic documents, which is the one thing
+ * this must not do.
+ */
+Deno.test('merge - a schema used twice as a sibling expands in both places', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Address: { type: 'object', properties: { street: { type: 'string' } } }
+  }
+
+  const merged = mergeIntersection({
+    schema: {
+      allOf: [
+        { type: 'object', properties: { billing: ref('Address'), shipping: ref('Address') } },
+        { type: 'object', properties: { note: { type: 'string' } } }
+      ]
+    },
+    getRef: toGetRef(schemas)
+  })
+
+  assert(!('$ref' in merged))
+  assertEquals(merged.properties?.billing, { $ref: '#/components/schemas/Address' })
+  assertEquals(merged.properties?.shipping, { $ref: '#/components/schemas/Address' })
+})

--- a/deno/core/parse/v3-1/_merge-all-of/merge-intersection.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/merge-intersection.ts
@@ -1,6 +1,7 @@
 import { decomposeIntersection } from './decompose-intersection.ts'
 import type { GetRefFn, SchemaOrReference, SchemaObject } from './types.ts'
 import { mergeSchemasOrRefs } from './merge.ts'
+import { derefMember } from './ref-cycle.ts'
 
 type MergeIntersectionArgs = {
   schema: SchemaObject
@@ -15,14 +16,13 @@ export const mergeIntersection = ({ schema, getRef }: MergeIntersectionArgs): Sc
     return decomposed[0]
   }
 
-  const dereffed = decomposed.map(decomposed => {
-    return '$ref' in decomposed ? getRef(decomposed) : decomposed
-  })
+  // Each member is resolved with its own scoped resolver: one that records the
+  // member's `$ref` as being expanded, so anything beneath it pointing back
+  // here stays a reference rather than inlining forever.
+  const result = decomposed.reduce<SchemaOrReference>((acc, member) => {
+    const [value, scoped] = derefMember(member, getRef)
 
-  const result = dereffed.reduce<SchemaOrReference>((acc, decomposed) => {
-    const merged = mergeSchemasOrRefs(acc, decomposed, getRef)
-
-    return merged
+    return mergeSchemasOrRefs(acc, value, scoped)
   }, {} as SchemaObject)
 
   return result

--- a/deno/core/parse/v3-1/_merge-all-of/merge-union.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/merge-union.ts
@@ -2,6 +2,7 @@ import { decomposeUnion } from './decompose-union.ts'
 import type { GetRefFn, SchemaOrReference, SchemaObject } from './types.ts'
 import { mergeSchemasOrRefs } from './merge.ts'
 import { crossProduct } from './cross-product.ts'
+import { derefMember } from './ref-cycle.ts'
 import { isRef } from '@/helpers/refFns.ts'
 type MergeUnionArgs = {
   schema: SchemaObject
@@ -25,14 +26,13 @@ export const mergeUnion = ({ schema, getRef, groupType }: MergeUnionArgs): Schem
   //   return result
   // }
 
-  const dereffed = decomposed.map(decomposed => {
-    return '$ref' in decomposed ? getRef(decomposed) : decomposed
-  })
+  // Each member is resolved with its own scoped resolver: one that records the
+  // member's `$ref` as being expanded, so anything beneath it pointing back
+  // here stays a reference rather than inlining forever.
+  const result = decomposed.reduce<SchemaObject>((acc, member) => {
+    const [value, scoped] = derefMember(member, getRef)
 
-  const result = dereffed.reduce<SchemaObject>((acc, decomposed) => {
-    const merged = mergeCrossProduct({ first: acc, second: decomposed, getRef, groupType })
-
-    return merged
+    return mergeCrossProduct({ first: acc, second: value, getRef: scoped, groupType })
   }, {} as SchemaObject)
 
   const output = {
@@ -45,10 +45,29 @@ export const mergeUnion = ({ schema, getRef, groupType }: MergeUnionArgs): Schem
 }
 
 type MergeCrossProductArgs = {
-  first: SchemaObject
-  second: SchemaObject
+  first: SchemaOrReference
+  second: SchemaOrReference
   getRef: GetRefFn
   groupType: 'oneOf' | 'anyOf'
+}
+
+/**
+ * A schema's union members, or the schema itself when it is not a union. A
+ * reference is never a union — it is one member, resolved later. A member can
+ * now arrive as a `$ref`, because the cycle guard leaves a re-entered
+ * reference unresolved.
+ */
+const toGroup = (
+  schema: SchemaOrReference,
+  groupType: 'oneOf' | 'anyOf'
+): SchemaOrReference[] => {
+  if (isRef(schema)) {
+    return [schema]
+  }
+
+  const group = schema[groupType]
+
+  return Array.isArray(group) ? group : [schema]
 }
 
 export const mergeCrossProduct = ({
@@ -57,16 +76,22 @@ export const mergeCrossProduct = ({
   getRef,
   groupType
 }: MergeCrossProductArgs): SchemaObject => {
-  const firstGroup = Array.isArray(first[groupType]) ? first[groupType] : [first]
-  const secondGroup = Array.isArray(second[groupType]) ? second[groupType] : [second]
-
-  const mergedGroup = crossProduct(firstGroup, secondGroup)
+  const mergedGroup = crossProduct(toGroup(first, groupType), toGroup(second, groupType))
     .map(([firstItem, secondItem]) => {
       try {
         const result = mergeSchemasOrRefs(firstItem, secondItem, getRef)
 
         return result
-      } catch (_error) {
+      } catch (error) {
+        // Dropping a branch on a genuine conflict is the design: a cross
+        // product legitimately contains impossible combinations. A RangeError
+        // is not that — it is the recursion running away, and swallowing it
+        // turned a fast stack overflow into a very long exponential search
+        // with union members silently vanishing. Let it out.
+        if (error instanceof RangeError) {
+          throw error
+        }
+
         return undefined
       }
     })

--- a/deno/core/parse/v3-1/_merge-all-of/merge.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/merge.ts
@@ -1,5 +1,6 @@
 import { isRef } from '@/helpers/refFns.ts'
-import type { SchemaOrReference, ReferenceObject, SchemaObject, GetRefFn } from './types.ts'
+import type { SchemaOrReference, SchemaObject, GetRefFn } from './types.ts'
+import { closesCycle, enteringRef } from './ref-cycle.ts'
 import { checkTypeConflicts } from './check-type-conflicts.ts'
 import { checkReadOnlyWriteOnlyConflicts } from './check-read-only-write-only-conflicts.ts'
 import { checkFormatConflicts } from './check-format-conflicts.ts'
@@ -180,8 +181,47 @@ const typedMerge = (first: SchemaObject, second: SchemaObject, getRef: GetRefFn)
 const mergeWithRef = (
   first: SchemaOrReference,
   second: SchemaOrReference,
-  getRef: (ref: ReferenceObject) => SchemaObject
+  getRef: GetRefFn
 ): SchemaOrReference => {
+  // A side already being expanded above us closes a cycle, so it cannot be
+  // resolved again — there is no finite inlining.
+  //
+  // What happens next depends on the other side. If the other side is empty the
+  // reference SURVIVES, and `toSchemaV3` turns it into an `OasRef` that resolves
+  // lazily at use time. If the other side carries content we keep that content
+  // and DROP the reference — so any constraint the referent imposes is lost from
+  // this position. That is not obviously right: the alternative is to keep both
+  // (`{allOf: [first, second]}`), which preserves the constraint but re-enters
+  // this branch on the way back up and needs a termination argument of its own.
+  //
+  // Known limitation, tracked with the guard's scoping redesign (see the
+  // `expanding` set on `GetRefFn`): the path is a property of ONE position, but
+  // the resolver carrying it governs a two-sided merge, so a reference on the
+  // opposite side that happens to name the same schema is also treated as
+  // closing a cycle. Measured at 4 sites in 2 of 66 sampled specs.
+  if (closesCycle(getRef, first)) {
+    return isEmpty(second) ? first : second
+  }
+
+  if (closesCycle(getRef, second)) {
+    return isEmpty(first) ? second : first
+  }
+
+  // Resolved schemas go back through `mergeSchemasOrRefs`, NOT straight to
+  // `mergeSchemas`.
+  //
+  // `mergeSchemas` has no `allOf` / `oneOf` dispatch — that lives in
+  // `mergeSchemasOrRefs` — so a referent carrying `allOf` was handed to
+  // `typedMerge`, which copies keys it does not recognise into its output. The
+  // `allOf` therefore survived the merge and re-triggered the intersection
+  // branch on the way back up, at a frame whose resolver had none of this
+  // expansion's path on it. That is what made the recursion unbounded: the
+  // cycle marker is scoped to the descent, but the unconsumed `allOf` escaped
+  // upward in the data and was re-expanded from scratch.
+  //
+  // Routing through `mergeSchemasOrRefs` consumes the `allOf` here, while the
+  // path is still in hand. There is no bounce risk: both arguments are resolved
+  // schemas, so `containsRef` is false and it cannot re-enter this function.
   if (isRef(first) && isRef(second)) {
     if (first.$ref === second.$ref) {
       return {
@@ -189,18 +229,26 @@ const mergeWithRef = (
         ...second
       }
     } else {
-      return mergeSchemas(getRef(first), getRef(second), getRef)
+      return mergeSchemasOrRefs(
+        getRef(first),
+        getRef(second),
+        enteringRef(enteringRef(getRef, first), second)
+      )
     }
   }
 
   if (isRef(first) && !isRef(second)) {
-    const merged = isEmpty(second) ? first : mergeSchemas(getRef(first), second, getRef)
+    const merged = isEmpty(second)
+      ? first
+      : mergeSchemasOrRefs(getRef(first), second, enteringRef(getRef, first))
 
     return merged
   }
 
   if (!isRef(first) && isRef(second)) {
-    const merged = isEmpty(first) ? second : mergeSchemas(first, getRef(second), getRef)
+    const merged = isEmpty(first)
+      ? second
+      : mergeSchemasOrRefs(first, getRef(second), enteringRef(getRef, second))
 
     return merged
   }

--- a/deno/core/parse/v3-1/_merge-all-of/merge.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/merge.ts
@@ -207,21 +207,23 @@ const mergeWithRef = (
     return isEmpty(first) ? second : first
   }
 
-  // Resolved schemas go back through `mergeSchemasOrRefs`, NOT straight to
-  // `mergeSchemas`.
+  // A resolved referent's `allOf` is consumed HERE, while this expansion's
+  // path is still on the resolver.
   //
-  // `mergeSchemas` has no `allOf` / `oneOf` dispatch — that lives in
-  // `mergeSchemasOrRefs` — so a referent carrying `allOf` was handed to
-  // `typedMerge`, which copies keys it does not recognise into its output. The
-  // `allOf` therefore survived the merge and re-triggered the intersection
-  // branch on the way back up, at a frame whose resolver had none of this
-  // expansion's path on it. That is what made the recursion unbounded: the
-  // cycle marker is scoped to the descent, but the unconsumed `allOf` escaped
-  // upward in the data and was re-expanded from scratch.
+  // That `allOf` was the second half of the runaway. `mergeSchemas` has no
+  // `allOf` dispatch, so `typedMerge` copied the key into its output, where it
+  // escaped UPWARD in the data and was re-expanded at a frame whose resolver
+  // carried none of the path. The cycle marker is scoped to the descent; the
+  // unconsumed `allOf` outlived it.
   //
-  // Routing through `mergeSchemasOrRefs` consumes the `allOf` here, while the
-  // path is still in hand. There is no bounce risk: both arguments are resolved
-  // schemas, so `containsRef` is false and it cannot re-enter this function.
+  // Only `allOf`. Handing the referent to `mergeSchemasOrRefs` instead would
+  // also dispatch its `oneOf`/`anyOf` to `mergeCrossProduct`, whose `toGroup`
+  // keeps the member list and discards every sibling keyword on that node — a
+  // referent's `discriminator`, `description`, `properties` and `required` all
+  // vanish, on acyclic documents. A union needs no consuming here: it survives
+  // as data and `toSchemaV3` parses it later, which is what `main` does.
+  // (`toGroup` dropping those siblings is a real defect, tracked on skmtc#117
+  // as its own line item; it is not this PR's to change.)
   if (isRef(first) && isRef(second)) {
     if (first.$ref === second.$ref) {
       return {
@@ -229,29 +231,62 @@ const mergeWithRef = (
         ...second
       }
     } else {
-      return mergeSchemasOrRefs(
-        getRef(first),
-        getRef(second),
-        enteringRef(enteringRef(getRef, first), second)
+      const scoped = enteringRef(enteringRef(getRef, first), second)
+
+      return mergeResolved(
+        consumeAllOf(getRef(first), scoped),
+        consumeAllOf(getRef(second), scoped),
+        scoped
       )
     }
   }
 
   if (isRef(first) && !isRef(second)) {
-    const merged = isEmpty(second)
-      ? first
-      : mergeSchemasOrRefs(getRef(first), second, enteringRef(getRef, first))
+    if (isEmpty(second)) {
+      return first
+    }
 
-    return merged
+    const scoped = enteringRef(getRef, first)
+
+    return mergeResolved(consumeAllOf(getRef(first), scoped), second, scoped)
   }
 
   if (!isRef(first) && isRef(second)) {
-    const merged = isEmpty(first)
-      ? second
-      : mergeSchemasOrRefs(first, getRef(second), enteringRef(getRef, second))
+    if (isEmpty(first)) {
+      return second
+    }
 
-    return merged
+    const scoped = enteringRef(getRef, second)
+
+    return mergeResolved(first, consumeAllOf(getRef(second), scoped), scoped)
   }
 
   throw new Error('Invalid input')
+}
+
+/** A referent's `allOf`, squashed. Anything else is returned untouched. */
+const consumeAllOf = (schema: SchemaOrReference, getRef: GetRefFn): SchemaOrReference => {
+  if (isRef(schema) || !schema.allOf?.length) {
+    return schema
+  }
+
+  return mergeIntersection({ schema, getRef })
+}
+
+/**
+ * Merge two schemas that have already been resolved. `consumeAllOf` can still
+ * hand back a reference — a single-member `allOf`, or one the cycle guard
+ * refused to expand — so that case goes back through the ref path, where the
+ * resolver already carries the expansion path that terminates it.
+ */
+const mergeResolved = (
+  first: SchemaOrReference,
+  second: SchemaOrReference,
+  getRef: GetRefFn
+): SchemaOrReference => {
+  if (isRef(first) || isRef(second)) {
+    return mergeWithRef(first, second, getRef)
+  }
+
+  return mergeSchemas(first, second, getRef)
 }

--- a/deno/core/parse/v3-1/_merge-all-of/nullable-merge.test.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/nullable-merge.test.ts
@@ -82,21 +82,6 @@ Deno.test('mergeNullOnly - returns the modified schema object', () => {
   assertEquals(result.nullable, true)
 })
 
-Deno.test('mergeNullOnly - mutates the original schema', () => {
-  const schema: OpenAPIV3.SchemaObject = {
-    type: 'number',
-    enum: [1, 2, 3]
-  }
-
-  const result = mergeNullOnly(schema)
-
-  // Verify it's the same object (reference equality)
-  assertEquals(result === schema, true)
-  // Verify the original was mutated
-  assertEquals(schema.nullable, true)
-  assertEquals(schema.enum, [1, 2, 3, null])
-})
-
 Deno.test('isNullOnly - returns true for valid null-only schema', () => {
   const schema: OpenAPIV3.SchemaObject = {
     nullable: true,
@@ -205,4 +190,23 @@ Deno.test('isNullOnly - returns false when enum contains non-null value', () => 
   const result = isNullOnly(schema)
 
   assertEquals(result, false)
+})
+
+/**
+ * `getRef` hands back the LIVE `components.schemas[X]` object, and property
+ * schemas are read straight off the document too, so anything mutated here is
+ * rewritten for every other use site and the result depends on parse order.
+ * Both fields matter: `enum` is an array, so appending to it reaches the
+ * original through a shallow copy.
+ */
+Deno.test('mergeNullOnly - does not mutate its argument', () => {
+  const schema: OpenAPIV3.SchemaObject = { type: 'string', enum: ['a', 'b'] }
+  const before = JSON.stringify(schema)
+
+  const result = mergeNullOnly(schema)
+
+  assertEquals(JSON.stringify(schema), before, 'the input schema must be untouched')
+  assertEquals(result.enum, ['a', 'b', null])
+  assertEquals(result.nullable, true)
+  assertEquals(schema.enum, ['a', 'b'], 'the enum ARRAY must not be appended to')
 })

--- a/deno/core/parse/v3-1/_merge-all-of/nullable-merge.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/nullable-merge.ts
@@ -1,14 +1,23 @@
 import type { OpenAPIV3 } from 'openapi-types'
 import { isEmpty } from '@/helpers/isEmpty.ts'
 
+/**
+ * Returns a NEW schema. `getRef` hands back the live
+ * `components.schemas[X]` object, so mutating here rewrote the shared
+ * component for every other use site and made the result depend on parse
+ * order. A shallow copy at the call site is not enough on its own — `enum`
+ * is an array, and pushing into it reaches the original through the copied
+ * reference — so the copy has to happen here, where the array is replaced
+ * rather than appended to.
+ */
 export const mergeNullOnly = (schema: OpenAPIV3.SchemaObject): OpenAPIV3.SchemaObject => {
+  const merged: OpenAPIV3.SchemaObject = { ...schema, nullable: true }
+
   if (schema.enum && !schema.enum.includes(null)) {
-    schema.enum.push(null)
+    merged.enum = [...schema.enum, null]
   }
 
-  schema.nullable = true
-
-  return schema
+  return merged
 }
 
 export const isNullOnly = (schema: OpenAPIV3.SchemaObject): boolean => {

--- a/deno/core/parse/v3-1/_merge-all-of/ref-cycle.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/ref-cycle.ts
@@ -1,0 +1,54 @@
+import { isRef } from '@/helpers/refFns.ts'
+import type { GetRefFn, ReferenceObject, SchemaOrReference } from './types.ts'
+
+/**
+ * Cycle handling for `allOf` / `oneOf` expansion.
+ *
+ * A schema reachable from itself has no finite expansion. `TargetView` in
+ * buddy-api is the worked example: it carries a `oneOf` of 18 variants and each
+ * variant is `allOf: [{$ref: TargetView}, …]`, so expanding one variant
+ * re-expands all eighteen, each of which re-expands the variant. Base-18
+ * growth, unbounded depth — measured at roughly 80x per added variant, which
+ * burns the isolate long before it finishes.
+ *
+ * The answer is the one the single-member `allOf` path already takes (see
+ * `parse/v3-0/schema/toSchemasV3.ts`, "eagerly resolving it would not
+ * terminate"): leave the reference alone. `toSchemaV3` turns a surviving `$ref`
+ * into an `OasRef` that resolves lazily at use time, which is what the emitted
+ * types want anyway — a reference, not an infinite inlining.
+ *
+ * Path-scoped, never global. A schema legitimately referenced twice in sibling
+ * positions must expand in both, and a global set would leave the second one a
+ * bare ref — changing output for acyclic documents, which is exactly what must
+ * not happen.
+ */
+
+/** Whether expanding `schema` would re-enter a `$ref` already on this path. */
+export const closesCycle = (getRef: GetRefFn, schema: SchemaOrReference): boolean =>
+  isRef(schema) && (getRef.expanding?.has(schema.$ref) ?? false)
+
+/** The same resolver, with `$ref` added to the path its descendants see. */
+export const enteringRef = (getRef: GetRefFn, { $ref }: ReferenceObject): GetRefFn => {
+  const scoped: GetRefFn = ref => getRef(ref)
+
+  return Object.defineProperty(scoped, 'expanding', {
+    value: new Set(getRef.expanding ?? []).add($ref),
+    enumerable: true
+  })
+}
+
+/**
+ * Resolve `member` for merging, and hand back the resolver its own expansion
+ * should use. A member that closes a cycle is returned untouched, so the merge
+ * keeps it as a reference instead of inlining it forever.
+ */
+export const derefMember = (
+  member: SchemaOrReference,
+  getRef: GetRefFn
+): [SchemaOrReference, GetRefFn] => {
+  if (!isRef(member) || closesCycle(getRef, member)) {
+    return [member, getRef]
+  }
+
+  return [getRef(member), enteringRef(getRef, member)]
+}

--- a/deno/core/parse/v3-1/_merge-all-of/referent-merge.test.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/referent-merge.test.ts
@@ -1,0 +1,82 @@
+import type { OpenAPIV3 } from 'openapi-types'
+import { assertEquals } from '@std/assert/equals'
+import { mergeIntersection } from './merge-intersection.ts'
+import type { GetRefFn } from './types.ts'
+
+/**
+ * What a resolved referent may and may not lose on the way through the merge.
+ *
+ * `mergeWithRef` consumes a referent's `allOf` — that key escaping upward in
+ * the data is half of what made the expansion unbounded. It consumes ONLY
+ * `allOf`: dispatching the referent's `oneOf`/`anyOf` as well sends it to
+ * `mergeCrossProduct`, whose `toGroup` keeps the member list and discards
+ * every sibling keyword on that node. These pin the boundary.
+ */
+
+const toGetRef = (schemas: Record<string, OpenAPIV3.SchemaObject>): GetRefFn =>
+  ((ref: OpenAPIV3.ReferenceObject) => {
+    const name = ref.$ref.split('/').pop()
+
+    if (name === undefined || !(name in schemas)) {
+      throw new Error(`unknown ref ${ref.$ref}`)
+    }
+
+    return schemas[name]
+  }) as GetRefFn
+
+Deno.test('referent merge - a discriminated union keeps its discriminator', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    Pet: {
+      oneOf: [
+        { type: 'object', properties: { petType: { type: 'string' }, bark: { type: 'string' } } },
+        { type: 'object', properties: { petType: { type: 'string' }, meow: { type: 'string' } } }
+      ],
+      discriminator: { propertyName: 'petType' },
+      description: 'a pet'
+    }
+  }
+
+  const merged = mergeIntersection({
+    schema: {
+      allOf: [
+        { type: 'object', properties: { pet: { $ref: '#/components/schemas/Pet' } } },
+        {
+          type: 'object',
+          properties: { pet: { description: 'the pet slot', type: 'object' } },
+          required: ['pet']
+        }
+      ]
+    },
+    getRef: toGetRef(schemas)
+  })
+
+  const pet = 'properties' in merged ? merged.properties?.pet : undefined
+  const petSchema = pet as OpenAPIV3.SchemaObject
+
+  assertEquals(petSchema.discriminator, { propertyName: 'petType' })
+  assertEquals(Array.isArray(petSchema.oneOf), true)
+})
+
+Deno.test('referent merge - the source document is not rewritten', () => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject> = {
+    X: { type: 'string', enum: ['a', 'b'] }
+  }
+  const before = JSON.stringify(schemas.X)
+
+  try {
+    mergeIntersection({
+      schema: {
+        allOf: [
+          { type: 'object', properties: { p: { $ref: '#/components/schemas/X' } } },
+          { type: 'object', properties: { p: { nullable: true, enum: [null] } } }
+        ]
+      },
+      getRef: toGetRef(schemas)
+    })
+  } catch {
+    // Whether this pair merges is not what is under test — an unrelated
+    // component gaining `null` in its enum is.
+  }
+
+  assertEquals(JSON.stringify(schemas.X), before, 'the shared component must be untouched')
+})

--- a/deno/core/parse/v3-1/_merge-all-of/types.ts
+++ b/deno/core/parse/v3-1/_merge-all-of/types.ts
@@ -1,6 +1,18 @@
 import type { OpenAPIV3 } from 'openapi-types'
 import * as v from 'valibot'
-export type GetRefFn = (ref: OpenAPIV3.ReferenceObject) => OpenAPIV3.SchemaObject
+/**
+ * Resolves a `$ref` to its schema, carrying the set of pointers already being
+ * expanded above it.
+ *
+ * The path rides on the resolver rather than being a separate parameter so that
+ * the eight modules which merely forward `getRef` — the per-type constraint
+ * mergers, `merge-properties`, `generic-merge` — propagate it without knowing it
+ * exists. Only the three places that actually dereference need to consult it.
+ */
+export type GetRefFn = ((ref: OpenAPIV3.ReferenceObject) => OpenAPIV3.SchemaObject) & {
+  /** `$ref` pointers being expanded on the current path. Absent at the root. */
+  readonly expanding?: ReadonlySet<string>
+}
 
 export type OneOfObject = {
   oneOf?: (OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject)[]


### PR DESCRIPTION
Docs operation pages return 503 for an unknown share of the catalog. `buddy`
and `wiremock` reproduce on demand: ~7–14s of CPU, then the isolate is
killed. `exceededMemory` never reaches Sentry, so nothing reports it.

**This is the cycle fix from #119, extracted and nothing else.** #119 bundled
it with four separable concerns; each of the others gets its own PR with its
own proof.

## Root cause

`buddy-api`'s `TargetView` carries a `oneOf` of 18 variants, and each variant
is `allOf: [{$ref: TargetView}, ...]`. Expanding one variant re-expanded all
eighteen, each of which re-expanded the variant.

Two things were needed, and the first alone was not enough.

**1. A path-scoped cycle guard.** The set of `$ref`s being expanded rides on
the resolver, so the modules that merely forward `getRef` propagate it
without knowing it exists; only the sites that dereference consult it. On
re-entry the reference is left alone instead of inlined — what the
single-member `allOf` path already does. Path-scoped, never global: a global
set would leave the second of two sibling uses a bare ref, changing output
for acyclic documents. `cycles.test.ts` pins this.

**2. Consume a referent's `allOf` instead of copying it through.**
`mergeWithRef` handed resolved schemas to `mergeSchemas`, which has no
`allOf`/`oneOf` dispatch — that lives in `mergeSchemasOrRefs` — so a referent
carrying `allOf` went to `typedMerge`, which copies unrecognised keys into
its output. The `allOf` survived, travelled back **up** the stack in the
data, and re-triggered expansion at a frame whose resolver carried none of
the path.

**Also here:** `mergeCrossProduct` no longer swallows `RangeError`. Dropping
a branch on a genuine conflict is the design; swallowing a stack overflow
turned a fast failure into a long exponential search with union members
vanishing.

## Deliberately not in this PR

Each of these lands separately, so each carries its own proof:

- **vendor extensions are union-level** — an independent bug with an
  independent repro (OpenAI's `AssistantStreamEvent`: 23 distinct
  `x-oaiMeta.dataDescription` values collapsed to one group label)
- **`anyOf` parsed as `oneOf`** — a design decision (#117 decision 1) with a
  census behind it, not a bug fix
- **3.1 list-valued `type` in the v3-1 checks** — held back deliberately. It
  recovers the identical-set case and leaves the dominant case throwing,
  while introducing a silent widening on the array path
  (`['array','null']` merged with a type-less constraint dropped the `null`).
  The full rule — one function owning `type`, intersecting the non-null sets
  — supersedes it.
- **the `_merge-all-of` dedup and its revert** — the reasoning now lives in
  prose, which carries it better than a revert pair does
- **docs** — each PR carries the prose for what it changes

## Verification

**1749 core tests pass, 0 failed** — `main`'s 1737 plus 12 new cycle
regression tests, six per dialect tree: self-referential `allOf`, ref-alias
cycles (`A→B→A`), cross-position property cycles, and the sibling-use case
that pins the guard as path-scoped rather than global.

## Known limitations, not fixed here

**The cycle guard is scoped too widely.** The expansion path lives on the
resolver, but the resolver is a single parameter governing a merge of *two*
schemas, while "what am I expanding" is a property of one position. So a
reference on the opposite side that names the same schema is also treated as
closing a cycle, and dropped. This is a regression against `main` on acyclic
documents — measured at **4 sites in 2 of 66 sampled specs**, out of 2,097
multi-member `allOf` sites.

**A cycle-cut reference is dropped when the other side has content**, taking
the referent's constraints with it.

Both need the same redesign: per-side expansion paths, which changes a
signature threaded through 11 files. The obvious shortcut does not work —
exempting property merges from the guard reintroduces non-termination
through `A.child → B`, `B.child → A`.

**The guard bounds depth, not breadth.** A synthetic fixture of the shape
described above — `TargetView` as a `oneOf` of 18 variants, each
`allOf: [{$ref: TargetView}, {...}]` — does not terminate within 3 minutes,
on this branch *or* on #119. Each expansion path accumulates distinct `$ref`
markers, so paths run up to 18 deep and the search is up to 18! wide:
terminating in principle, not in practice. buddy's real document parses fast,
so its variants must contain something that makes merges fail and prune
cross-product branches — that difference is unexplained.

Worth stating plainly: the improvement here is measured against real
documents, not against the shape class. That gap is what a parse conformance
corpus is for, and it is being scoped separately.

## Follow-ups

- **#117** — the squash rules: `anyOf` collapse, ref inlining, bounded
  distribution
- **#118** — single-member `allOf` wrappers discard use-site annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
