### PR TITLE
Run the coverage job on a Blacksmith runner

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     # No JSR_URL override: everything resolves from public jsr.io.
     # @skmtc/* has published there since 2026-07-05 (the publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,10 @@ concurrency:
 
 jobs:
   publish:
+    # Stays GitHub-hosted while coverage runs on Blacksmith: npm Trusted
+    # Publishing accepts only an OIDC token minted on a cloud-hosted GitHub
+    # runner, so the `--provenance` publishes below fail on a third-party one.
+    # JSR is not the constraint here; npm is.
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Companion to skmtc-hub #504 / #507, which moved that repo's Linux jobs to
Blacksmith. The org's Blacksmith free tier is 3000 x64 2vCPU minutes a month
and is shared between the two repos.

`coverage` moves to `blacksmith-4vcpu-ubuntu-2404`. `publish` stays on
`ubuntu-latest`, and has to: npm Trusted Publishing accepts only an OIDC token
minted on a cloud-hosted GitHub runner, so the `--provenance` publishes for
`@skmtc/core` and `@skmtc/vite` would fail on a third-party runner. JSR is not
the constraint there; npm is. That reason is now a comment above the
`runs-on`, so the next migration pass does not undo it.

## What this is and is not buying

This repo is public, so GitHub's own Actions minutes are already free and
unlimited here. The reason to move is wall time on the deno test + coverage
run, not cost — measured at 2.7 min average, 3.5 min worst case over the last
20 successful runs, so the gain is modest.

Worth knowing rather than hidden: `coverage` triggers on `pull_request`, and
this repo is public, so a fork PR from a returning contributor would run on
the org's Blacksmith minutes instead of GitHub's free ones. There are zero
fork PRs in the last 50, so this is theoretical today. If that changes, the
fix is to restrict the trigger to same-repo PRs rather than to move the job
back.

Free-tier headroom is comfortable either way: skmtc-hub is running about 400
wall-minutes a month, which is roughly 800 of the 3000 at 4vCPU.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/skmtc/codesmith/skmtc/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790697675&installation_model_id=434944&pr_number=133&repository=skmtc%2Fskmtc&return_to=https%3A%2F%2Fgithub.com%2Fskmtc%2Fskmtc%2Fpull%2F133&signature=b3b0bbb7861ae2d35600684bde261bd98ccffecb87958352566f9554b01bbfe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->