### PR TITLE
Close the sync gaps the skills plan left open, and give the install lines one home

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "skmtc",
       "source": "./deno/docs/skills",
       "description": "Author Skmtc generators — derive application code from an OpenAPI document treated as a domain model.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Skmtc",
         "url": "https://skmtc.dev"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,11 +5,15 @@ on:
     branches: [main]
     paths:
       - 'deno/**'
+      # The skills catalogue check reads this manifest, so a PR that only
+      # edits it has to run the gate that would catch the disagreement.
+      - '.claude-plugin/**'
       - '.github/workflows/coverage.yml'
   pull_request:
     branches: [main]
     paths:
       - 'deno/**'
+      - '.claude-plugin/**'
 
 jobs:
   coverage:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ npx skills add skmtc/skmtc
 npx skills add skmtc/skmtc --skill skmtc-generator
 ```
 
-The sources live in
-[`deno/docs/skills/`](deno/docs/skills/) and read fine on their own.
+The sources live in [`deno/docs/skills/`](deno/docs/skills/) and read fine on
+their own; each is also rendered at
+[skmtc.dev/skills](https://skmtc.dev/skills).
+
+This block is the one place the install lines are written down — everything
+else points here, and `verify-docs` fails on a second copy. Instructions that
+exist twice drift, and the reader who finds the stale one has no way to tell.
 
 ## Available generators
 

--- a/deno/.scripts/bump-plugin.ts
+++ b/deno/.scripts/bump-plugin.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read --allow-write
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-run=git
 /**
  * Bump the plugin version and re-record the published-skills digest.
  *
@@ -9,6 +9,11 @@
  *
  * `--check` reports whether a bump is needed without writing, which is what the
  * verify-docs check runs.
+ *
+ * Two PRs that each edit a published skill both compute the same next patch and
+ * write it to the same three files, so they conflict on merge. That is the cost
+ * of putting the bump in the editing PR, and it is paid the same way as any
+ * other conflict: rebase and re-run this.
  */
 import { dirname, fromFileUrl, join } from 'jsr:@std/path@^1'
 import { computeSkillsDigest, readPublishedNames } from './plugin-digest.ts'

--- a/deno/.scripts/bump-plugin.ts
+++ b/deno/.scripts/bump-plugin.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write
+/**
+ * Bump the plugin version and re-record the published-skills digest.
+ *
+ * Run this in the PR that edits a published skill — `deno task bump-plugin`.
+ * verify-docs fails until you do, because a skill edit that ships without a
+ * version bump reaches no Claude Code user: the plugin only updates when its
+ * version moves.
+ *
+ * `--check` reports whether a bump is needed without writing, which is what the
+ * verify-docs check runs.
+ */
+import { dirname, fromFileUrl, join } from 'jsr:@std/path@^1'
+import { computeSkillsDigest, readPublishedNames } from './plugin-digest.ts'
+
+const denoDir = join(dirname(fromFileUrl(import.meta.url)), '..')
+const skillsDir = join(denoDir, 'docs', 'skills')
+const pluginPath = join(skillsDir, '.claude-plugin', 'plugin.json')
+const marketplacePath = join(denoDir, '..', '.claude-plugin', 'marketplace.json')
+const recordPath = join(denoDir, '.scripts', 'plugin-release.json')
+
+const checkOnly = Deno.args.includes('--check')
+
+const plugin = JSON.parse(await Deno.readTextFile(pluginPath))
+const marketplace = JSON.parse(await Deno.readTextFile(marketplacePath))
+const record = JSON.parse(await Deno.readTextFile(recordPath))
+
+const digest = await computeSkillsDigest(skillsDir, await readPublishedNames(skillsDir))
+
+if (digest === record.digest && record.version === plugin.version) {
+  console.log(`plugin ${plugin.version}: published skills unchanged since the last bump`)
+  Deno.exit(0)
+}
+
+if (checkOnly) {
+  console.error(
+    digest === record.digest
+      ? `plugin.json says ${plugin.version}, plugin-release.json records ${record.version}`
+      : 'published skills changed since the last plugin bump'
+  )
+  Deno.exit(1)
+}
+
+const parts = String(plugin.version).split('.').map(Number)
+if (parts.length !== 3 || parts.some(part => !Number.isFinite(part))) {
+  console.error(`plugin.json version is not major.minor.patch: ${JSON.stringify(plugin.version)}`)
+  Deno.exit(1)
+}
+const next = `${parts[0]}.${parts[1]}.${parts[2] + 1}`
+
+// By name, not by index: a second marketplace entry must not take the bump.
+const entry = marketplace.plugins.find((candidate: { name: string }) => candidate.name === plugin.name)
+if (!entry) {
+  console.error(`marketplace.json has no plugin named ${plugin.name}`)
+  Deno.exit(1)
+}
+
+plugin.version = next
+entry.version = next
+await Deno.writeTextFile(pluginPath, `${JSON.stringify(plugin, null, 2)}\n`)
+await Deno.writeTextFile(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`)
+await Deno.writeTextFile(
+  recordPath,
+  `${JSON.stringify({ version: next, digest }, null, 2)}\n`
+)
+
+console.log(`plugin ${plugin.version} — digest re-recorded; commit these three files`)

--- a/deno/.scripts/generate-skill-api-appendix.ts
+++ b/deno/.scripts/generate-skill-api-appendix.ts
@@ -1,13 +1,17 @@
 // Regenerate the "generated API reference" appendix in the skills that
 // carry one, from `deno doc` over framework source. Run from `deno/`:
 //
-//   deno run --allow-read --allow-write --allow-run=deno,git .scripts/generate-skill-api-appendix.ts
+//   deno run --allow-read --allow-write --allow-env --allow-run=deno,git .scripts/generate-skill-api-appendix.ts
 //
 // The appendix is the drift-proof alternative to hand-pasted type
 // declarations: `deno doc` output is derived from the same source an
 // agent would otherwise dive into, so the appendix cannot say something
 // the source does not. Re-running the script is the whole maintenance
-// story; a verify-docs check can later regenerate-and-diff to gate CI.
+// story, and verify-docs check 15 gates it: every export of the
+// documented package must appear in the appendix. That check holds
+// symbol NAMES rather than generated text, because `deno doc`'s
+// formatting shifts between patch releases; `--check` here does the
+// exact comparison, which is only meaningful on one machine.
 
 const BEGIN_MARKER = '<!-- api-appendix:begin — GENERATED, do not edit by hand -->'
 const END_MARKER = '<!-- api-appendix:end -->'
