### PR TITLE
Retire skm.tc, and fix the CLI permission scope it left broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ### Install Skmtc
 
 ```bash
-curl -fsSL https://skm.tc/install | sh
+curl -fsSL https://skmtc.dev/install | sh
 ```
 
 This installs the latest `skmtc` CLI, bootstrapping [Deno](https://deno.com)
@@ -29,7 +29,7 @@ This installs the latest `skmtc` CLI, bootstrapping [Deno](https://deno.com)
 version, set `SKMTC_VERSION`:
 
 ```bash
-SKMTC_VERSION=0.9.26 curl -fsSL https://skm.tc/install | sh
+SKMTC_VERSION=0.9.26 curl -fsSL https://skmtc.dev/install | sh
 ```
 
 ### Create project and generate artifacts using TUI

--- a/deno/cli/.scripts/build-node.ts
+++ b/deno/cli/.scripts/build-node.ts
@@ -44,7 +44,7 @@ await build({
       url: 'https://github.com/skmtc/skmtc.git'
     },
     bugs: 'https://github.com/skmtc/skmtc/issues',
-    homepage: 'https://skm.tc',
+    homepage: 'https://skmtc.dev',
     keywords: ['openapi', 'swagger', 'typescript', 'codegen', 'code generator']
   },
   postBuild() {

--- a/deno/cli/README.md
+++ b/deno/cli/README.md
@@ -18,7 +18,7 @@
 Skmtc is a Deno CLI. Install the latest version with:
 
 ```bash
-curl -fsSL https://skm.tc/install | sh
+curl -fsSL https://skmtc.dev/install | sh
 ```
 
 This bootstraps [Deno](https://deno.com) (the runtime) automatically if needed.
@@ -131,7 +131,7 @@ For day-to-day work the published install is the right choice — pin a version
 with `SKMTC_VERSION`:
 
 ```bash
-SKMTC_VERSION=<version> curl -fsSL https://skm.tc/install | sh
+SKMTC_VERSION=<version> curl -fsSL https://skmtc.dev/install | sh
 ```
 
 To install a binary that tracks your **local checkout** instead, use `deno compile` rather than `deno install`:

--- a/deno/cli/deno.json
+++ b/deno/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/cli",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "license": "Apache-2.0",
   "exports": "./mod.ts",
   "imports": {
@@ -37,7 +37,7 @@
       ],
       "net": [
         "jsr.io",
-        "skm.tc"
+        "api.skmtc.dev"
       ]
     }
   },

--- a/deno/cli/lib/publish-headless.ts
+++ b/deno/cli/lib/publish-headless.ts
@@ -33,6 +33,10 @@ import type { SkmtcRoot } from '@/lib/skmtc-root.ts'
 import { collectSourceFiles, type SourceFile } from '@/lib/source-upload.ts'
 import { parseScopedName } from '@/lib/scoped-name.ts'
 import { toProjectInstallCommand } from '@/lib/dependency-age.ts'
+// One definition, in the module that owns the stored-auth shape. This file
+// used to declare its own copy of the same literal, which is how a default
+// hub silently drifts between `login` and `publish`.
+import { DEFAULT_ORIGIN } from '@/lib/hub-token.ts'
 
 type PublishHeadlessArgs = {
   skmtcRoot: SkmtcRoot
@@ -69,7 +73,6 @@ export type PublishHeadlessResult =
       stage: 'version' | 'identity' | 'source' | 'publish'
     }
 
-const DEFAULT_ORIGIN = 'https://api.skmtc.dev'
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null

--- a/deno/core/.scripts/build-node.ts
+++ b/deno/core/.scripts/build-node.ts
@@ -93,7 +93,7 @@ await build({
       url: 'https://github.com/skmtc/skmtc.git'
     },
     bugs: 'https://github.com/skmtc/skmtc/issues',
-    homepage: 'https://skm.tc',
+    homepage: 'https://skmtc.dev',
     keywords: ['openapi', 'swagger', 'typescript', 'codegen', 'code generator']
   },
   postBuild() {

--- a/deno/core/README.md
+++ b/deno/core/README.md
@@ -16,7 +16,7 @@
 Skmtc is a Deno CLI. Install the latest version with:
 
 ```bash
-curl -fsSL https://skm.tc/install | sh
+curl -fsSL https://skmtc.dev/install | sh
 ```
 
 This bootstraps [Deno](https://deno.com) (the runtime) automatically if needed.

--- a/deno/docs/README.md
+++ b/deno/docs/README.md
@@ -3,7 +3,7 @@
 Generate idiomatic TypeScript source code from an OpenAPI v3 or GraphQL schema. Types, validators, query hooks, mocks, forms, and server routes — all from one schema, in one run, all consistent with each other.
 
 ```bash
-curl -fsSL https://skm.tc/install | sh
+curl -fsSL https://skmtc.dev/install | sh
 skmtc init my-api ./
 skmtc install @skmtc/gen-typescript @skmtc/gen-zod @skmtc/gen-tanstack-query-fetch-zod my-api
 skmtc generate my-api ./openapi.json
@@ -75,7 +75,7 @@ See [`explanation/comparison-to-other-tools.md`](explanation/comparison-to-other
 
 ## Quick start
 
-1. Install the CLI: `curl -fsSL https://skm.tc/install | sh`
+1. Install the CLI: `curl -fsSL https://skmtc.dev/install | sh`
 2. Create a project: `skmtc init my-api ./`
 3. Install generators: `skmtc install @skmtc/gen-typescript @skmtc/gen-zod my-api`
 4. Configure a schema source in `.skmtc/my-api/.settings/client.json`

--- a/deno/docs/llms.md
+++ b/deno/docs/llms.md
@@ -511,7 +511,7 @@ Self-contained playbooks. Read only the one you need.
 
 #### Setting up SKMTC in a project
 
-1. Install the CLI: `curl -fsSL https://skm.tc/install | sh` — bootstraps Deno if needed and pins a version via `SKMTC_VERSION=<version>`. The script bakes in the required `--unstable-worker-options` flag (`@skmtc/worker` uses Deno's `Worker.deno.permissions` API, which sits behind it); a hand-rolled `deno install` without that flag makes the first `skmtc generate` exit with `Unstable API 'Worker.deno.permissions'`.
+1. Install the CLI: `curl -fsSL https://skmtc.dev/install | sh` — bootstraps Deno if needed and pins a version via `SKMTC_VERSION=<version>`. The script bakes in the required `--unstable-worker-options` flag (`@skmtc/worker` uses Deno's `Worker.deno.permissions` API, which sits behind it); a hand-rolled `deno install` without that flag makes the first `skmtc generate` exit with `Unstable API 'Worker.deno.permissions'`.
 2. `skmtc init <project-name> ./` creates `.skmtc/<project>/`.
 3. `skmtc install @skmtc/gen-typescript @skmtc/gen-zod <project>` to add generators.
 4. Edit `.skmtc/<project>/.settings/client.json` to set `source` and `settings.basePath`.
@@ -560,7 +560,7 @@ Self-contained playbooks. Read only the one you need.
 #### Using SKMTC in CI
 
 1. Pin Deno version.
-2. Install CLI in CI: `SKMTC_VERSION=<version> curl -fsSL https://skm.tc/install | sh` — the pin keeps runs reproducible.
+2. Install CLI in CI: `SKMTC_VERSION=<version> curl -fsSL https://skmtc.dev/install | sh` — the pin keeps runs reproducible.
 3. `skmtc bundle <project>` once at CI setup (only if generators are cloned).
 4. `skmtc generate <project> --no-input --json --typecheck`.
 5. Archive `manifest.json` as a CI artifact.

--- a/deno/docs/reference/cli/overview.md
+++ b/deno/docs/reference/cli/overview.md
@@ -15,7 +15,7 @@ skmtc <command> [args...] [--json] [--no-input]
 skmtc -v | --version
 ```
 
-Install the CLI with `curl -fsSL https://skm.tc/install | sh` (bootstraps Deno
+Install the CLI with `curl -fsSL https://skmtc.dev/install | sh` (bootstraps Deno
 if needed), then invoke it as `skmtc` from any shell. The entry point is
 `skmtc/deno/cli/mod.ts`. The top-level `-v` / `--version` flag prints the CLI
 version and exits.

--- a/deno/docs/skills/skmtc-cli-v2/task-cards.md
+++ b/deno/docs/skills/skmtc-cli-v2/task-cards.md
@@ -261,7 +261,7 @@ key isn't a `gen-*` entry in `deno.json#imports`.
 ```bash
 # Setup (once per CI run) — the installer bootstraps Deno if needed;
 # SKMTC_VERSION pins the CLI so runs are reproducible:
-SKMTC_VERSION=<version> curl -fsSL https://skm.tc/install | sh
+SKMTC_VERSION=<version> curl -fsSL https://skmtc.dev/install | sh
 # Build the project's bundle.js (required for every project unless a
 # fresh one is committed/cached):
 skmtc bundle <project>

--- a/deno/docs/skills/skmtc-cli/task-cards.md
+++ b/deno/docs/skills/skmtc-cli/task-cards.md
@@ -261,7 +261,7 @@ key isn't a `gen-*` entry in `deno.json#imports`.
 ```bash
 # Setup (once per CI run) — the installer bootstraps Deno if needed;
 # SKMTC_VERSION pins the CLI so runs are reproducible:
-SKMTC_VERSION=<version> curl -fsSL https://skm.tc/install | sh
+SKMTC_VERSION=<version> curl -fsSL https://skmtc.dev/install | sh
 # Build the project's bundle.js (required for every project unless a
 # fresh one is committed/cached):
 skmtc bundle <project>

--- a/deno/docs/using/how-to/debug-failing-generation.md
+++ b/deno/docs/using/how-to/debug-failing-generation.md
@@ -98,7 +98,7 @@ flag must be provided.
 binary at install time, so a binary installed without it fails here.
 
 Fix: reinstall the CLI with the flag. The `curl` installer
-(`curl -fsSL https://skm.tc/install | sh`) includes it; if you installed
+(`curl -fsSL https://skmtc.dev/install | sh`) includes it; if you installed
 with a bare `deno install`, overwrite the binary:
 
 ```bash

--- a/deno/docs/using/how-to/install-a-generator.md
+++ b/deno/docs/using/how-to/install-a-generator.md
@@ -13,7 +13,7 @@ instead.
 
 - The `skmtc` CLI:
   ```bash
-  curl -fsSL https://skm.tc/install | sh
+  curl -fsSL https://skmtc.dev/install | sh
   ```
   The installer bootstraps Deno if needed and bakes in the
   `--unstable-worker-options` flag. The flag is required so the per-project Worker can use Deno's

--- a/deno/docs/using/how-to/use-in-ci-cd.md
+++ b/deno/docs/using/how-to/use-in-ci-cd.md
@@ -30,7 +30,7 @@ deterministic. For GitHub Actions:
 ### Install the CLI in CI
 
 ```bash
-SKMTC_VERSION=<version> curl -fsSL https://skm.tc/install | sh
+SKMTC_VERSION=<version> curl -fsSL https://skmtc.dev/install | sh
 ```
 
 Pin to a specific CLI version with `SKMTC_VERSION`. The CLI itself

--- a/deno/docs/using/tutorials/01-your-first-generation.md
+++ b/deno/docs/using/tutorials/01-your-first-generation.md
@@ -19,7 +19,7 @@ If you don't have one handy, use the canonical Petstore spec:
 ## Step 1: Install the CLI
 
 ```bash
-curl -fsSL https://skm.tc/install | sh
+curl -fsSL https://skmtc.dev/install | sh
 ```
 
 The installer bootstraps Deno if it isn't already on your machine and

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "swagger",
     "typescript"
   ],
-  "homepage": "https://skm.tc",
+  "homepage": "https://skmtc.dev",
   "bugs": "https://github.com/skmtc/skmtc/issues",
   "license": "Apache-2.0",
   "author": "Skmtc Contributors",

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -5,7 +5,7 @@ plugin serves project metadata, applies enrichment edits, regenerates code, and
 renders generated components in an iframe — with the app's real React, aliases,
 plugins, and CSS pipeline.
 
-For apps generated or onboarded with [SKMTC](https://skm.tc). The plugin is
+For apps generated or onboarded with [SKMTC](https://skmtc.dev). The plugin is
 dev-only (`apply: 'serve'`) and adds nothing to production builds.
 
 ## Install

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@skmtc/vite",
-  "version": "0.9.0",
-  "homepage": "https://skm.tc",
+  "version": "0.9.1",
+  "homepage": "https://skmtc.dev",
   "bugs": "https://github.com/skmtc/skmtc/issues",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Retires `skm.tc` from everything this repo ships, and fixes a live bug the domain change had already left behind. Companion to skmtc-hub#400, which stands up production on **skmtc.dev**.

`whois` says `skm.tc` expired 2026-07-22 and is in **`pendingDelete`** — past redemption, dropping to the public pool within days. It will be re-registered when it drops, but nothing depends on it in the meantime: it comes back as a redirect *into* skmtc.dev, never as a primary host.

## The live bug

`deno/cli/deno.json` scoped net permissions to `["jsr.io", "skm.tc"]`, while the CLI's own `DEFAULT_ORIGIN` has been `https://api.skmtc.dev` for some time. So the default hub was **not in the CLI's own permission allowlist** — the out-of-box path prompts for a permission it should already hold, against a host the allowlist never mentions, while granting one to a domain that no longer resolves.

Replaced `skm.tc` with `api.skmtc.dev`. `HUB_TOKEN_SETTINGS_URL` is only ever printed (checked: `login.tsx` renders it, nothing fetches it), so `skmtc.dev` itself needs no entry.

## De-duplication

`lib/publish-headless.ts` declared its own private `DEFAULT_ORIGIN` holding the same literal that `lib/hub-token.ts` exports. That is how a default hub silently drifts between `login` and `publish`. It now imports the one definition.

## The sweep

The published install command is out of every README, docs page and skill task-card; the `homepage` field is out of the three `build-node` scripts and two package manifests. `deno/docs/friction-log/` is left alone — history, like `notes/`.

## Versions

Bumped per the cascade rule in `CLAUDE.md`. **`deno task release` is deliberately not run here** — that is the owner's call, and hand-publishing is never the path.

- **`@skmtc/cli` 0.9.44 → 0.9.45** — a real functional fix that has to ship.
- **`@skmtc/vite` 0.9.0 → 0.9.1** — CI publishes on merge and skips already-published versions, so the homepage change only lands with a bump.
- **`@skmtc/core` deliberately not bumped.** The change there is a homepage string in the npm build script plus a README line, and a core bump cascades a patch through every downstream `@skmtc/*` package. It can ride the next real core release. Say the word if you'd rather it went now.

## Verification

`deno check` passes on the changed CLI module. Note that `deno fmt --check` fails repo-wide on untouched files too — its defaults (double quotes, semicolons) disagree with this repo's actual style, so it is not the formatter here. The edit follows the surrounding style.
