### PR TITLE
cli: status help promised protection that does not exist

### DIFF
--- a/deno/cli/lib/cli-schema.ts
+++ b/deno/cli/lib/cli-schema.ts
@@ -138,7 +138,7 @@ export const COMMAND_DESCRIPTORS: CommandDescriptor[] = [
   {
     name: 'status',
     description:
-      'Classify every generated file against the generated lock: clean / modified (hand-edited, protected from overwrite) / missing / unverified, plus orphaned files spared from pruning. Read-only.',
+      'Classify every generated file against the generated lock: clean / modified (hand-edited, and overwritten by the next generate — `eject` is what makes a file yours) / missing / unverified, plus orphaned files spared from pruning. Read-only.',
     args: ['<project>'],
     flags: [
       { flag: '--json', description: 'Emit structured JSON output.' },


### PR DESCRIPTION
## What

`skmtc status --help` described a modified file as:

> clean / modified (**hand-edited, protected from overwrite**) / missing / unverified

It is not protected from overwrite.

## Evidence

The write path says so in as many words:

```ts
// This is a pure cache-validity check (same render in, same formatted bytes on
// disk); any other disk state — hand edits included — is overwritten below.
// Generated files are engine-owned.
```

And the reference page already says so too — "a `modified` file is a heads-up
that the next generate will overwrite those edits, not a protection".

Measured on a real project, to be sure it wasn't only theory: a hand-edited
method body in a generated file was reported `modified` by `status`, and the
next `generate` returned `protectedFiles: 0` and overwrote it.

So the code and the docs agree, and the one-line help was the only thing
claiming otherwise — and it is the line someone is most likely to read before
deciding it's safe to edit a generated file. Which is how you lose work.

## Change

The help now states the behaviour and names the mechanism that does make a file
the user's:

> clean / modified (hand-edited, and overwritten by the next generate — `eject`
> is what makes a file yours) / missing / unverified

`deno task check` green: 3195 passed, 0 failed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/skmtc/codesmith/skmtc/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790880194&installation_model_id=434944&pr_number=137&repository=skmtc%2Fskmtc&return_to=https%3A%2F%2Fgithub.com%2Fskmtc%2Fskmtc%2Fpull%2F137&signature=96967eb9eae65d7984cf057413ff489d1d411fa65df7283c2d2e83fa06ced691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->