### PR TITLE
Give KtFunctionSignature a modifier slot

### DIFF
--- a/deno/lang-kotlin/deno.json
+++ b/deno/lang-kotlin/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@skmtc/lang-kotlin",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": false,
   "license": "Apache-2.0",
   "exports": {

--- a/deno/lang-kotlin/src/KtFunctionSignature.test.ts
+++ b/deno/lang-kotlin/src/KtFunctionSignature.test.ts
@@ -128,3 +128,30 @@ Deno.test('signature renders KDoc above annotations; parameters render defaults'
       '    fun getCreditNotes(limit: Int? = null): CreditNotePage'
   )
 })
+
+Deno.test('signature renders modifiers before `fun`, in the order given', () => {
+  const override = new KtFunctionSignature({
+    name: 'getUsersId',
+    modifiers: ['override'],
+    parameters: [{ name: 'id', type: 'String' }],
+    returnType: 'User',
+    body: 'throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "getUsersId")'
+  })
+  const visibility = new KtFunctionSignature({
+    name: 'helper',
+    modifiers: ['private', 'open'],
+    parameters: []
+  })
+
+  assertEquals(
+    override.toString(),
+    '    override fun getUsersId(id: String): User = throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "getUsersId")'
+  )
+  assertEquals(visibility.toString(), '    private open fun helper()')
+})
+
+Deno.test('an empty modifier list renders exactly like no modifiers', () => {
+  const empty = new KtFunctionSignature({ name: 'run', modifiers: [], parameters: [] })
+
+  assertEquals(empty.toString(), '    fun run()')
+})

--- a/deno/lang-kotlin/src/KtFunctionSignature.ts
+++ b/deno/lang-kotlin/src/KtFunctionSignature.ts
@@ -55,11 +55,22 @@ export class KtFunctionParameter {
 }
 
 /**
+ * A modifier rendered before `fun`. `suspend` is deliberately absent —
+ * coroutine handlers are a WebFlux concern this grammar does not cover.
+ */
+export type KtFunctionModifier = 'override' | 'open' | 'private' | 'internal' | 'protected'
+
+/**
  * Constructor arguments for {@link KtFunctionSignature}.
  */
 export type KtFunctionSignatureArgs = {
   /** The FINAL method name — already derived/sanitized by the generator. */
   name: string
+  /**
+   * Modifiers rendered before `fun`, in the order given — Kotlin's own
+   * convention is visibility first (`private override fun`).
+   */
+  modifiers?: KtFunctionModifier[]
   parameters: KtFunctionParameterArgs[]
   /** Omitted → no `: T` (Kotlin's implicit `Unit`). */
   returnType?: Stringable
@@ -88,11 +99,13 @@ export type KtFunctionSignatureArgs = {
  * one line (formatting is the consumer's formatter's job). Abstract by
  * default; an expression `body` renders the delegation form (` = …` —
  * block bodies deliberately unsupported). Optional KDoc `description`
- * above the annotations and per-parameter `= default`. Grammar only —
- * no `suspend`; the mapping annotations are generator policy.
+ * above the annotations and per-parameter `= default`. `modifiers`
+ * renders `override fun` and friends. Grammar only — no `suspend`; the
+ * mapping annotations are generator policy.
  */
 export class KtFunctionSignature {
   name: string
+  modifiers: KtFunctionModifier[] | undefined
   parameters: KtFunctionParameter[]
   returnType: Stringable | undefined
   annotations: KtAnnotation[] | undefined
@@ -101,6 +114,7 @@ export class KtFunctionSignature {
 
   constructor({
     name,
+    modifiers,
     parameters,
     returnType,
     annotations,
@@ -108,6 +122,7 @@ export class KtFunctionSignature {
     body
   }: KtFunctionSignatureArgs) {
     this.name = name
+    this.modifiers = modifiers
     this.parameters = parameters.map(parameter => new KtFunctionParameter(parameter))
     this.returnType = returnType
     this.annotations = annotations
@@ -123,7 +138,8 @@ export class KtFunctionSignature {
     const parameters = this.parameters.join(', ')
     const returns = this.returnType !== undefined ? `: ${this.returnType}` : ''
     const body = this.body !== undefined ? ` = ${this.body}` : ''
+    const modifiers = this.modifiers?.length ? `${this.modifiers.join(' ')} ` : ''
 
-    return `${kdoc}${annotations}    fun ${this.name}(${parameters})${returns}${body}`
+    return `${kdoc}${annotations}    ${modifiers}fun ${this.name}(${parameters})${returns}${body}`
   }
 }


### PR DESCRIPTION
## What

`KtFunctionSignature` renders `fun name(...)` with nothing before it, so
`@skmtc/lang-kotlin` can describe an interface member or a class method
but not an implementation of one — Kotlin requires `override`, and there
was no slot for it.

This adds an optional `modifiers` field:

```ts
new KtFunctionSignature({
  name: 'getUsersId',
  modifiers: ['override'],
  parameters: [{ name: 'id', type: 'String' }],
  returnType: 'User',
  body: 'throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "getUsersId")'
})
// →     override fun getUsersId(id: String): User = throw ResponseStatusException(...)
```

## Why now

`gen-kotlin-spring` generates the controller and the interface it
delegates to. For a document the size of the Sequence API that leaves
171 method signatures for the consumer to type by hand, so the generator
now scaffolds the `<Tag>ServiceImpl` classes too — each method an
`override` throwing 501, ejectable once you want to own it. Without a
modifier slot the generator has to splice `override ` onto the rendered
line itself, which is grammar leaking out of the lang package.

## Shape of the addition

- `KtFunctionModifier` is a closed union (`override`, `open`, `private`,
  `internal`, `protected`) so a caller cannot invent one.
- `suspend` stays out, which was already the class doc's stated position:
  coroutine handlers are a WebFlux concern this grammar does not cover.
- Modifiers render in the order given — the ordering convention
  (`private override fun`) belongs to the caller.
- Optional, and an empty list renders exactly as no list does, so no
  existing call site changes. Two new tests pin both.

Version bumped 0.10.2 → 0.11.0 for the release cascade.

`deno task check` green: 3195 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwjbRKbtcd9odZKwSd29Jm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/skmtc/codesmith/skmtc/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848608&installation_model_id=434944&pr_number=135&repository=skmtc%2Fskmtc&return_to=https%3A%2F%2Fgithub.com%2Fskmtc%2Fskmtc%2Fpull%2F135&signature=da4f8e24d9488589508a40659dcf6883e69cf85ccb2b477cc9a5507ca7156822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->