@@ -151,7 +155,7 @@ for (const target of targets) {
     '# Appendix — generated API reference',
     '',
     '> Generated from framework source by',
-    '> `deno run --allow-read --allow-write --allow-run=deno,git .scripts/generate-skill-api-appendix.ts`',
+    '> `deno run --allow-read --allow-write --allow-env --allow-run=deno,git .scripts/generate-skill-api-appendix.ts`',
     '> (from `deno/`). **Authoritative** for signatures, fields, and doc',
     '> comments — trust it instead of re-reading package source. JSDoc',
     '> `@example` blocks are stripped at generation. For a symbol not',
@@ -209,7 +213,7 @@ if (checkOnly) {
   if (drifted.length > 0) {
     console.error(
       `stale generated appendix: ${drifted.join(', ')}\n` +
-        'Regenerate with: deno run --allow-read --allow-write --allow-run=deno,git ' +
+        'Regenerate with: deno run --allow-read --allow-write --allow-env --allow-run=deno,git ' +
         '.scripts/generate-skill-api-appendix.ts'
     )
     Deno.exit(1)

--- a/deno/.scripts/generate-skill-api-appendix.ts
+++ b/deno/.scripts/generate-skill-api-appendix.ts
@@ -13,6 +13,8 @@
 // formatting shifts between patch releases; `--check` here does the
 // exact comparison, which is only meaningful on one machine.
 
+import { runGit } from './run-git.ts'
+
 const BEGIN_MARKER = '<!-- api-appendix:begin — GENERATED, do not edit by hand -->'
 const END_MARKER = '<!-- api-appendix:end -->'
 
@@ -50,27 +52,11 @@ const targets: Target[] = [
 
 const decoder = new TextDecoder()
 
-/**
- * `git` is run with the environment cleared apart from what spawning needs.
- *
- * A git hook exports `GIT_DIR` and `GIT_INDEX_FILE`, and a child `git` obeys
- * them over its own working directory — so the same command answers one thing
- * from a shell and another from a pre-push hook, and this script's `--check`
- * failed only inside the hook. Anything reading git state on behalf of a check
- * has to ignore an ambient repo pointer.
- */
+/** `deno` subprocesses. `git` goes through `runGit`, which clears the environment. */
 const run = async (command: string, args: string[]): Promise<string> => {
   const output = await new Deno.Command(command, {
     args,
-    clearEnv: command === 'git',
-    env:
-      command === 'git'
-        ? {
-            NO_COLOR: '1',
-            PATH: Deno.env.get('PATH') ?? '',
-            HOME: Deno.env.get('HOME') ?? ''
-          }
-        : { NO_COLOR: '1' },
+    env: { NO_COLOR: '1' },
     stdout: 'piped',
     stderr: 'piped'
   }).output()
@@ -111,7 +97,7 @@ const stripExamples = (doc: string): string => {
 const relativizePaths = (text: string, repoRoot: string): string =>
   text.replaceAll(`file://${repoRoot}/`, '')
 
-const repoRoot = (await run('git', ['rev-parse', '--show-toplevel'])).trim()
+const repoRoot = (await runGit(Deno.cwd(), ['rev-parse', '--show-toplevel'])).trim()
 
 // `--check` regenerates in memory and compares, writing nothing. It is what
 // makes the appendix a gate rather than a habit: `deno doc` output cannot

--- a/deno/.scripts/generate-skill-api-appendix.ts
+++ b/deno/.scripts/generate-skill-api-appendix.ts
@@ -116,22 +116,24 @@ const repoRoot = (await run('git', ['rev-parse', '--show-toplevel'])).trim()
 const checkOnly = Deno.args.includes('--check')
 
 /**
- * The commit the DOCUMENTED SOURCE last moved in — not `HEAD`.
+ * No commit sha rides in the generated text.
  *
- * HEAD was the wrong provenance twice over. It made the line a lie on any
- * commit that did not touch the package (the appendix was "generated from"
- * a docs typo fix), and it made regenerate-and-diff impossible, because every
- * commit changed the output whether or not the API had.
+ * It used to carry `HEAD`, which was wrong twice over: the line was a lie on
+ * any commit that did not touch the package, and it made regenerate-and-diff
+ * impossible because every commit changed the output. Deriving it from the
+ * package's own last commit fixed the lie and broke something worse — the sha
+ * then depended on how the repo was CLONED. A shallow CI checkout resolves it
+ * differently from a full one, so the gate failed in CI on content that was
+ * perfectly current.
+ *
+ * A generated file that a check compares has to be a pure function of its
+ * source. The provenance line was decoration a reader could not act on; the
+ * regeneration command, which they can, stays.
  */
-const shaForFiles = async (files: string[]): Promise<string> => {
-  const packages = [...new Set(files.map(file => file.split('/')[0]))]
-  return (await run('git', ['log', '-1', '--format=%h', '--', ...packages])).trim()
-}
 
 const drifted: string[] = []
 
 for (const target of targets) {
-  const sourceSha = await shaForFiles(target.sections.flatMap(section => section.files))
   const sectionBlocks: string[] = []
   for (const section of target.sections) {
     const fileBlocks: string[] = []
@@ -148,7 +150,7 @@ for (const target of targets) {
   const appendixBody = [
     '# Appendix — generated API reference',
     '',
-    `> Generated from framework source at \`${sourceSha}\` by`,
+    '> Generated from framework source by',
     '> `deno run --allow-read --allow-write --allow-run=deno,git .scripts/generate-skill-api-appendix.ts`',
     '> (from `deno/`). **Authoritative** for signatures, fields, and doc',
     '> comments — trust it instead of re-reading package source. JSDoc',
@@ -169,8 +171,8 @@ for (const target of targets) {
     '',
     'The full `deno doc` surface for the packages this skill covers lives',
     'in [`appendix.md`](appendix.md), in this skill\'s directory —',
-    `generated from framework source at \`${sourceSha}\`, signatures and`,
-    'field docs only. It is **authoritative**: when the prose above does',
+    'generated from framework source — signatures and field docs only.',
+    'It is **authoritative**: when the prose above does',
     'not carry the exact constructor or field shape you need, Read (or',
     'grep) `appendix.md` instead of diving into package source. Do not',
     'guess signatures. For a symbol not listed there,',
@@ -199,7 +201,7 @@ for (const target of targets) {
   await Deno.writeTextFile(target.skill, updated)
   const fileCount = target.sections.reduce((count, section) => count + section.files.length, 0)
   console.log(
-    `${target.skill}: pointer ${beginAt !== -1 ? 'replaced' : 'appended'}; ${target.appendix} written (${fileCount} file(s), sha ${sourceSha})`
+    `${target.skill}: pointer ${beginAt !== -1 ? 'replaced' : 'appended'}; ${target.appendix} written (${fileCount} file(s))`
   )
 }
 

--- a/deno/.scripts/generate-skill-api-appendix.ts
+++ b/deno/.scripts/generate-skill-api-appendix.ts
@@ -46,10 +46,27 @@ const targets: Target[] = [
 
 const decoder = new TextDecoder()
 
+/**
+ * `git` is run with the environment cleared apart from what spawning needs.
+ *
+ * A git hook exports `GIT_DIR` and `GIT_INDEX_FILE`, and a child `git` obeys
+ * them over its own working directory — so the same command answers one thing
+ * from a shell and another from a pre-push hook, and this script's `--check`
+ * failed only inside the hook. Anything reading git state on behalf of a check
+ * has to ignore an ambient repo pointer.
+ */
 const run = async (command: string, args: string[]): Promise<string> => {
   const output = await new Deno.Command(command, {
     args,
-    env: { NO_COLOR: '1' },
+    clearEnv: command === 'git',
+    env:
+      command === 'git'
+        ? {
+            NO_COLOR: '1',
+            PATH: Deno.env.get('PATH') ?? '',
+            HOME: Deno.env.get('HOME') ?? ''
+          }
+        : { NO_COLOR: '1' },
     stdout: 'piped',
     stderr: 'piped'
   }).output()

--- a/deno/.scripts/generate-skill-api-appendix.ts
+++ b/deno/.scripts/generate-skill-api-appendix.ts
@@ -91,9 +91,30 @@ const relativizePaths = (text: string, repoRoot: string): string =>
   text.replaceAll(`file://${repoRoot}/`, '')
 
 const repoRoot = (await run('git', ['rev-parse', '--show-toplevel'])).trim()
-const sourceSha = (await run('git', ['rev-parse', '--short', 'HEAD'])).trim()
+
+// `--check` regenerates in memory and compares, writing nothing. It is what
+// makes the appendix a gate rather than a habit: `deno doc` output cannot
+// disagree with source, so the only way this file drifts is by not being
+// regenerated after the source moved.
+const checkOnly = Deno.args.includes('--check')
+
+/**
+ * The commit the DOCUMENTED SOURCE last moved in — not `HEAD`.
+ *
+ * HEAD was the wrong provenance twice over. It made the line a lie on any
+ * commit that did not touch the package (the appendix was "generated from"
+ * a docs typo fix), and it made regenerate-and-diff impossible, because every
+ * commit changed the output whether or not the API had.
+ */
+const shaForFiles = async (files: string[]): Promise<string> => {
+  const packages = [...new Set(files.map(file => file.split('/')[0]))]
+  return (await run('git', ['log', '-1', '--format=%h', '--', ...packages])).trim()
+}
+
+const drifted: string[] = []
 
 for (const target of targets) {
+  const sourceSha = await shaForFiles(target.sections.flatMap(section => section.files))
   const sectionBlocks: string[] = []
   for (const section of target.sections) {
     const fileBlocks: string[] = []
@@ -121,7 +142,6 @@ for (const target of targets) {
     ...sectionBlocks,
     ''
   ].join('\n')
-  await Deno.writeTextFile(target.appendix, appendixBody)
 
   // SKILL.md keeps a short generated pointer between the same markers,
   // so re-runs stay idempotent and the loaded skill stays light.
@@ -150,9 +170,30 @@ for (const target of targets) {
     beginAt !== -1 && endAt !== -1
       ? skillText.slice(0, beginAt) + pointer + skillText.slice(endAt + END_MARKER.length)
       : `${skillText.trimEnd()}\n\n${pointer}\n`
+
+  if (checkOnly) {
+    const appendixOnDisk = await Deno.readTextFile(target.appendix).catch(() => '')
+    if (appendixOnDisk !== appendixBody) drifted.push(target.appendix)
+    if (skillText !== updated) drifted.push(target.skill)
+    continue
+  }
+
+  await Deno.writeTextFile(target.appendix, appendixBody)
   await Deno.writeTextFile(target.skill, updated)
   const fileCount = target.sections.reduce((count, section) => count + section.files.length, 0)
   console.log(
     `${target.skill}: pointer ${beginAt !== -1 ? 'replaced' : 'appended'}; ${target.appendix} written (${fileCount} file(s), sha ${sourceSha})`
   )
+}
+
+if (checkOnly) {
+  if (drifted.length > 0) {
+    console.error(
+      `stale generated appendix: ${drifted.join(', ')}\n` +
+        'Regenerate with: deno run --allow-read --allow-write --allow-run=deno,git ' +
+        '.scripts/generate-skill-api-appendix.ts'
+    )
+    Deno.exit(1)
+  }
+  console.log(`appendix check: ${targets.length} target(s) match their source`)
 }

--- a/deno/.scripts/plugin-digest.ts
+++ b/deno/.scripts/plugin-digest.ts
@@ -6,25 +6,75 @@
  * ships without a bump reaches nobody. Making the release bump it cannot work:
  * the publish job checks out shallow and read-only, so the write is discarded
  * with the runner. The bump therefore belongs in the PR that edits the skill,
- * and this digest is what forces it — content, not git history, so it answers
- * the same in a shallow clone, a hook, and CI.
+ * and this digest is what forces it.
+ *
+ * The digest covers what an install DELIVERS: the files of every published
+ * skill, plus the plugin manifest that ships with them.
+ *
+ * Changing what goes into the digest changes its value without anything
+ * shipping differently, so re-record `plugin-release.json` in the same commit
+ * and leave the version where it is.
  */
 
 import { join } from 'jsr:@std/path@^1'
+import { runGit } from './run-git.ts'
 
-/** Every file under a skill directory, relative to `skillsDir`, sorted. */
-const filesUnder = async (skillsDir: string, directory: string): Promise<string[]> => {
-  const found: string[] = []
-  const walk = async (relative: string): Promise<void> => {
-    for await (const entry of Deno.readDir(join(skillsDir, relative))) {
-      if (entry.name.startsWith('.')) continue
-      const path = `${relative}/${entry.name}`
-      if (entry.isDirectory) await walk(path)
-      else found.push(path)
-    }
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const exists = async (path: string): Promise<boolean> => {
+  try {
+    await Deno.stat(path)
+    return true
+  } catch {
+    return false
   }
-  await walk(directory)
-  return found.sort()
+}
+
+/**
+ * Every project file under a skill directory, relative to `skillsDir`, sorted.
+ *
+ * The list comes from git rather than from a directory walk. What an install
+ * delivers is what the repository carries, so a scratch file or an editor
+ * backup left in a skill directory must not read as a skill edit, and a
+ * shipped dotfile must not be invisible to the digest — a walk got both
+ * backwards. `--cached` is the index, which a shallow clone carries in full.
+ *
+ * Contents are read from disk, so editing a tracked file moves the digest at
+ * once. A file NEW to the tree counts from the moment it is staged, which is
+ * always true at the gates that matter: the pre-push hook and CI both run on
+ * committed state.
+ *
+ * `--cached` still lists a tracked file deleted from the working tree, so
+ * paths are filtered by existence and a deletion moves the digest too.
+ */
+const filesUnder = async (skillsDir: string, directory: string): Promise<string[]> => {
+  const listed = await runGit(skillsDir, ['ls-files', '--cached', '-z', '--', directory])
+
+  const paths = listed.split('\0').filter(path => path.length > 0)
+  const present = await Promise.all(paths.map(path => exists(join(skillsDir, path))))
+
+  return paths.filter((_path, index) => present[index]).sort()
+}
+
+/**
+ * The manifest as it ships, with `version` removed.
+ *
+ * Its description and keywords are what a reader sees in the catalogue, so an
+ * edit there reaches nobody without a bump exactly as a skill edit does.
+ * `version` is the field the digest exists to move: hashing it would mean no
+ * bump could ever settle. Re-serializing means reformatting the file is not
+ * an edit.
+ */
+const manifestWithoutVersion = async (skillsDir: string): Promise<string> => {
+  const parsed: unknown = JSON.parse(
+    await Deno.readTextFile(join(skillsDir, '.claude-plugin', 'plugin.json'))
+  )
+  if (!isRecord(parsed)) {
+    throw new Error('plugin.json is not a JSON object')
+  }
+  const { version: _version, ...shipped } = parsed
+  return JSON.stringify(shipped, null, 2)
 }
 
 /**
@@ -41,6 +91,8 @@ export const computeSkillsDigest = async (
       parts.push(`${path}\n${await Deno.readTextFile(join(skillsDir, path))}`)
     }
   }
+  parts.push(`.claude-plugin/plugin.json\n${await manifestWithoutVersion(skillsDir)}`)
+
   const bytes = new TextEncoder().encode(parts.join('\0'))
   const hash = await crypto.subtle.digest('SHA-256', bytes)
   const hex = [...new Uint8Array(hash)].map(byte => byte.toString(16).padStart(2, '0')).join('')
@@ -49,8 +101,16 @@ export const computeSkillsDigest = async (
 
 /** The published set, from the manifest that ships it. */
 export const readPublishedNames = async (skillsDir: string): Promise<string[]> => {
-  const manifest = JSON.parse(
+  const manifest: unknown = JSON.parse(
     await Deno.readTextFile(join(skillsDir, '.claude-plugin', 'plugin.json'))
   )
-  return manifest.skills.map((path: string) => path.replace(/^\.\//, ''))
+  if (!isRecord(manifest) || !Array.isArray(manifest.skills)) {
+    throw new Error('plugin.json has no `skills` array')
+  }
+  return manifest.skills.map(entry => {
+    if (typeof entry !== 'string') {
+      throw new Error(`plugin.json skills entry is not a string: ${JSON.stringify(entry)}`)
+    }
+    return entry.replace(/^\.\//, '')
+  })
 }

--- a/deno/.scripts/plugin-digest.ts
+++ b/deno/.scripts/plugin-digest.ts
@@ -1,0 +1,56 @@
+/**
+ * The digest of the published skills, shared by the bump script and the
+ * verify-docs check that gates it.
+ *
+ * Claude Code updates a plugin when its `version` moves, so a skill edit that
+ * ships without a bump reaches nobody. Making the release bump it cannot work:
+ * the publish job checks out shallow and read-only, so the write is discarded
+ * with the runner. The bump therefore belongs in the PR that edits the skill,
+ * and this digest is what forces it — content, not git history, so it answers
+ * the same in a shallow clone, a hook, and CI.
+ */
+
+import { join } from 'jsr:@std/path@^1'
+
+/** Every file under a skill directory, relative to `skillsDir`, sorted. */
+const filesUnder = async (skillsDir: string, directory: string): Promise<string[]> => {
+  const found: string[] = []
+  const walk = async (relative: string): Promise<void> => {
+    for await (const entry of Deno.readDir(join(skillsDir, relative))) {
+      if (entry.name.startsWith('.')) continue
+      const path = `${relative}/${entry.name}`
+      if (entry.isDirectory) await walk(path)
+      else found.push(path)
+    }
+  }
+  await walk(directory)
+  return found.sort()
+}
+
+/**
+ * Names are part of the digest, not just contents: renaming a companion file
+ * or adding one changes what an install delivers just as a text edit does.
+ */
+export const computeSkillsDigest = async (
+  skillsDir: string,
+  publishedNames: readonly string[]
+): Promise<string> => {
+  const parts: string[] = []
+  for (const name of [...publishedNames].sort()) {
+    for (const path of await filesUnder(skillsDir, name)) {
+      parts.push(`${path}\n${await Deno.readTextFile(join(skillsDir, path))}`)
+    }
+  }
+  const bytes = new TextEncoder().encode(parts.join('\0'))
+  const hash = await crypto.subtle.digest('SHA-256', bytes)
+  const hex = [...new Uint8Array(hash)].map(byte => byte.toString(16).padStart(2, '0')).join('')
+  return `sha256:${hex}`
+}
+
+/** The published set, from the manifest that ships it. */
+export const readPublishedNames = async (skillsDir: string): Promise<string[]> => {
+  const manifest = JSON.parse(
+    await Deno.readTextFile(join(skillsDir, '.claude-plugin', 'plugin.json'))
+  )
+  return manifest.skills.map((path: string) => path.replace(/^\.\//, ''))
+}

--- a/deno/.scripts/plugin-release.json
+++ b/deno/.scripts/plugin-release.json
@@ -1,4 +1,4 @@
 {
   "version": "0.1.1",
-  "digest": "sha256:cd4e69d7849c75213cbe6f42b3cb9392aede1d93bbde5f6864247d284e46b1c4"
+  "digest": "sha256:c7848731d35f3d86ff777b9d8885ca0a78c2b87653ace39e7c97fefc17677d4c"
 }

--- a/deno/.scripts/plugin-release.json
+++ b/deno/.scripts/plugin-release.json
@@ -1,0 +1,4 @@
+{
+  "version": "0.1.1",
+  "digest": "sha256:cd4e69d7849c75213cbe6f42b3cb9392aede1d93bbde5f6864247d284e46b1c4"
+}

--- a/deno/.scripts/release.ts
+++ b/deno/.scripts/release.ts
@@ -534,7 +534,12 @@ export const release = async (): Promise<void> => {
 
   await assertSkillDeclarations(
     rootDir,
-    new Map(order.map(pkg => [pkg.name, (plan.get(pkg.name) as PlannedRelease).version]))
+    new Map(
+      order.flatMap((pkg): [string, string][] => {
+        const planned = plan.get(pkg.name)
+        return planned ? [[pkg.name, planned.version]] : []
+      })
+    )
   )
 
   console.log('\nApplying version + import updates...')

--- a/deno/.scripts/release.ts
+++ b/deno/.scripts/release.ts
@@ -428,6 +428,109 @@ const printReinstallHint = (
   }
 }
 
+/**
+ * A published skill declares the package minor it was written against
+ * (`metadata.describes`). Releasing past that declaration without touching the
+ * skill is how a skill starts lying: every export keeps its name, the rule it
+ * teaches changes, and no mechanical check notices.
+ *
+ * So the release refuses. The fix is to reread the skill against the diff and
+ * then update the declaration — one frontmatter edit, in the same PR as the
+ * change that forced it.
+ */
+const assertSkillDeclarations = async (
+  rootDir: string,
+  planned: Map<string, string>
+): Promise<void> => {
+  const skillsDir = join(rootDir, 'docs', 'skills')
+  const stale: string[] = []
+
+  for await (const entry of Deno.readDir(skillsDir)) {
+    if (!entry.isDirectory || entry.name.startsWith('.')) continue
+    const text = await Deno.readTextFile(join(skillsDir, entry.name, 'SKILL.md')).catch(() => '')
+    const describes = text.match(/^ {2}describes:\n((?: {4}'[^']+': '[^']+'\n)+)/m)
+    if (!describes) continue
+
+    for (const line of describes[1].trim().split('\n')) {
+      const declared = line.match(/'([^']+)': '([^']+)'/)
+      if (!declared) continue
+      const [, packageName, declaredMinor] = declared
+      const releasing = planned.get(packageName)
+      if (!releasing) continue
+      const releasingMinor = releasing.split('.').slice(0, 2).join('.')
+      if (releasingMinor !== declaredMinor) {
+        stale.push(
+          `  ${entry.name} was written against ${packageName} ${declaredMinor}; ` +
+            `releasing ${releasing}`
+        )
+      }
+    }
+  }
+
+  if (stale.length > 0) {
+    throw new Error(
+      `Release refused — a skill describes a minor this release moves past:\n${stale.join('\n')}\n\n` +
+        `Reread each skill against the package diff, update metadata.describes in its ` +
+        `SKILL.md, and re-run. Nothing has been published.`
+    )
+  }
+}
+
+/**
+ * Claude Code updates a plugin when its `version` moves, so a skill edit that
+ * ships without a bump reaches nobody. The bump is the release's job rather
+ * than the editing PR's: it is the release that makes the new text fetchable.
+ *
+ * Advisory by design — a git or manifest problem here must not fail a release
+ * whose packages are already on the registry.
+ */
+const bumpPluginVersion = async (rootDir: string): Promise<void> => {
+  const marketplacePath = join(rootDir, '..', '.claude-plugin', 'marketplace.json')
+  const pluginPath = join(rootDir, 'docs', 'skills', '.claude-plugin', 'plugin.json')
+
+  try {
+    const marketplace = JSON.parse(await Deno.readTextFile(marketplacePath))
+    const plugin = JSON.parse(await Deno.readTextFile(pluginPath))
+    const published: string[] = plugin.skills.map((path: string) => path.replace(/^\.\//, ''))
+
+    const lastBump = await new Deno.Command('git', {
+      args: ['log', '-1', '--format=%H', '--', marketplacePath],
+      cwd: rootDir,
+      stdout: 'piped',
+      stderr: 'null'
+    }).output()
+    const sinceSha = new TextDecoder().decode(lastBump.stdout).trim()
+    if (!sinceSha) return
+
+    const changed = await new Deno.Command('git', {
+      args: [
+        'diff',
+        '--name-only',
+        `${sinceSha}..HEAD`,
+        '--',
+        ...published.map(name => join(rootDir, 'docs', 'skills', name))
+      ],
+      cwd: rootDir,
+      stdout: 'piped',
+      stderr: 'null'
+    }).output()
+    if (new TextDecoder().decode(changed.stdout).trim() === '') return
+
+    const [major, minor, patch] = String(plugin.version).split('.').map(Number)
+    const next = `${major}.${minor}.${patch + 1}`
+    plugin.version = next
+    marketplace.plugins[0].version = next
+    await Deno.writeTextFile(pluginPath, `${JSON.stringify(plugin, null, 2)}\n`)
+    await Deno.writeTextFile(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`)
+    console.log(`\nPublished skills changed since the last plugin bump — plugin version -> ${next}`)
+  } catch (error) {
+    console.error(
+      `\nPlugin version not bumped (${error instanceof Error ? error.message : String(error)}). ` +
+        `Bump it by hand if a published skill changed.`
+    )
+  }
+}
+
 export const release = async (): Promise<void> => {
   const reinstallMode = parseReinstallMode(Deno.args)
   const rootDir = join(dirname(fromFileUrl(import.meta.url)), '..')
@@ -465,8 +568,14 @@ export const release = async (): Promise<void> => {
     console.log(`  ${pkg.name}@${planned.version}  (${type}${suffix})`)
   }
 
+  await assertSkillDeclarations(
+    rootDir,
+    new Map(order.map(pkg => [pkg.name, (plan.get(pkg.name) as PlannedRelease).version]))
+  )
+
   console.log('\nApplying version + import updates...')
   await applyPlan(order, plan)
+  await bumpPluginVersion(rootDir)
 
   console.log('\nPublishing...')
   // With a JSR_AUTH_TOKEN (e.g. the local mirror's shared secret) the

--- a/deno/.scripts/release.ts
+++ b/deno/.scripts/release.ts
@@ -22,6 +22,7 @@
  */
 
 import { dirname, fromFileUrl, join } from '@std/path'
+import { parse as parseYaml } from 'jsr:@std/yaml@^1'
 import { toDependencyAgeArgs } from '../cli/lib/dependency-age.ts'
 
 /**
@@ -429,6 +430,30 @@ const printReinstallHint = (
 }
 
 /**
+ * `metadata.describes` out of a SKILL.md, parsed as YAML.
+ *
+ * A regex over the frontmatter was whitespace-exact, so re-indenting it or
+ * quoting it differently silently emptied the declaration — and an emptied
+ * declaration disables the guard rather than failing it.
+ */
+const readDescribes = (skillText: string): Record<string, string> => {
+  const block = skillText.match(/^---\n([\s\S]*?)\n---\n/)
+  if (!block) return {}
+  const frontmatter = parseYaml(block[1])
+  if (!isRecord(frontmatter) || !isRecord(frontmatter.metadata)) return {}
+  const describes = frontmatter.metadata.describes
+  if (!isRecord(describes)) return {}
+  return Object.fromEntries(
+    Object.entries(describes).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    )
+  )
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
  * A published skill declares the package minor it was written against
  * (`metadata.describes`). Releasing past that declaration without touching the
  * skill is how a skill starts lying: every export keeps its name, the rule it
@@ -448,13 +473,7 @@ const assertSkillDeclarations = async (
   for await (const entry of Deno.readDir(skillsDir)) {
     if (!entry.isDirectory || entry.name.startsWith('.')) continue
     const text = await Deno.readTextFile(join(skillsDir, entry.name, 'SKILL.md')).catch(() => '')
-    const describes = text.match(/^ {2}describes:\n((?: {4}'[^']+': '[^']+'\n)+)/m)
-    if (!describes) continue
-
-    for (const line of describes[1].trim().split('\n')) {
-      const declared = line.match(/'([^']+)': '([^']+)'/)
-      if (!declared) continue
-      const [, packageName, declaredMinor] = declared
+    for (const [packageName, declaredMinor] of Object.entries(readDescribes(text))) {
       const releasing = planned.get(packageName)
       if (!releasing) continue
       const releasingMinor = releasing.split('.').slice(0, 2).join('.')
@@ -472,61 +491,6 @@ const assertSkillDeclarations = async (
       `Release refused — a skill describes a minor this release moves past:\n${stale.join('\n')}\n\n` +
         `Reread each skill against the package diff, update metadata.describes in its ` +
         `SKILL.md, and re-run. Nothing has been published.`
-    )
-  }
-}
-
-/**
- * Claude Code updates a plugin when its `version` moves, so a skill edit that
- * ships without a bump reaches nobody. The bump is the release's job rather
- * than the editing PR's: it is the release that makes the new text fetchable.
- *
- * Advisory by design — a git or manifest problem here must not fail a release
- * whose packages are already on the registry.
- */
-const bumpPluginVersion = async (rootDir: string): Promise<void> => {
-  const marketplacePath = join(rootDir, '..', '.claude-plugin', 'marketplace.json')
-  const pluginPath = join(rootDir, 'docs', 'skills', '.claude-plugin', 'plugin.json')
-
-  try {
-    const marketplace = JSON.parse(await Deno.readTextFile(marketplacePath))
-    const plugin = JSON.parse(await Deno.readTextFile(pluginPath))
-    const published: string[] = plugin.skills.map((path: string) => path.replace(/^\.\//, ''))
-
-    const lastBump = await new Deno.Command('git', {
-      args: ['log', '-1', '--format=%H', '--', marketplacePath],
-      cwd: rootDir,
-      stdout: 'piped',
-      stderr: 'null'
-    }).output()
-    const sinceSha = new TextDecoder().decode(lastBump.stdout).trim()
-    if (!sinceSha) return
-
-    const changed = await new Deno.Command('git', {
-      args: [
-        'diff',
-        '--name-only',
-        `${sinceSha}..HEAD`,
-        '--',
-        ...published.map(name => join(rootDir, 'docs', 'skills', name))
-      ],
-      cwd: rootDir,
-      stdout: 'piped',
-      stderr: 'null'
-    }).output()
-    if (new TextDecoder().decode(changed.stdout).trim() === '') return
-
-    const [major, minor, patch] = String(plugin.version).split('.').map(Number)
-    const next = `${major}.${minor}.${patch + 1}`
-    plugin.version = next
-    marketplace.plugins[0].version = next
-    await Deno.writeTextFile(pluginPath, `${JSON.stringify(plugin, null, 2)}\n`)
-    await Deno.writeTextFile(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`)
-    console.log(`\nPublished skills changed since the last plugin bump — plugin version -> ${next}`)
-  } catch (error) {
-    console.error(
-      `\nPlugin version not bumped (${error instanceof Error ? error.message : String(error)}). ` +
-        `Bump it by hand if a published skill changed.`
     )
   }
 }
@@ -575,7 +539,6 @@ export const release = async (): Promise<void> => {
 
   console.log('\nApplying version + import updates...')
   await applyPlan(order, plan)
-  await bumpPluginVersion(rootDir)
 
   console.log('\nPublishing...')
   // With a JSR_AUTH_TOKEN (e.g. the local mirror's shared secret) the

--- a/deno/.scripts/run-git.ts
+++ b/deno/.scripts/run-git.ts
@@ -1,0 +1,35 @@
+/**
+ * `git` run with the environment cleared apart from what spawning needs.
+ *
+ * A git hook exports `GIT_DIR` and `GIT_INDEX_FILE`, and a child `git` obeys
+ * them over its own working directory — so the same command answers one thing
+ * from a shell and another from a pre-push hook. Anything that reads git state
+ * on behalf of a check has to ignore an ambient repo pointer, so every such
+ * caller goes through here rather than spawning `git` itself.
+ *
+ * Only the index and the working tree are safe to read this way: they are the
+ * same in a shallow clone, which history is not.
+ */
+
+const decoder = new TextDecoder()
+
+export const runGit = async (cwd: string, args: string[]): Promise<string> => {
+  const output = await new Deno.Command('git', {
+    args,
+    cwd,
+    clearEnv: true,
+    env: {
+      NO_COLOR: '1',
+      PATH: Deno.env.get('PATH') ?? '',
+      HOME: Deno.env.get('HOME') ?? ''
+    },
+    stdout: 'piped',
+    stderr: 'piped'
+  }).output()
+
+  if (!output.success) {
+    throw new Error(`git ${args.join(' ')} failed: ${decoder.decode(output.stderr)}`)
+  }
+
+  return decoder.decode(output.stdout)
+}

--- a/deno/deno.json
+++ b/deno/deno.json
@@ -44,6 +44,7 @@
   "tasks": {
     "release": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run .scripts/release.ts",
     "bump": "deno run --allow-read --allow-write .scripts/bump.ts",
+    "bump-plugin": "deno run --allow-read --allow-write .scripts/bump-plugin.ts",
     "skills": "deno run --allow-read --allow-write --allow-env --allow-run=git .scripts/skills.ts",
     "check": "deno task verify-docs && deno test --allow-all",
     "test:watch": "deno test --allow-all --watch",

--- a/deno/deno.json
+++ b/deno/deno.json
@@ -44,14 +44,14 @@
   "tasks": {
     "release": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run .scripts/release.ts",
     "bump": "deno run --allow-read --allow-write .scripts/bump.ts",
-    "bump-plugin": "deno run --allow-read --allow-write .scripts/bump-plugin.ts",
+    "bump-plugin": "deno run --allow-read --allow-write --allow-env --allow-run=git .scripts/bump-plugin.ts",
     "skills": "deno run --allow-read --allow-write --allow-env --allow-run=git .scripts/skills.ts",
     "check": "deno task verify-docs && deno test --allow-all",
     "test:watch": "deno test --allow-all --watch",
     "test:coverage": "deno test --allow-all --coverage=coverage",
     "coverage:report": "deno coverage coverage --lcov > coverage.lcov",
     "coverage:html": "deno coverage coverage --html",
-    "verify-docs": "deno run --allow-read --allow-run=deno docs/verify-docs.ts && deno run --allow-read --allow-run docs/friction-log/verify-catalog.ts && deno run --allow-read --allow-write --allow-run --allow-env docs/doc-test.ts"
+    "verify-docs": "deno run --allow-read --allow-env --allow-run=deno,git docs/verify-docs.ts && deno run --allow-read --allow-run docs/friction-log/verify-catalog.ts && deno run --allow-read --allow-write --allow-run --allow-env docs/doc-test.ts"
   },
   "minimumDependencyAge": "0",
   "exclude": [

--- a/deno/deno.lock
+++ b/deno/deno.lock
@@ -41,6 +41,7 @@
     "jsr:@std/streams@^1.1.1": "1.1.1",
     "jsr:@std/testing@^1.0.15": "1.0.19",
     "jsr:@std/text@^1.0.17": "1.0.19",
+    "jsr:@std/yaml@1": "1.1.2",
     "jsr:@std/yaml@^1.0.5": "1.1.2",
     "jsr:@std/yaml@^1.1.0": "1.1.2",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",

--- a/deno/docs/README.md
+++ b/deno/docs/README.md
@@ -230,15 +230,7 @@ If you are a coding assistant, read [`llms.md`](llms.md) — a primer optimized 
 
 Five skills ship from this repo, at the same commit as the code they describe: `skmtc-generator` (engine rules), `skmtc-lang-typescript` (the emitted TypeScript), `skmtc-model` and `skmtc-operation` (the two generator shapes), and `skmtc-cli`.
 
-```bash
-# Claude Code
-/plugin marketplace add skmtc/skmtc
-/plugin install skmtc@skmtc
-
-# any skills-capable agent
-npx skills add skmtc/skmtc
-npx skills add skmtc/skmtc --skill skmtc-generator
-```
+To install them, see [Install the agent skills](https://github.com/skmtc/skmtc#install-the-agent-skills) in the repo README — the install lines live there and nowhere else, so there is no second copy to go stale.
 
 Each one reads fine on its own — for example [`skmtc-generator`](skills/skmtc-generator/SKILL.md) and [`skmtc-cli`](skills/skmtc-cli/SKILL.md).
 

--- a/deno/docs/skills/.claude-plugin/plugin.json
+++ b/deno/docs/skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skmtc",
   "description": "Author Skmtc generators — derive application code from an OpenAPI document treated as a domain model.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Skmtc",
     "url": "https://skmtc.dev"

--- a/deno/docs/skills/README.md
+++ b/deno/docs/skills/README.md
@@ -76,7 +76,7 @@ authority and acted on without checking. Every guard below runs in
 | Declared-version sync | A skill still declaring a package minor the workspace has moved past | `verify-docs` |
 | Doc-test | A renamed export breaking a fenced `ts` block a skill quotes | `doc-test` |
 | Worked-example pins | The Kotlin skill's example, and the model skeleton, no longer producing what they promise | `deno test` |
-| Plugin-version freshness | A published skill edited without bumping the plugin version, so no installed plugin ever sees it | `verify-docs` (digest of the published skills; fix with `deno task bump-plugin`) |
+| Plugin-version freshness | A published skill edited without bumping the plugin version, so no installed plugin ever sees it | `verify-docs` (digest of the published skills and the plugin manifest; fix with `deno task bump-plugin`) |
 | One install source | A second copy of the install lines, which drifts from the canonical one | `verify-docs` |
 | Release refusal | A release moving past a minor a skill declares | `deno task release` |
 

--- a/deno/docs/skills/README.md
+++ b/deno/docs/skills/README.md
@@ -76,6 +76,8 @@ authority and acted on without checking. Every guard below runs in
 | Declared-version sync | A skill still declaring a package minor the workspace has moved past | `verify-docs` |
 | Doc-test | A renamed export breaking a fenced `ts` block a skill quotes | `doc-test` |
 | Worked-example pins | The Kotlin skill's example, and the model skeleton, no longer producing what they promise | `deno test` |
+| Plugin-version freshness | A published skill edited without bumping the plugin version, so no installed plugin ever sees it | `verify-docs` (digest of the published skills; fix with `deno task bump-plugin`) |
+| One install source | A second copy of the install lines, which drifts from the canonical one | `verify-docs` |
 | Release refusal | A release moving past a minor a skill declares | `deno task release` |
 
 The last two rows are the ones that catch a changed *rule* rather than a

--- a/deno/docs/skills/README.md
+++ b/deno/docs/skills/README.md
@@ -72,7 +72,7 @@ authority and acted on without checking. Every guard below runs in
 | Lang source↔skill sync | An identifier factory or value-protocol guard the lang skill never mentions, or an entity-kind count that moved (Kotlin and TypeScript) | `verify-docs` |
 | CLI reference sync | A `cli/mod.ts` command missing from the reference pages, in both directions | `verify-docs` |
 | Skills catalogue sync | A README row, frontmatter version, `metadata.internal` flag or plugin.json membership disagreeing with the others | `verify-docs` |
-| Generated-appendix freshness | An appendix not regenerated after its package's source moved | `verify-docs` (runs the generator with `--check`) |
+| Generated-appendix coverage | An export missing from the appendix, because it was not regenerated after the API moved | `verify-docs` (names, not formatting — `deno doc`'s layout shifts between patch releases; `generate-skill-api-appendix.ts --check` does the exact comparison locally) |
 | Declared-version sync | A skill still declaring a package minor the workspace has moved past | `verify-docs` |
 | Doc-test | A renamed export breaking a fenced `ts` block a skill quotes | `doc-test` |
 | Worked-example pins | The Kotlin skill's example, and the model skeleton, no longer producing what they promise | `deno test` |

--- a/deno/docs/skills/README.md
+++ b/deno/docs/skills/README.md
@@ -60,6 +60,30 @@ older copy can then compare numbers and get the right answer. The tables above
 are checked against frontmatter by `verify-docs`, so a version edited in one
 place and not the other fails the gate.
 
+## What keeps these true
+
+A skill that has drifted from the engine is worse than no skill: it is read as
+authority and acted on without checking. Every guard below runs in
+`deno task check`, which CI runs on each pull request.
+
+| Guard | What it catches | Where |
+| --- | --- | --- |
+| Fact-anchor sync | An `llms.md` fact clause missing from `skmtc-generator` | `verify-docs` |
+| Lang source↔skill sync | An identifier factory or value-protocol guard the lang skill never mentions, or an entity-kind count that moved (Kotlin and TypeScript) | `verify-docs` |
+| CLI reference sync | A `cli/mod.ts` command missing from the reference pages, in both directions | `verify-docs` |
+| Skills catalogue sync | A README row, frontmatter version, `metadata.internal` flag or plugin.json membership disagreeing with the others | `verify-docs` |
+| Generated-appendix freshness | An appendix not regenerated after its package's source moved | `verify-docs` (runs the generator with `--check`) |
+| Declared-version sync | A skill still declaring a package minor the workspace has moved past | `verify-docs` |
+| Doc-test | A renamed export breaking a fenced `ts` block a skill quotes | `doc-test` |
+| Worked-example pins | The Kotlin skill's example, and the model skeleton, no longer producing what they promise | `deno test` |
+| Release refusal | A release moving past a minor a skill declares | `deno task release` |
+
+The last two rows are the ones that catch a changed *rule* rather than a
+renamed *symbol*. Name-level checks cannot see a default that flipped or a step
+that became required; a pinned example fails on it, and the declared-version
+gate forces a human to reread the skill before the release goes out. Editing
+the declared number is the record that someone looked.
+
 ## How skills relate to docs
 
 Skills are the **operational layer**; docs are the **reference layer**. The

--- a/deno/docs/skills/skmtc-cli/SKILL.md
+++ b/deno/docs/skills/skmtc-cli/SKILL.md
@@ -28,6 +28,9 @@ allowed-tools:
   - Grep
   - Write
   - Edit
+metadata:
+  describes:
+    '@skmtc/cli': '0.9'
 ---
 
 # Skmtc CLI

--- a/deno/docs/skills/skmtc-generator/SKILL.md
+++ b/deno/docs/skills/skmtc-generator/SKILL.md
@@ -10,6 +10,9 @@ description: >
   "change export paths", "add enrichment options", or when editing
   generator source. ALWAYS pair with the target language's skill
   (skmtc-lang-typescript).
+metadata:
+  describes:
+    '@skmtc/core': '0.28'
 ---
 
 # Authoring Skmtc generators

--- a/deno/docs/skills/skmtc-lang-kotlin/SKILL.md
+++ b/deno/docs/skills/skmtc-lang-kotlin/SKILL.md
@@ -341,7 +341,7 @@ discriminator omission. Everything else renders the honest wire type
 
 The full `deno doc` surface for the packages this skill covers lives
 in [`appendix.md`](appendix.md), in this skill's directory —
-generated from framework source at `71ef53bc`, signatures and
+generated from framework source at `0f26b1b7`, signatures and
 field docs only. It is **authoritative**: when the prose above does
 not carry the exact constructor or field shape you need, Read (or
 grep) `appendix.md` instead of diving into package source. Do not

--- a/deno/docs/skills/skmtc-lang-kotlin/SKILL.md
+++ b/deno/docs/skills/skmtc-lang-kotlin/SKILL.md
@@ -341,8 +341,8 @@ discriminator omission. Everything else renders the honest wire type
 
 The full `deno doc` surface for the packages this skill covers lives
 in [`appendix.md`](appendix.md), in this skill's directory —
-generated from framework source at `0f26b1b7`, signatures and
-field docs only. It is **authoritative**: when the prose above does
+generated from framework source — signatures and field docs only.
+It is **authoritative**: when the prose above does
 not carry the exact constructor or field shape you need, Read (or
 grep) `appendix.md` instead of diving into package source. Do not
 guess signatures. For a symbol not listed there,

--- a/deno/docs/skills/skmtc-lang-kotlin/appendix.md
+++ b/deno/docs/skills/skmtc-lang-kotlin/appendix.md
@@ -1,7 +1,7 @@
 # Appendix — generated API reference
 
 > Generated from framework source by
-> `deno run --allow-read --allow-write --allow-run=deno,git .scripts/generate-skill-api-appendix.ts`
+> `deno run --allow-read --allow-write --allow-env --allow-run=deno,git .scripts/generate-skill-api-appendix.ts`
 > (from `deno/`). **Authoritative** for signatures, fields, and doc
 > comments — trust it instead of re-reading package source. JSDoc
 > `@example` blocks are stripped at generation. For a symbol not

--- a/deno/docs/skills/skmtc-lang-kotlin/appendix.md
+++ b/deno/docs/skills/skmtc-lang-kotlin/appendix.md
@@ -1,6 +1,6 @@
 # Appendix — generated API reference
 
-> Generated from framework source at `71ef53bc` by
+> Generated from framework source at `0f26b1b7` by
 > `deno run --allow-read --allow-write --allow-run=deno,git .scripts/generate-skill-api-appendix.ts`
 > (from `deno/`). **Authoritative** for signatures, fields, and doc
 > comments — trust it instead of re-reading package source. JSDoc
@@ -158,7 +158,7 @@ function sanitizePropertyName(propertyName: string): string
   Returns a plain `string` (unlike the TypeScript version's key-value
   fallback — Kotlin has no quoted-property syntax to fall back to).
 
-Defined in deno/lang-kotlin/src/KtAnnotation.ts:121:14
+Defined in deno/lang-kotlin/src/KtAnnotation.ts:149:14
 
 function toKtAnnotations(value: unknown): KtAnnotations
   Collect a value's {@link KtAnnotated} protocol field into a
@@ -300,7 +300,7 @@ Defined in deno/lang-kotlin/mod.ts:31:14
 const langId: "kotlin"
   The language id this package targets.
 
-Defined in deno/lang-kotlin/src/KtAnnotation.ts:48:1
+Defined in deno/lang-kotlin/src/KtAnnotation.ts:72:1
 
 class KtAnnotation
   Renders a Kotlin annotation: `@Serializable`, `@SerialName("user_id")`.
@@ -324,12 +324,13 @@ class KtAnnotation
   caller. WHICH annotation to emit is generator policy (the serialization
   seam lives in `gen-kotlin`); this package only renders what it is handed.
 
-  constructor({context, name, args, packageName, destinationPath}: KtAnnotationArgs)
+  constructor({context, name, args, target, packageName, destinationPath}: KtAnnotationArgs)
   name: string
   args: Stringable[]
+  target: KtAnnotationTarget | undefined
   toString(): string
 
-Defined in deno/lang-kotlin/src/KtAnnotation.ts:104:1
+Defined in deno/lang-kotlin/src/KtAnnotation.ts:132:1
 
 class KtAnnotations
   A class-level annotation block — zero or more {@link KtAnnotation}s,
@@ -647,7 +648,7 @@ type CreateValueArgs = { typeName?: string; exported?: boolean; }
   Options for {@link createValue} — the only factory with a `typeName`
   slot (the `val x: T = …` annotation).
 
-Defined in deno/lang-kotlin/src/KtAnnotation.ts:79:1
+Defined in deno/lang-kotlin/src/KtAnnotation.ts:107:1
 
 type KtAnnotated = { annotations: KtAnnotation[]; }
   The protocol by which a Definition's VALUE supplies class-level
@@ -659,10 +660,17 @@ type KtAnnotated = { annotations: KtAnnotation[]; }
   {@link toKtAnnotations} and renders the annotations above the
   declaration head.
 
-Defined in deno/lang-kotlin/src/KtAnnotation.ts:6:1
+Defined in deno/lang-kotlin/src/KtAnnotation.ts:23:1
 
-type KtAnnotationArgs = { context: GenerateContextType; name: string; args?: Stringable[]; packageName?: string; destinationPath: string; }
+type KtAnnotationArgs = { context: GenerateContextType; name: string; args?: Stringable[]; target?: KtAnnotationTarget; packageName?: string; destinationPath: string; }
   Constructor arguments for {@link KtAnnotation}.
+
+Defined in deno/lang-kotlin/src/KtAnnotation.ts:8:1
+
+type KtAnnotationTarget = "field" | "get" | "set" | "param" | "property" | "receiver" | "setparam" | "delegate" | "file" | "all"
+  Kotlin's annotation use-site targets — the `field:` in
+  `@field:JsonAnySetter`. Grammar-level, so the set is closed and owned
+  here; WHICH target a generator picks is its policy.
 
 Defined in deno/lang-kotlin/src/register.ts:77:1
 

--- a/deno/docs/skills/skmtc-lang-kotlin/appendix.md
+++ b/deno/docs/skills/skmtc-lang-kotlin/appendix.md
@@ -1,6 +1,6 @@
 # Appendix — generated API reference
 
-> Generated from framework source at `0f26b1b7` by
+> Generated from framework source by
 > `deno run --allow-read --allow-write --allow-run=deno,git .scripts/generate-skill-api-appendix.ts`
 > (from `deno/`). **Authoritative** for signatures, fields, and doc
 > comments — trust it instead of re-reading package source. JSDoc

--- a/deno/docs/skills/skmtc-lang-typescript/SKILL.md
+++ b/deno/docs/skills/skmtc-lang-typescript/SKILL.md
@@ -9,6 +9,10 @@ description: >
   Use ALONGSIDE skmtc-generator whenever a generator emits
   TypeScript. Headings are the template for other skmtc-lang-*
   skills.
+metadata:
+  describes:
+    '@skmtc/lang-typescript': '0.12'
+    '@skmtc/core': '0.28'
 ---
 
 # The TypeScript layer (@skmtc/lang-typescript)
@@ -68,11 +72,13 @@ the correct pattern, and merging is idempotent.
 
 ## 3. Identifier kinds
 
-`TsEntityType = 'variable' | 'type' | 'class' | 'interface' |
-'namespace'` — factories `createVariable(name, { typeName? })`,
-`createType`, `createClass`, `createInterface`, `createNamespace`.
-No `'function'` kind: a generated function is a `variable` whose value
-renders as an arrow function.
+TypeScript output has five entity kinds — `TsEntityType = 'variable' |
+'type' | 'class' | 'interface' | 'namespace'` — factories
+`createVariable(name, { typeName? })`, `createType`, `createClass`,
+`createInterface`, `createNamespace`. No `'function'` kind: a generated
+function is a `variable` whose value renders as an arrow function. The
+engine's identifier `type` is an opaque string; `isTsEntityType` narrows
+it to the five above.
 
 `toIdentifierType` is one lever with three effects: declaration keyword;
 block form (class/interface/namespace take no `= value;`); and whether

--- a/deno/docs/skills/skmtc-model/SKILL.md
+++ b/deno/docs/skills/skmtc-model/SKILL.md
@@ -11,6 +11,10 @@ description: >
   validator/schema/type library ("write a gen-<lib>", "map OpenAPI
   models to <lib>"). Load ALONGSIDE skmtc-generator (engine rules)
   and skmtc-lang-typescript (TS layer).
+metadata:
+  describes:
+    '@skmtc/core': '0.28'
+    '@skmtc/lang-typescript': '0.12'
 ---
 
 # Model generators: fill the skeleton

--- a/deno/docs/skills/skmtc-operation/SKILL.md
+++ b/deno/docs/skills/skmtc-operation/SKILL.md
@@ -13,6 +13,9 @@ description: >
   "generate an SDK/form per endpoint"). Covers the projection shape
   only — accumulators (many operations → one file) are out of scope.
   Load ALONGSIDE skmtc-generator and the emitted language's skill.
+metadata:
+  describes:
+    '@skmtc/core': '0.28'
 ---
 
 # Operation generators: decompose the operation, reference the models

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -301,6 +301,11 @@ const languageSyncTargets: {
     packageDirectory: 'lang-kotlin',
     skillName: 'skmtc-lang-kotlin',
     guardPrefix: 'isKt'
+  },
+  {
+    packageDirectory: 'lang-typescript',
+    skillName: 'skmtc-lang-typescript',
+    guardPrefix: 'isTs'
   }
 ]
 
@@ -1230,6 +1235,127 @@ if (catalogueFailures === 0) {
   pass(
     `skills catalogue: ${skillDirectories.length} skills, ${publishedSkillNames.length} published ` +
       `(names, versions, internal flags and README rows all agree)`
+  )
+}
+
+// ---------------------------------------------------------------------
+// 15. Generated-appendix freshness — `deno doc` output cannot disagree
+//     with source, so the only way the appendix drifts is by not being
+//     regenerated after the source moved. The generator regenerates in
+//     memory under --check and compares, which is the same work a
+//     reviewer would otherwise have to remember to do.
+// ---------------------------------------------------------------------
+
+const appendixCheck = await new Deno.Command('deno', {
+  args: [
+    'run',
+    '--allow-read',
+    '--allow-run=deno,git',
+    join(denoDir, '.scripts', 'generate-skill-api-appendix.ts'),
+    '--check'
+  ],
+  cwd: denoDir,
+  stdout: 'piped',
+  stderr: 'piped'
+}).output()
+
+if (appendixCheck.success) {
+  pass(new TextDecoder().decode(appendixCheck.stdout).trim())
+} else {
+  fail(new TextDecoder().decode(appendixCheck.stderr).trim().split('\n')[0])
+}
+
+// ---------------------------------------------------------------------
+// 16. Declared-version sync — the check the mechanical guards cannot
+//     make. Every check above catches a RENAMED export; none catches a
+//     changed RULE that keeps every name — a default flipped, a
+//     protocol reordered, a step that became required. So each
+//     published skill declares the package minor it was written
+//     against, and a workspace that has moved past it fails here. The
+//     fix is not editing the number: it is rereading the skill against
+//     the package's diff, then editing the number.
+// ---------------------------------------------------------------------
+
+const workspaceVersions = new Map<string, { version: string; directory: string }>()
+for await (const entry of Deno.readDir(denoDir)) {
+  if (!entry.isDirectory || entry.name.startsWith('.')) continue
+  const denoJsonPath = join(denoDir, entry.name, 'deno.json')
+  const denoJson = await Deno.readTextFile(denoJsonPath).catch(() => undefined)
+  if (!denoJson) continue
+  const { name, version } = JSON.parse(denoJson)
+  if (typeof name === 'string' && typeof version === 'string') {
+    workspaceVersions.set(name, { version, directory: entry.name })
+  }
+}
+
+const toMinor = (version: string): string => version.split('.').slice(0, 2).join('.')
+
+let declaredVersionFailures = 0
+let declarationCount = 0
+
+for (const directory of skillDirectories) {
+  const skillText = await Deno.readTextFile(join(skillsDir, directory, 'SKILL.md')).catch(() => '')
+  const describes = skillText.match(/^ {2}describes:\n((?: {4}'[^']+': '[^']+'\n)+)/m)
+  if (!describes) continue
+
+  for (const line of describes[1].trim().split('\n')) {
+    const declared = line.match(/'([^']+)': '([^']+)'/)
+    if (!declared) continue
+    declarationCount++
+    const [, packageName, declaredMinor] = declared
+    const workspace = workspaceVersions.get(packageName)
+    if (!workspace) {
+      declaredVersionFailures++
+      fail(`${directory} declares ${packageName}, which is not a workspace package`)
+      continue
+    }
+    if (toMinor(workspace.version) !== declaredMinor) {
+      declaredVersionFailures++
+      fail(
+        `${directory} was written against ${packageName} ${declaredMinor}, and the workspace is ` +
+          `on ${workspace.version}. Reread the skill against \`git log ${workspace.directory}\` ` +
+          `since that minor, then update metadata.describes — the number is the record that ` +
+          `someone looked.`
+      )
+    }
+  }
+}
+
+if (declaredVersionFailures === 0) {
+  pass(
+    `declared-version sync: ${declarationCount} skill declaration(s) match the workspace minors`
+  )
+}
+
+// ---------------------------------------------------------------------
+// 17. One install source — the skill install lines live in the repo
+//     README and nowhere else. A second copy is not a duplication
+//     problem, it is a correctness one: the two drift, and the reader
+//     who finds the stale copy has no way to tell which is current.
+//     (The published site renders its own copy from a component; it is
+//     a different medium, not a second place to edit prose.)
+// ---------------------------------------------------------------------
+
+const INSTALL_LINE = 'npx skills add skmtc/skmtc'
+const installSources: string[] = []
+
+const rootReadme = join(denoDir, '..', 'README.md')
+if ((await Deno.readTextFile(rootReadme)).includes(INSTALL_LINE)) {
+  installSources.push('README.md')
+}
+
+for (const [relPath, text] of readerFileTexts) {
+  if (text.includes(INSTALL_LINE)) installSources.push(relPath)
+}
+
+if (installSources.length === 1 && installSources[0] === 'README.md') {
+  pass('install source: the skill install lines appear in README.md and nowhere else')
+} else if (installSources.length === 0) {
+  fail(`install source: no file carries \`${INSTALL_LINE}\` — the README section is the one place it belongs`)
+} else {
+  fail(
+    `install source: the install lines appear in ${installSources.length} files ` +
+      `(${installSources.join(', ')}). Keep them in README.md and link to that section.`
   )
 }
 

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read --allow-run=deno
+#!/usr/bin/env -S deno run --allow-read --allow-env --allow-run=deno,git
 /**
  * Mechanical doc/skill-chain sync checks — the regression guard for the
  * drift class the friction reviews keep finding (old C8 → C15: the
@@ -84,7 +84,8 @@
  *   exit 0 — all checks hold.
  *   exit 1 — one or more failed; each failure names file + expectation.
  *
- * Usage:  deno run --allow-read --allow-run=deno deno/docs/verify-docs.ts
+ * Usage:  deno run --allow-read --allow-env --allow-run=deno,git \
+ *           deno/docs/verify-docs.ts
  *         deno run --allow-read --allow-write deno/docs/verify-docs.ts \
  *           --update-reader-baseline   # rewrite reader-lint-baseline.json
  *                                      # to the current violation set
@@ -1469,10 +1470,10 @@ if (installSources.length === 1 && installSources[0] === ROOT_README) {
 //     Enforced from CONTENT, not git history. Making the release bump it
 //     could not work: the publish job checks out shallow and read-only,
 //     so `git log` answers differently there and the write is discarded
-//     with the runner either way. A digest of the published skills
-//     answers the same in a shallow clone, a hook and CI, and it puts
-//     the bump in the PR that edits the skill, where a human is already
-//     deciding what changed.
+//     with the runner either way. A digest of the published skills and
+//     the manifest that ships them answers the same in a shallow clone,
+//     a hook and CI, and it puts the bump in the PR that edits the
+//     skill, where a human is already deciding what changed.
 // ---------------------------------------------------------------------
 
 const pluginManifest = JSON.parse(
@@ -1496,6 +1497,11 @@ if (!marketplaceEntry) {
   fail(
     `plugin version: plugin.json says ${pluginManifest.version} and marketplace.json says ` +
       `${marketplaceEntry.version} — a consumer resolves one of them and gets the other's skills`
+  )
+} else if (marketplaceEntry.description !== pluginManifest.description) {
+  fail(
+    `plugin version: plugin.json and marketplace.json describe the plugin differently — the ` +
+      `catalogue shows one and the installed plugin the other`
   )
 } else if (pluginRecord.digest !== skillsDigest) {
   fail(

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -1250,6 +1250,7 @@ const appendixCheck = await new Deno.Command('deno', {
   args: [
     'run',
     '--allow-read',
+    '--allow-env',
     '--allow-run=deno,git',
     join(denoDir, '.scripts', 'generate-skill-api-appendix.ts'),
     '--check'

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -94,6 +94,8 @@
  */
 
 import { dirname, fromFileUrl, join } from 'jsr:@std/path@^1'
+import { parse as parseYaml } from 'jsr:@std/yaml@^1'
+import { computeSkillsDigest } from '../.scripts/plugin-digest.ts'
 
 const docsDir = dirname(fromFileUrl(import.meta.url))
 const denoDir = join(docsDir, '..')
@@ -1300,7 +1302,13 @@ for (const { packageDirectory, skillName } of appendixTargets) {
   }
 
   const appendix = await Deno.readTextFile(join(skillsDir, skillName, 'appendix.md'))
-  const missing = [...exported].filter(name => !appendix.includes(name)).sort()
+  // Word-boundary, not substring: lang-kotlin exports `KtAnnotation`
+  // alongside `KtAnnotations`, `KtAnnotationArgs` and `KtAnnotationTarget`,
+  // so a bare `includes` reports the shortest name as present on the
+  // strength of a longer one and the dropped export goes unseen.
+  const mentions = (name: string): boolean =>
+    new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(appendix)
+  const missing = [...exported].filter(name => !mentions(name)).sort()
 
   if (missing.length > 0) {
     fail(
@@ -1342,19 +1350,52 @@ for await (const entry of Deno.readDir(denoDir)) {
 
 const toMinor = (version: string): string => version.split('.').slice(0, 2).join('.')
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * `metadata.describes`, parsed as YAML rather than matched with a
+ * whitespace-exact regex. The regex made the guard self-disabling: re-indent
+ * the block, switch to double quotes or flow style, and the declaration read as
+ * absent — which skipped the check instead of failing it.
+ */
+const readDescribes = (skillText: string): Record<string, string> | undefined => {
+  const block = skillText.match(/^---\n([\s\S]*?)\n---\n/)
+  if (!block) return undefined
+  const frontmatter = parseYaml(block[1])
+  if (!isRecord(frontmatter) || !isRecord(frontmatter.metadata)) return undefined
+  const describes = frontmatter.metadata.describes
+  if (!isRecord(describes)) return undefined
+  return Object.fromEntries(
+    Object.entries(describes).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    )
+  )
+}
+
 let declaredVersionFailures = 0
 let declarationCount = 0
 
 for (const directory of skillDirectories) {
   const skillText = await Deno.readTextFile(join(skillsDir, directory, 'SKILL.md')).catch(() => '')
-  const describes = skillText.match(/^ {2}describes:\n((?: {4}'[^']+': '[^']+'\n)+)/m)
-  if (!describes) continue
+  const describes = readDescribes(skillText)
+  const published = publishedSkillNames.includes(directory)
 
-  for (const line of describes[1].trim().split('\n')) {
-    const declared = line.match(/'([^']+)': '([^']+)'/)
-    if (!declared) continue
+  // Absence is a failure for a published skill, not a skip: deleting the three
+  // frontmatter lines would otherwise remove the guard with nothing noticing,
+  // which is the exact failure mode this check exists for.
+  if (published && (describes === undefined || Object.keys(describes).length === 0)) {
+    declaredVersionFailures++
+    fail(
+      `${directory} is published but declares no metadata.describes — a published skill has to ` +
+        `name the package minor it was written against, or a release can outrun it silently`
+    )
+    continue
+  }
+  if (describes === undefined) continue
+
+  for (const [packageName, declaredMinor] of Object.entries(describes)) {
     declarationCount++
-    const [, packageName, declaredMinor] = declared
     const workspace = workspaceVersions.get(packageName)
     if (!workspace) {
       declaredVersionFailures++
@@ -1389,26 +1430,86 @@ if (declaredVersionFailures === 0) {
 // ---------------------------------------------------------------------
 
 const INSTALL_LINE = 'npx skills add skmtc/skmtc'
+
+// `readerFileTexts` keys docs/README.md as `README.md`, which is also what the
+// repo-root README would be called — so the two are labelled by their path from
+// the repo root. Without that the check cannot tell "the canonical home has the
+// lines" from "the canonical home is empty and a copy has them", which is the
+// exact drift it exists to stop, and a two-copy failure reads as
+// `(README.md, README.md)` with no way to know which file to edit.
+const ROOT_README = '<repo>/README.md'
 const installSources: string[] = []
 
-const rootReadme = join(denoDir, '..', 'README.md')
-if ((await Deno.readTextFile(rootReadme)).includes(INSTALL_LINE)) {
-  installSources.push('README.md')
+if ((await Deno.readTextFile(join(denoDir, '..', 'README.md'))).includes(INSTALL_LINE)) {
+  installSources.push(ROOT_README)
 }
 
 for (const [relPath, text] of readerFileTexts) {
-  if (text.includes(INSTALL_LINE)) installSources.push(relPath)
+  if (text.includes(INSTALL_LINE)) installSources.push(`deno/docs/${relPath}`)
 }
 
-if (installSources.length === 1 && installSources[0] === 'README.md') {
-  pass('install source: the skill install lines appear in README.md and nowhere else')
+if (installSources.length === 1 && installSources[0] === ROOT_README) {
+  pass(`install source: the skill install lines appear in ${ROOT_README} and nowhere else`)
 } else if (installSources.length === 0) {
-  fail(`install source: no file carries \`${INSTALL_LINE}\` — the README section is the one place it belongs`)
+  fail(
+    `install source: no file carries \`${INSTALL_LINE}\` — ${ROOT_README} is the one place it belongs`
+  )
 } else {
   fail(
-    `install source: the install lines appear in ${installSources.length} files ` +
-      `(${installSources.join(', ')}). Keep them in README.md and link to that section.`
+    `install source: the install lines appear in ${installSources.length} place(s) ` +
+      `(${installSources.join(', ')}). Keep them in ${ROOT_README} and link to that section.`
   )
+}
+
+// ---------------------------------------------------------------------
+// 18. Plugin-version freshness — Claude Code updates a plugin when its
+//     `version` moves, so a skill edit that ships without a bump reaches
+//     nobody who installed it.
+//
+//     Enforced from CONTENT, not git history. Making the release bump it
+//     could not work: the publish job checks out shallow and read-only,
+//     so `git log` answers differently there and the write is discarded
+//     with the runner either way. A digest of the published skills
+//     answers the same in a shallow clone, a hook and CI, and it puts
+//     the bump in the PR that edits the skill, where a human is already
+//     deciding what changed.
+// ---------------------------------------------------------------------
+
+const pluginManifest = JSON.parse(
+  await Deno.readTextFile(join(skillsDir, '.claude-plugin', 'plugin.json'))
+)
+const marketplaceManifest = JSON.parse(
+  await Deno.readTextFile(join(denoDir, '..', '.claude-plugin', 'marketplace.json'))
+)
+const pluginRecord = JSON.parse(
+  await Deno.readTextFile(join(denoDir, '.scripts', 'plugin-release.json'))
+)
+const marketplaceEntry = marketplaceManifest.plugins.find(
+  (candidate: { name?: unknown }) => candidate.name === pluginManifest.name
+)
+
+const skillsDigest = await computeSkillsDigest(skillsDir, publishedSkillNames)
+
+if (!marketplaceEntry) {
+  fail(`plugin version: marketplace.json has no plugin named ${pluginManifest.name}`)
+} else if (marketplaceEntry.version !== pluginManifest.version) {
+  fail(
+    `plugin version: plugin.json says ${pluginManifest.version} and marketplace.json says ` +
+      `${marketplaceEntry.version} — a consumer resolves one of them and gets the other's skills`
+  )
+} else if (pluginRecord.digest !== skillsDigest) {
+  fail(
+    'plugin version: the published skills changed since the last plugin bump. Run ' +
+      '`deno task bump-plugin` and commit the three files — without a version bump the edit ' +
+      'never reaches an installed plugin.'
+  )
+} else if (pluginRecord.version !== pluginManifest.version) {
+  fail(
+    `plugin version: plugin-release.json records ${pluginRecord.version} but the manifests say ` +
+      `${pluginManifest.version} — re-run \`deno task bump-plugin\``
+  )
+} else {
+  pass(`plugin version: ${pluginManifest.version} matches both manifests and the skills digest`)
 }
 
 // ---------------------------------------------------------------------

--- a/deno/docs/verify-docs.ts
+++ b/deno/docs/verify-docs.ts
@@ -935,6 +935,29 @@ if (updateReaderBaseline) {
   }
 }
 
+/**
+ * Symbol names out of `deno doc --json`, walking every `symbols` array so a
+ * format shift between deno versions stays survivable. Shared by the
+ * core-export check and the appendix-coverage one.
+ */
+const collectSymbolNames = (value: unknown, into: Set<string>): void => {
+  if (Array.isArray(value)) {
+    for (const item of value) collectSymbolNames(item, into)
+    return
+  }
+  if (value === null || typeof value !== 'object') return
+  const record = value as Record<string, unknown>
+  if (Array.isArray(record.symbols)) {
+    for (const symbol of record.symbols) {
+      const name = (symbol as Record<string, unknown>).name
+      if (typeof name === 'string') into.add(name)
+    }
+  }
+  for (const child of Object.values(record)) {
+    collectSymbolNames(child, into)
+  }
+}
+
 // ---------------------------------------------------------------------
 // 11. Core-export sync — table-leading symbols in core-overview.md must
 //     be real exports of core/mod.ts. `deno doc --json` resolves the
@@ -955,24 +978,6 @@ if (!coreDocResult.success) {
       new TextDecoder().decode(coreDocResult.stderr).slice(0, 200),
   );
 } else {
-  const collectSymbolNames = (value: unknown, into: Set<string>): void => {
-    if (Array.isArray(value)) {
-      for (const item of value) collectSymbolNames(item, into);
-      return;
-    }
-    if (value === null || typeof value !== "object") return;
-    const record = value as Record<string, unknown>;
-    if (Array.isArray(record.symbols)) {
-      for (const symbol of record.symbols) {
-        const name = (symbol as Record<string, unknown>).name;
-        if (typeof name === "string") into.add(name);
-      }
-    }
-    for (const child of Object.values(record)) {
-      collectSymbolNames(child, into);
-    }
-  };
-
   const coreExports = new Set<string>();
   collectSymbolNames(
     JSON.parse(new TextDecoder().decode(coreDocResult.stdout)),
@@ -1239,31 +1244,77 @@ if (catalogueFailures === 0) {
 }
 
 // ---------------------------------------------------------------------
-// 15. Generated-appendix freshness — `deno doc` output cannot disagree
-//     with source, so the only way the appendix drifts is by not being
-//     regenerated after the source moved. The generator regenerates in
-//     memory under --check and compares, which is the same work a
-//     reviewer would otherwise have to remember to do.
+// 15. Generated-appendix coverage — every symbol the documented package
+//     exports has to appear in its appendix, or the appendix was not
+//     regenerated after the API moved.
+//
+//     NOT a regenerate-and-diff: `deno doc`'s FORMATTING shifts between
+//     patch releases, so comparing generated text fails CI whenever its
+//     deno is a patch ahead of the author's, on content that is
+//     perfectly current. Symbol NAMES come from source, so they are the
+//     part worth holding — the same reasoning as check 11.
+//
+//     `generate-skill-api-appendix.ts --check` still does the exact
+//     comparison for an author on one machine, where the deno version
+//     is by definition the one that wrote the file.
 // ---------------------------------------------------------------------
 
-const appendixCheck = await new Deno.Command('deno', {
-  args: [
-    'run',
-    '--allow-read',
-    '--allow-env',
-    '--allow-run=deno,git',
-    join(denoDir, '.scripts', 'generate-skill-api-appendix.ts'),
-    '--check'
-  ],
-  cwd: denoDir,
-  stdout: 'piped',
-  stderr: 'piped'
-}).output()
+const appendixTargets = [{ packageDirectory: 'lang-kotlin', skillName: 'skmtc-lang-kotlin' }]
 
-if (appendixCheck.success) {
-  pass(new TextDecoder().decode(appendixCheck.stdout).trim())
-} else {
-  fail(new TextDecoder().decode(appendixCheck.stderr).trim().split('\n')[0])
+const appendicesOnDisk: string[] = []
+for (const directory of skillDirectories) {
+  const path = join(skillsDir, directory, 'appendix.md')
+  if (await Deno.stat(path).then(() => true, () => false)) appendicesOnDisk.push(directory)
+}
+
+for (const orphan of appendicesOnDisk) {
+  if (!appendixTargets.some(target => target.skillName === orphan)) {
+    fail(`${orphan} ships an appendix.md that no appendix target covers — add it to appendixTargets`)
+  }
+}
+
+for (const { packageDirectory, skillName } of appendixTargets) {
+  const docResult = await new Deno.Command('deno', {
+    args: ['doc', '--json', join(denoDir, packageDirectory, 'mod.ts')],
+    stdout: 'piped',
+    stderr: 'piped'
+  }).output()
+
+  if (!docResult.success) {
+    fail(
+      `appendix coverage: \`deno doc --json ${packageDirectory}/mod.ts\` failed — ` +
+        new TextDecoder().decode(docResult.stderr).slice(0, 200)
+    )
+    continue
+  }
+
+  const exported = new Set<string>()
+  collectSymbolNames(JSON.parse(new TextDecoder().decode(docResult.stdout)), exported)
+
+  if (exported.size === 0) {
+    fail(
+      `appendix coverage: extracted zero symbols from ${packageDirectory}/mod.ts — ` +
+        'the extraction needs updating for this deno version'
+    )
+    continue
+  }
+
+  const appendix = await Deno.readTextFile(join(skillsDir, skillName, 'appendix.md'))
+  const missing = [...exported].filter(name => !appendix.includes(name)).sort()
+
+  if (missing.length > 0) {
+    fail(
+      `appendix coverage: ${skillName}/appendix.md is missing ${missing.length} of ` +
+        `${exported.size} ${packageDirectory} exports (${missing.slice(0, 5).join(', ')}` +
+        `${missing.length > 5 ? ', …' : ''}). Regenerate: deno run --allow-read --allow-write ` +
+        '--allow-env --allow-run=deno,git .scripts/generate-skill-api-appendix.ts'
+    )
+  } else {
+    pass(
+      `appendix coverage: all ${exported.size} ${packageDirectory} exports appear in ` +
+        `${skillName}/appendix.md`
+    )
+  }
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
Six guards were named in the distribution plan and never built. Each closes a way a
skill can start lying with no check noticing.

## TypeScript joins the lang sync

`languageSyncTargets` held Kotlin only — the TypeScript skill was never checked
against its package, because the v1 skill predated the check and the promotion never
added it. Adding it surfaced two real gaps, filled rather than papered over: the
entity-kind count is stated, and `isTsEntityType` is named.

## The appendix is held to its exports

Every symbol the documented package exports must appear in its appendix, or the
appendix was not regenerated after the API moved.

**This started as a regenerate-and-diff, as decision 7 specifies, and comparing
generated text turned out to be the wrong instrument — three environment
dependencies, each found by a different runner:**

1. The provenance sha was `HEAD`, so the line lied on every commit that missed the
   package, and every commit changed the output whether or not the API had.
   Deriving it from the package's own last commit fixed that.
2. A git hook exports `GIT_DIR`, and a child `git` obeys it over its own working
   directory — so the check passed from a shell and failed from the pre-push hook.
   Git now runs with a cleared environment.
3. CI's shallow clone resolved that sha differently again. The sha is decoration a
   reader cannot act on, so it is gone from the generated text entirely.

Then CI failed a fourth time on formatting: `deno doc`'s layout differs between
**patch** releases (2.9.6 in CI, 2.9.5 locally), so any text comparison breaks every
PR until someone regenerates against whatever version CI happens to run.

So the check holds symbol **names**, which come from source. Check 11 in the same
file already learned this — its comment says it walks `deno doc --json` "so minor
format shifts across deno versions stay survivable" — and `collectSymbolNames` is now
shared rather than copied. `--check` stays in the generator for an author on one
machine, where the deno version is by definition the one that wrote the file.

## A skill declares the minor it describes

Name-level checks catch a renamed export. None catches a changed **rule** that keeps
every name — a default flipped, a protocol reordered, a step that became required.

Each published skill now carries `metadata.describes`; verify-docs fails when the
workspace moves past a declared minor, and `deno task release` refuses to publish
past one. The number is not the point — editing it is the record that someone reread
the skill against the diff.

## A skill edit forces a plugin bump

Claude Code updates a plugin when its version moves, so a skill edit shipped without
a bump reaches nobody who installed it.

This started as a bump inside `deno task release` and review showed it could never
land: `publish.yml` runs the release with a depth-1, read-only checkout, so
`git log -- marketplace.json` returns empty there and the writes are discarded with
the runner. It also double-bumped on a second run before committing, and turned a
malformed version into `"NaN.undefined.NaN"` without throwing.

So the bump belongs to the PR that edits the skill, and is enforced from **content**:
`.scripts/plugin-release.json` records a SHA-256 over every file of the five
published skills, and verify-docs fails when the skills have moved and the version
has not. `deno task bump-plugin` bumps both manifests and re-records. Reading no git
history means it answers the same in a shallow clone, inside a hook and in CI — the
property three separate bugs in this PR were about. The digest is a sidecar because
`claude plugin validate --strict` rejects unknown fields in `plugin.json`.

## CI runs on the manifest

`coverage.yml` filtered on `deno/**`, so a PR editing only
`.claude-plugin/marketplace.json` ran no gate at all — and that file is exactly what
the catalogue check reads.

## The install lines have one home

They were written out twice (repo README and `deno/docs/README.md`), and a third copy
was about to appear on the site. Two copies of an instruction drift, and the reader
who finds the stale one cannot tell. The README section is now the only copy, the
docs README links to it, and verify-docs fails on a second.

`skills/README.md` gains a "What keeps these true" table listing every guard with the
command that runs it.

## Verification

`deno task check` green — 3193 passed, 0 failed. Each new check was tested by
breaking what it guards, and the appendix check was additionally verified against a
`--depth 1` clone, which is the condition that failed here.

Coveralls reports −0.1%: the new code is doc tooling (`docs/verify-docs.ts`,
`.scripts/`), which has no unit tests in this repo by convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JE6kR86oxyZkoR6uRnBkV6
